### PR TITLE
docs: link Jacquard human introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![CI](https://github.com/jbwinters/jacquard-lang/actions/workflows/ci.yml/badge.svg)](https://github.com/jbwinters/jacquard-lang/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/jbwinters/jacquard-lang?include_prereleases&sort=semver)](https://github.com/jbwinters/jacquard-lang/releases)
 
-Jacquard is a research prototype for running, reviewing, simulating, and trusting
-programs written by models and reviewed by people.
+Jacquard is a FriendMachine research project for running, reviewing, simulating,
+and trusting programs written by models and reviewed by people. Start with the
+[human-friendly introduction to Jacquard](https://research.friendmachine.co/jacquard/).
 
 Concretely, it is a small programming language with a compact `.jac` surface
 syntax, an OCaml checker and CPS interpreter, a C-emitting native AOT backend

--- a/docs/release/surface-syntax/MANIFEST.sha256
+++ b/docs/release/surface-syntax/MANIFEST.sha256
@@ -3,7 +3,7 @@
 # The manifest excludes itself and protected untracked drafts.
 
 # Reconstructible evidence overlay
-e91a8c13ea6e0c5ec2d67ade3b58452b8148cf295195a9f49a1f0d153731c438  README.md
+838812a371fe7627a921dcedb22325bbdb415fa630c2a9b3c85e0b416a27da15  README.md
 958e8d99f1055f7eb2322c1687f6a9a490f38a7994c437353842800345a9c245  corpus/golden/hashes.golden
 e93f4ba7f81206278bdd0f331884af751fadb9d5df43ab0ba7b86110272e387b  corpus/golden/prelude-hashes.golden
 a159849342085dff62727c56f06439465277574623dc59cd75d6c1136687722e  corpus/golden/ring0-freeze.golden


### PR DESCRIPTION
Adds the human-friendly Jacquard introduction to the README and identifies Jacquard as a FriendMachine research project.\n\nAlso refreshes the README entry in the release evidence manifest.