### PR TITLE
Harden structured diagnostics across Jacquard

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 738
-Alcotest/QCheck cases, 43 cram transcripts, 27 documentation examples, native
+semantic boundary remains historical; the current successor is pinned by 742
+Alcotest/QCheck cases, 44 cram transcripts, 27 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
 runtime/output license exception and packages the native runtime. The current
@@ -236,8 +236,9 @@ until you grant the rest:
 ```console
 $ jac run demos/tooling/repair.jac
 8
-error[E0814]: this program requires the `eval` effect, which is not granted (performed via `posterior-over-patches`)
-  hint: grant it with --allow eval, or handle the effect in the program
+error[E0814]: The program requires an effect that was not granted
+  Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `posterior-over-patches`).
+  Next step: grant it with --allow eval, or handle the effect in the program
 $ jac run demos/tooling/repair.jac --allow eval
 ```
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -16,8 +16,88 @@ let exit_diags = 1
 let exit_runtime = 2
 let exit_unhandled = 3
 
+type diagnostic_format = Text | Json_v1
+
+let selected_diagnostic_format = ref Text
+
+let print_diagnostic diagnostic =
+  prerr_endline
+    (match !selected_diagnostic_format with
+    | Text -> Diag.to_string diagnostic
+    | Json_v1 -> Diag.to_json_string diagnostic)
+
+let print_runtime_error error = print_diagnostic (Runtime_err.to_diag error)
+
+let diagnostic_domain code =
+  if String.starts_with ~prefix:"E01" code then Diag.Reader
+  else if String.starts_with ~prefix:"E06" code then Diag.Store
+  else if String.starts_with ~prefix:"E07" code then Diag.Prelude
+  else if String.starts_with ~prefix:"E08" code then Diag.Checker
+  else if String.equal code "E0908" then Diag.Concurrency
+  else if String.equal code "E0903" then Diag.Inference
+  else if String.starts_with ~prefix:"E09" code then Diag.Runtime
+  else if String.starts_with ~prefix:"E10" code then Diag.Warp
+  else if String.starts_with ~prefix:"E11" code then Diag.Native
+  else if List.mem code [ "E1301"; "E1302"; "E1303" ] then Diag.Export
+  else if String.starts_with ~prefix:"E13" code then Diag.Audit
+  else if String.starts_with ~prefix:"E14" code || String.starts_with ~prefix:"E15" code then
+    Diag.Governance
+  else Diag.Cli
+
+let diagnostic_summary = function
+  | "E0104" -> "Command argument contains an invalid bootstrap form or value"
+  | "E0606" -> "Requested store is unavailable"
+  | "E0608" -> "Store operation could not complete"
+  | "E0609" -> "Semantic diff input could not be read"
+  | "E0610" -> "Semantic diff input is invalid"
+  | "E0702" -> "Required prelude contents are unavailable"
+  | "E0704" -> "Store add accepts declarations only"
+  | "E0801" -> "Compared model result types do not agree"
+  | "E0903" -> "Model file has no expression"
+  | "E0904" -> "Observation is invalid at the sampling root"
+  | "E0908" -> "Schedule configuration or trace is invalid"
+  | "E1001" -> "Test file has an expression at top level"
+  | "E1002" -> "Dry-run cannot sandbox eval"
+  | "E1101" -> "Program is outside the native v1 compilation subset"
+  | "E1102" -> "Program requires the interpreter tier"
+  | "E1103" -> "Native build could not complete"
+  | "E1301" -> "Export destination already exists"
+  | "E1302" -> "Export input could not be read"
+  | "E1303" -> "Export output could not be written"
+  | "E1307" -> "Audit operation could not complete"
+  | "E1516" -> "Action evidence still requires operator reconciliation"
+  | code -> "Command failed (" ^ code ^ ")"
+
+let diagnostic_next_step = function
+  | "E0104" -> "Correct the command argument and try again."
+  | "E0606" -> "Pass the path to an existing Jacquard store."
+  | "E0608" -> "Correct the store state described here and try again."
+  | "E0609" | "E0610" -> "Pass readable, valid semantic-diff inputs."
+  | "E0702" -> "Load the complete prelude and try again."
+  | "E0704" -> "Pass declarations to `store add`, not a top-level expression."
+  | "E0801" -> "Compare models whose result types agree."
+  | "E0903" -> "Add one model expression to the file."
+  | "E0904" -> "Move the observation under an inference handler."
+  | "E0908" -> "Correct the schedule option or trace described here."
+  | "E1001" -> "Keep test files declaration-only."
+  | "E1002" -> "Run this program without --dry-run or remove eval from its authority row."
+  | "E1101" -> "Run the program with the interpreter or rewrite the unsupported construct."
+  | "E1102" -> "Run this program with the interpreter."
+  | "E1103" -> "Correct the native toolchain or build input and try again."
+  | "E1301" | "E1302" | "E1303" -> "Correct the export path or input and try again."
+  | "E1307" -> "Correct the audit input or destination and try again."
+  | "E1516" -> "Reconcile the remaining action evidence before retrying or rolling back."
+  | _ -> "Correct the command input and try again."
+
+let cli_diagnostic ?hint ?summary ~code cause =
+  Diag.error ~domain:(diagnostic_domain code) ~code
+    ~summary:(Option.value summary ~default:(diagnostic_summary code))
+    ~cause
+    ~next_step:(Option.value hint ~default:(diagnostic_next_step code))
+    ~contrast:None ()
+
 let print_diags ds =
-  List.iter (fun d -> prerr_endline (Diag.to_string d)) ds;
+  List.iter print_diagnostic ds;
   exit_diags
 
 let read_file path =
@@ -75,8 +155,7 @@ let validate_parsed_top = function
   | Bootstrap_form form -> Kernel.of_form form
   | Surface_top top -> Ok top
 
-let print_warnings warnings =
-  List.iter (fun warning -> prerr_endline (Diag.to_string warning)) warnings
+let print_warnings warnings = List.iter print_diagnostic warnings
 
 (** [resolve_source_tops] parses, surface-lowers when selected, validates, and resolves a whole
     source artifact in order. Declarations are installed in [store] as they are encountered so later
@@ -193,7 +272,8 @@ let schedule_file_error action path message =
     else message
   in
   [
-    Diag.error ~code:"E0908" (Printf.sprintf "cannot %s schedule trace %s: %s" action path message);
+    cli_diagnostic ~code:"E0908"
+      (Printf.sprintf "cannot %s schedule trace %s: %s" action path message);
   ]
 
 let load_schedule path =
@@ -206,7 +286,8 @@ let load_schedule path =
 
 let parse_schedule_fork spec =
   match String.index_opt spec '=' with
-  | None -> Error [ Diag.error ~code:"E0908" "invalid --schedule-fork (expected DECISION=TASK)" ]
+  | None ->
+      Error [ cli_diagnostic ~code:"E0908" "invalid --schedule-fork (expected DECISION=TASK)" ]
   | Some index ->
       let decision = String.sub spec 0 index in
       let task = String.sub spec (index + 1) (String.length spec - index - 1) in
@@ -214,14 +295,15 @@ let parse_schedule_fork spec =
         (match int_of_string_opt decision with
         | Some decision when decision >= 0 -> Ok decision
         | Some _ | None ->
-            Error [ Diag.error ~code:"E0908" "schedule fork decision must be non-negative" ])
+            Error [ cli_diagnostic ~code:"E0908" "schedule fork decision must be non-negative" ])
         (fun decision ->
           Result.map (fun chosen -> (decision, chosen)) (Schedule_trace.task_id_of_string task))
 
 let schedule_mode replay_file fork_spec =
   match (replay_file, fork_spec) with
   | None, None -> Ok None
-  | None, Some _ -> Error [ Diag.error ~code:"E0908" "--schedule-fork requires --schedule-replay" ]
+  | None, Some _ ->
+      Error [ cli_diagnostic ~code:"E0908" "--schedule-fork requires --schedule-replay" ]
   | Some path, None ->
       Result.map (fun trace -> Some (Round_robin.Replay_schedule trace)) (load_schedule path)
   | Some path, Some spec ->
@@ -269,7 +351,7 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
                       else
                         Error
                           [
-                            Diag.error ~code:"E0908"
+                            cli_diagnostic ~code:"E0908"
                               (Printf.sprintf
                                  "schedule record/replay requires exactly one top-level \
                                   expression, found %d"
@@ -326,15 +408,15 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
                         match Check.check_top cctx (Kernel.Expr e) with
                         | Error ds -> Error ds
                         | Ok { Check.row; warnings; _ } -> (
-                            List.iter (fun w -> prerr_endline (Diag.to_string w)) warnings;
+                            List.iter print_diagnostic warnings;
                             (if dry_run then
                                let r = Types.repr_row (Option.value row ~default:Types.empty_row) in
                                match eval_hash with
                                | Some eh when List.exists (Hash.equal eh) r.Types.effects ->
                                    raise
                                      (Invalid_argument
-                                        "error[E1002]: --dry-run cannot sandbox eval: eval'd code \
-                                         runs at root authority and bypasses the dry handlers")
+                                        "--dry-run cannot sandbox eval: eval'd code runs at root \
+                                         authority and bypasses the dry handlers")
                                | _ -> ());
                             match
                               Check.manifest_errors cctx ~grantable:Prelude.grantable_names ~granted
@@ -371,9 +453,8 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
                       in
                       match process_forms ?origin ~syntax store ~file source ~on_expr with
                       | exception Invalid_argument msg
-                        when String.length msg > 6 && String.sub msg 0 5 = "error" ->
-                          prerr_endline msg;
-                          exit_diags
+                        when String.starts_with ~prefix:"--dry-run cannot sandbox eval" msg ->
+                          print_diags [ cli_diagnostic ~code:"E1002" msg ]
                       | Ok () -> (
                           let write_result =
                             match (schedule_record, !completed_schedule) with
@@ -382,7 +463,8 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
                             | Some _, None ->
                                 Error
                                   [
-                                    Diag.error ~code:"E0908" "scheduled execution produced no trace";
+                                    cli_diagnostic ~code:"E0908"
+                                      "scheduled execution produced no trace";
                                   ]
                           in
                           match write_result with
@@ -403,19 +485,17 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
                       | Error _ when !runtime_failure <> None -> (
                           match Option.get !runtime_failure with
                           | Runtime_err.Unhandled _ as e ->
-                              prerr_endline (Runtime_err.to_string e);
+                              print_runtime_error e;
                               exit_unhandled
                           | Runtime_err.Observe_at_root as e ->
-                              prerr_endline
-                                (Diag.to_string
-                                   (Diag.error ~code:"E0904" (Runtime_err.to_string e)));
+                              print_runtime_error e;
                               exit_runtime
                           | e ->
-                              prerr_endline (Runtime_err.to_string e);
+                              print_runtime_error e;
                               exit_runtime)
                       | Error ds when !refused ->
                           (* the capability refusal keeps its own exit code, now at the type level *)
-                          List.iter (fun d -> prerr_endline (Diag.to_string d)) ds;
+                          List.iter print_diagnostic ds;
                           exit_unhandled
                       | Error ds -> print_diags ds)))))
 
@@ -441,7 +521,7 @@ let check_cmd file prelude print_sigs manifest origin syntax =
             match Check.check_top cctx top with
             | Error ds -> Error ds
             | Ok { Check.names; warnings; row } -> (
-                List.iter (fun w -> prerr_endline (Diag.to_string w)) warnings;
+                List.iter print_diagnostic warnings;
                 if print_sigs then
                   List.iter
                     (fun (n, s) ->
@@ -504,7 +584,7 @@ let check_cmd file prelude print_sigs manifest origin syntax =
                             match Resolve.resolve_w (Store.names_view store) top with
                             | Error ds -> print_diags ds
                             | Ok (resolved, warns) -> (
-                                List.iter (fun w -> prerr_endline (Diag.to_string w)) warns;
+                                List.iter print_diagnostic warns;
                                 match on_top resolved with
                                 | Error ds -> print_diags ds
                                 | Ok () -> (
@@ -563,7 +643,7 @@ let load_model store ~syntax ~file =
         | [] -> (
             match last with
             | Some e -> Ok e
-            | None -> Error [ Diag.error ~code:"E0903" "the model file has no expression" ])
+            | None -> Error [ cli_diagnostic ~code:"E0903" "the model file has no expression" ])
         | parsed :: rest -> (
             match validate_parsed_top parsed with
             | Error ds -> Error ds
@@ -797,7 +877,8 @@ let dist_diff_cmd model_a model_b tolerance cache_dir no_cache sweep prelude =
               | [] -> (
                   match last with
                   | Some e -> Ok e
-                  | None -> Error [ Diag.error ~code:"E0903" (file ^ " has no model expression") ])
+                  | None ->
+                      Error [ cli_diagnostic ~code:"E0903" (file ^ " has no model expression") ])
               | f :: rest -> (
                   match Kernel.of_form f with
                   | Error ds -> Error ds
@@ -832,7 +913,8 @@ let dist_diff_cmd model_a model_b tolerance cache_dir no_cache sweep prelude =
                       match last with
                       | Some t -> Ok t
                       | None ->
-                          Error [ Diag.error ~code:"E0903" (file ^ " has no model expression") ])
+                          Error [ cli_diagnostic ~code:"E0903" (file ^ " has no model expression") ]
+                      )
                   | f :: rest -> (
                       match Kernel.of_form f with
                       | Error ds -> Error ds
@@ -887,7 +969,7 @@ let dist_diff_cmd model_a model_b tolerance cache_dir no_cache sweep prelude =
         | Ok ta, Ok tb when ta <> tb ->
             Some
               [
-                Diag.error ~code:"E0801"
+                cli_diagnostic ~code:"E0801"
                   (Printf.sprintf
                      "dist-diff: model result types differ (%s : %s, %s : %s); probabilities over \
                       different types are not comparable"
@@ -924,7 +1006,7 @@ let log_entries_of_file file =
   | Ok f ->
       Error
         [
-          Diag.error ~code:"E0104"
+          cli_diagnostic ~code:"E0104"
             (Printf.sprintf "%s is not a log payload (head %s)" file f.Form.head);
         ]
 
@@ -965,7 +1047,7 @@ let replay_cmd log_file program forks to_n compare prelude =
             print_diags
               (List.map
                  (fun spec ->
-                   Diag.error ~code:"E0104"
+                   cli_diagnostic ~code:"E0104"
                      (Printf.sprintf "invalid --fork %S (expected N=FORM with a parseable form)"
                         spec))
                  bad)
@@ -1056,7 +1138,7 @@ let replay_cmd log_file program forks to_n compare prelude =
                   print_endline (Value.show v);
                   Ok ()
               | Error err ->
-                  prerr_endline (Runtime_err.to_string err);
+                  print_runtime_error err;
                   Error []
             in
             match
@@ -1103,13 +1185,13 @@ let test_cmd files allows prelude cache_dir no_cache coverage seed samples exhau
     | Some count, _ when count <= 0 ->
         Error
           [
-            Diag.error ~code:"E0908" ~hint:"pass --schedules N with N greater than zero"
+            cli_diagnostic ~code:"E0908" ~hint:"pass --schedules N with N greater than zero"
               "--schedules must be positive";
           ]
     | Some _, None ->
         Error
           [
-            Diag.error ~code:"E0908" ~hint:"add an explicit --seed S"
+            cli_diagnostic ~code:"E0908" ~hint:"add an explicit --seed S"
               "--schedules requires --seed so every interleaving is reproducible";
           ]
     | Some schedules, Some seed ->
@@ -1173,7 +1255,7 @@ let test_cmd files allows prelude cache_dir no_cache coverage seed samples exhau
                           | Ok (Kernel.Expr _) ->
                               Error
                                 [
-                                  Diag.error ~code:"E1001"
+                                  cli_diagnostic ~code:"E1001"
                                     (Printf.sprintf
                                        "%s: test files hold declarations only; found a top-level \
                                         expression"
@@ -1209,7 +1291,7 @@ let test_cmd files allows prelude cache_dir no_cache coverage seed samples exhau
                             match Check.check_top cctx (Kernel.Decl d) with
                             | Error ds -> Error ds
                             | Ok { Check.warnings; _ } ->
-                                List.iter (fun w -> prerr_endline (Diag.to_string w)) warnings;
+                                List.iter print_diagnostic warnings;
                                 check_loaded rest)
                       in
                       match check_loaded (List.rev !loaded) with
@@ -1217,11 +1299,11 @@ let test_cmd files allows prelude cache_dir no_cache coverage seed samples exhau
                       | Ok () -> (
                           match Store.lookup_kind store "test.run" Resolve.KTerm with
                           | None ->
-                              print_diags [ Diag.error ~code:"E0702" "prelude has no test.run" ]
+                              print_diags [ cli_diagnostic ~code:"E0702" "prelude has no test.run" ]
                           | Some { Resolve.hash = tr; _ } -> (
                               match Warp.value_of ctx tr with
                               | Error e ->
-                                  prerr_endline (Runtime_err.to_string e);
+                                  print_runtime_error e;
                                   exit_runtime
                               | Ok test_run -> (
                                   let discovered = Warp.discover store cctx in
@@ -1267,7 +1349,8 @@ let test_cmd files allows prelude cache_dir no_cache coverage seed samples exhau
                                   in
                                   match go discovered with
                                   | Error e ->
-                                      prerr_endline ("test runner error: " ^ e);
+                                      print_runtime_error
+                                        (Runtime_err.Type_error ("test runner error: " ^ e));
                                       exit_runtime
                                   | Ok () ->
                                       Printf.printf "%d passed, %d failed, %d skipped, %d refused\n"
@@ -1301,17 +1384,21 @@ let read_diff_source file =
   try Ok (read_file file)
   with Sys_error message ->
     Error
-      [ Diag.error ~code:"E0609" (Printf.sprintf "cannot read diff source %s: %s" file message) ]
+      [
+        cli_diagnostic ~code:"E0609" (Printf.sprintf "cannot read diff source %s: %s" file message);
+      ]
 
 let open_diff_store dir =
   try Store.open_store dir with
   | Sys_error message ->
       Error
-        [ Diag.error ~code:"E0609" (Printf.sprintf "cannot read diff store %s: %s" dir message) ]
+        [
+          cli_diagnostic ~code:"E0609" (Printf.sprintf "cannot read diff store %s: %s" dir message);
+        ]
   | Unix.Unix_error (error, operation, path) ->
       Error
         [
-          Diag.error ~code:"E0609"
+          cli_diagnostic ~code:"E0609"
             (Printf.sprintf "cannot read diff store %s: %s (%s, %s)" dir (Unix.error_message error)
                operation path);
         ]
@@ -1331,7 +1418,7 @@ let load_diff_source ~prelude ~syntax file =
                ~on_expr:(fun _ ->
                  Error
                    [
-                     Diag.error ~code:"E0610"
+                     cli_diagnostic ~code:"E0610"
                        (Printf.sprintf
                           "%s: diff source files must contain declarations only; found a top-level \
                            expression"
@@ -1350,25 +1437,27 @@ let render_diff ~syntax ~old_side ~new_side =
 let diff_cmd operand_a operand_b syntax prelude =
   match (classify_diff_operand operand_a, classify_diff_operand operand_b) with
   | Missing, Store_dir ->
-      print_diags [ Diag.error ~code:"E0606" (Printf.sprintf "store %s does not exist" operand_a) ]
+      print_diags
+        [ cli_diagnostic ~code:"E0606" (Printf.sprintf "store %s does not exist" operand_a) ]
   | Store_dir, Missing ->
-      print_diags [ Diag.error ~code:"E0606" (Printf.sprintf "store %s does not exist" operand_b) ]
+      print_diags
+        [ cli_diagnostic ~code:"E0606" (Printf.sprintf "store %s does not exist" operand_b) ]
   | Missing, _ ->
       print_diags
-        [ Diag.error ~code:"E0606" (Printf.sprintf "diff operand %s does not exist" operand_a) ]
+        [ cli_diagnostic ~code:"E0606" (Printf.sprintf "diff operand %s does not exist" operand_a) ]
   | _, Missing ->
       print_diags
-        [ Diag.error ~code:"E0606" (Printf.sprintf "diff operand %s does not exist" operand_b) ]
+        [ cli_diagnostic ~code:"E0606" (Printf.sprintf "diff operand %s does not exist" operand_b) ]
   | Unsupported, _ | _, Unsupported ->
       print_diags
         [
-          Diag.error ~code:"E0609"
+          cli_diagnostic ~code:"E0609"
             "diff operands must both be regular source files or both be store directories";
         ]
   | Source_file, Store_dir | Store_dir, Source_file ->
       print_diags
         [
-          Diag.error ~code:"E0609"
+          cli_diagnostic ~code:"E0609"
             "cannot compare a source file with a store directory; pass two files or two stores";
         ]
   | Store_dir, Store_dir -> (
@@ -1408,7 +1497,7 @@ let store_add_cmd store_dir file origin =
   with_store store_dir (fun store ->
       match
         process_forms ?origin ~syntax:Bootstrap store ~file (read_file file) ~on_expr:(fun _ ->
-            Error [ Diag.error ~code:"E0704" "store add expects declarations only" ])
+            Error [ cli_diagnostic ~code:"E0704" "store add expects declarations only" ])
       with
       | Ok () ->
           print_endline "ok";
@@ -1418,7 +1507,7 @@ let store_add_cmd store_dir file origin =
 let store_name_cmd store_dir name hex =
   with_store store_dir (fun store ->
       match Hash.of_hex hex with
-      | None -> print_diags [ Diag.error ~code:"E0104" "invalid hash" ]
+      | None -> print_diags [ cli_diagnostic ~code:"E0104" "invalid hash" ]
       | Some h -> (
           match Store.bind_name store name h with Ok () -> ok | Error ds -> print_diags ds))
 
@@ -1437,7 +1526,7 @@ let store_rename_cmd store_dir old_name new_name kind =
       | Error other ->
           print_diags
             [
-              Diag.error ~code:"E0608"
+              cli_diagnostic ~code:"E0608"
                 (Printf.sprintf "unknown kind %S (expected term, con, op, type, or effect)" other);
             ]
       | Ok kind -> (
@@ -1453,7 +1542,7 @@ let audit_head_arg label spelling =
   | None ->
       Error
         [
-          Diag.error ~code:"E1307"
+          cli_diagnostic ~code:"E1307"
             (Printf.sprintf "%s must be exactly 64 lowercase hexadecimal HASH_V0 digits" label);
         ]
 
@@ -1527,16 +1616,31 @@ let governance_reconcile_cmd bundle_file prelude store_dir =
           then ok
           else (
             flush stdout;
-            prerr_endline
-              "error[E1516]: valid action evidence still requires operator reconciliation; no \
-               rollback or safe retry is implied";
-            exit_diags))
+            print_diags
+              [
+                cli_diagnostic ~code:"E1516"
+                  "Valid action evidence still requires operator reconciliation; no rollback or \
+                   safe retry is implied.";
+              ]))
 
 (* --- cmdliner wiring --- *)
 
 open Cmdliner
 
 let file_arg = Arg.(required & pos 0 (some file) None & info [] ~docv:"FILE")
+
+let diagnostic_format_arg =
+  Arg.(
+    value
+    & opt (enum [ ("text", Text); ("json-v1", Json_v1) ]) Text
+    & info [ "diagnostic-format" ] ~docv:"FORMAT"
+        ~doc:
+          "Diagnostic rendering contract: text (default) or json-v1 (one canonical JSON object per \
+           line on the existing diagnostic stream).")
+
+let configure_diagnostics command format =
+  selected_diagnostic_format := format;
+  command
 
 let syntax_arg =
   Arg.(
@@ -1637,7 +1741,8 @@ let run_t =
   Cmd.v
     (Cmd.info "run" ~doc:"Run a .jac surface or .jqd bootstrap file in top-level order.")
     Term.(
-      const run_cmd $ file_arg $ allows_arg $ prelude_arg $ store_dir_opt_arg $ seed_arg
+      const (configure_diagnostics run_cmd)
+      $ diagnostic_format_arg $ file_arg $ allows_arg $ prelude_arg $ store_dir_opt_arg $ seed_arg
       $ infer_cache_arg $ origin_arg $ dry_run_arg $ schedule_record_arg $ schedule_replay_arg
       $ schedule_fork_arg $ syntax_arg)
 
@@ -1657,32 +1762,40 @@ let check_t =
   Cmd.v
     (Cmd.info "check" ~doc:"Parse, validate, resolve, and typecheck a .jac or .jqd file.")
     Term.(
-      const check_cmd $ file_arg $ prelude_arg $ print_sigs_arg $ manifest_arg $ origin_arg
+      const (configure_diagnostics check_cmd)
+      $ diagnostic_format_arg $ file_arg $ prelude_arg $ print_sigs_arg $ manifest_arg $ origin_arg
       $ syntax_arg)
 
 let hash_t =
   Cmd.v
     (Cmd.info "hash" ~doc:"Print the canonical HASH_V0 hashes of each top-level form.")
-    Term.(const hash_cmd $ file_arg $ prelude_arg $ syntax_arg)
+    Term.(
+      const (configure_diagnostics hash_cmd)
+      $ diagnostic_format_arg $ file_arg $ prelude_arg $ syntax_arg)
 
 let write_arg = Arg.(value & flag & info [ "write"; "w" ] ~doc:"Rewrite the file in place.")
 
 let fmt_t =
   Cmd.v
     (Cmd.info "fmt" ~doc:"Format a .jac or .jqd file canonically, preserving comments.")
-    Term.(const fmt_cmd $ file_arg $ write_arg $ syntax_arg)
+    Term.(
+      const (configure_diagnostics fmt_cmd)
+      $ diagnostic_format_arg $ file_arg $ write_arg $ syntax_arg)
 
 let infer_t =
   let enumerate =
     Cmd.v
       (Cmd.info "enumerate" ~doc:"Exact posterior by multi-shot enumeration.")
-      Term.(const infer_enumerate_cmd $ file_arg $ prelude_arg $ syntax_arg)
+      Term.(
+        const (configure_diagnostics infer_enumerate_cmd)
+        $ diagnostic_format_arg $ file_arg $ prelude_arg $ syntax_arg)
   in
   let lw =
     Cmd.v
       (Cmd.info "lw" ~doc:"Approximate posterior by likelihood weighting.")
       Term.(
-        const infer_lw_cmd $ file_arg $ prelude_arg
+        const (configure_diagnostics infer_lw_cmd)
+        $ diagnostic_format_arg $ file_arg $ prelude_arg
         $ Arg.(
             required
             & opt (some int) None
@@ -1701,7 +1814,8 @@ let diff_t =
          "Semantically compare two source files or two stores: renames are renames, reformatting \
           is nothing, and real edits localize to the smallest changed subtrees.")
     Term.(
-      const diff_cmd
+      const (configure_diagnostics diff_cmd)
+      $ diagnostic_format_arg
       $ Arg.(required & pos 0 (some string) None & info [] ~docv:"FILE_OR_STORE_A")
       $ Arg.(required & pos 1 (some string) None & info [] ~docv:"FILE_OR_STORE_B")
       $ syntax_arg $ prelude_arg)
@@ -1713,7 +1827,8 @@ let store_t =
     Cmd.v
       (Cmd.info "add" ~doc:"Add the file's declarations to a persistent store.")
       Term.(
-        const store_add_cmd $ store_pos_dir
+        const (configure_diagnostics store_add_cmd)
+        $ diagnostic_format_arg $ store_pos_dir
         $ Arg.(required & pos 1 (some file) None & info [] ~docv:"FILE")
         $ origin_arg)
   in
@@ -1721,7 +1836,8 @@ let store_t =
     Cmd.v
       (Cmd.info "name" ~doc:"Bind NAME to a hash already in the store.")
       Term.(
-        const store_name_cmd $ store_pos_dir
+        const (configure_diagnostics store_name_cmd)
+        $ diagnostic_format_arg $ store_pos_dir
         $ Arg.(required & pos 1 (some string) None & info [] ~docv:"NAME")
         $ Arg.(required & pos 2 (some string) None & info [] ~docv:"HASH"))
   in
@@ -1729,7 +1845,8 @@ let store_t =
     Cmd.v
       (Cmd.info "rename" ~doc:"Rebind OLD to NEW; object files are untouched.")
       Term.(
-        const store_rename_cmd $ store_pos_dir
+        const (configure_diagnostics store_rename_cmd)
+        $ diagnostic_format_arg $ store_pos_dir
         $ Arg.(required & pos 1 (some string) None & info [] ~docv:"OLD")
         $ Arg.(required & pos 2 (some string) None & info [] ~docv:"NEW")
         $ Arg.(
@@ -1746,7 +1863,7 @@ let audit_t =
   let genesis =
     Cmd.v
       (Cmd.info "genesis" ~doc:"Print the fixed predecessor/head of an empty Audit v1 chain.")
-      Term.(const audit_genesis_cmd $ const ())
+      Term.(const (configure_diagnostics audit_genesis_cmd) $ diagnostic_format_arg $ const ())
   in
   let append =
     Cmd.v
@@ -1755,7 +1872,8 @@ let audit_t =
            "Verify LOG against its published predecessor, append one canonical AuditEntry, and \
             print the new publishable head.")
       Term.(
-        const audit_append_cmd
+        const (configure_diagnostics audit_append_cmd)
+        $ diagnostic_format_arg
         $ Arg.(required & pos 0 (some string) None & info [] ~docv:"LOG")
         $ Arg.(required & pos 1 (some string) None & info [] ~docv:"AUDIT_ENTRY")
         $ Arg.(
@@ -1775,7 +1893,8 @@ let governance_t =
       (Cmd.info "verify-log"
          ~doc:"Strictly verify a canonical Audit v1 chain against an independently published head.")
       Term.(
-        const audit_verify_cmd
+        const (configure_diagnostics audit_verify_cmd)
+        $ diagnostic_format_arg
         $ Arg.(required & pos 0 (some string) None & info [] ~docv:"LOG")
         $ Arg.(
             required
@@ -1789,7 +1908,8 @@ let governance_t =
            "Verify one canonical governance-run-bundle-v1, including its unchanged Audit chain and \
             exact Call, policy, assessment, Proposal, and parent-lineage links.")
       Term.(
-        const governance_verify_run_cmd
+        const (configure_diagnostics governance_verify_run_cmd)
+        $ diagnostic_format_arg
         $ Arg.(required & pos 0 (some string) None & info [] ~docv:"BUNDLE")
         $ prelude_arg $ store_dir_opt_arg)
   in
@@ -1800,7 +1920,8 @@ let governance_t =
            "Verify a governance-reconciliation-bundle-v1 and report action/receipt completion gaps \
             without inferring rollback or safe retry.")
       Term.(
-        const governance_reconcile_cmd
+        const (configure_diagnostics governance_reconcile_cmd)
+        $ diagnostic_format_arg
         $ Arg.(required & pos 0 (some string) None & info [] ~docv:"BUNDLE")
         $ prelude_arg $ store_dir_opt_arg)
   in
@@ -1815,7 +1936,8 @@ let dist_diff_t =
          "Posterior divergence between two model versions (TL.1): per-outcome deltas over \
           tolerance, support gains/losses called out, enumerations cached by content hash.")
     Term.(
-      const dist_diff_cmd
+      const (configure_diagnostics dist_diff_cmd)
+      $ diagnostic_format_arg
       $ Arg.(required & pos 0 (some file) None & info [] ~docv:"MODEL_A")
       $ Arg.(required & pos 1 (some file) None & info [] ~docv:"MODEL_B")
       $ Arg.(value & opt float 1e-9 & info [ "tolerance" ] ~docv:"T")
@@ -1831,7 +1953,8 @@ let replay_t =
          "Counterfactual debugging (TL.3): serve world ops from a recorded log, scrub with --to, \
           fork with --fork N=FORM; forked futures run under the dry handlers.")
     Term.(
-      const replay_cmd
+      const (configure_diagnostics replay_cmd)
+      $ diagnostic_format_arg
       $ Arg.(required & pos 0 (some file) None & info [] ~docv:"LOG")
       $ Arg.(required & pos 1 (some file) None & info [] ~docv:"PROGRAM")
       $ Arg.(value & opt_all string [] & info [ "fork" ] ~docv:"N=FORM")
@@ -1889,8 +2012,10 @@ let test_t =
          "Discover tests by checked type (decision D12) and run them: the hermetic lane under \
           test.run, the world lane behind --allow grants.")
     Term.(
-      const test_cmd $ test_files_arg $ allows_arg $ prelude_arg $ cache_dir_arg $ no_cache_arg
-      $ coverage_arg $ seed_arg $ samples_arg $ exhaustive_arg $ budget_arg $ schedules_arg)
+      const (configure_diagnostics test_cmd)
+      $ diagnostic_format_arg $ test_files_arg $ allows_arg $ prelude_arg $ cache_dir_arg
+      $ no_cache_arg $ coverage_arg $ seed_arg $ samples_arg $ exhaustive_arg $ budget_arg
+      $ schedules_arg)
 
 (* --- tiers (PF.2 phase 1) --- *)
 
@@ -2086,19 +2211,22 @@ let read_export_source file =
   | Error Export.Stdin ->
       Error
         [
-          Diag.error ~code:"E1302"
+          cli_diagnostic ~code:"E1302"
             "jacquard export requires a named regular input file; materialize stdin first";
         ]
   | Error Export.Not_regular ->
       Error
         [
-          Diag.error ~code:"E1302"
+          cli_diagnostic ~code:"E1302"
             (Printf.sprintf
                "export input %s is not a regular seekable file; materialize the source first" file);
         ]
   | Error (Export.Read_failure message) ->
       Error
-        [ Diag.error ~code:"E1302" (Printf.sprintf "cannot read export input %s: %s" file message) ]
+        [
+          cli_diagnostic ~code:"E1302"
+            (Printf.sprintf "cannot read export input %s: %s" file message);
+        ]
 
 let export_cmd file out prelude syntax =
   match read_export_source file with
@@ -2127,7 +2255,7 @@ let export_cmd file out prelude syntax =
                   | Error Export.Collision ->
                       print_diags
                         [
-                          Diag.error ~code:"E1301"
+                          cli_diagnostic ~code:"E1301"
                             (Printf.sprintf
                                "export output %s already exists; choose a new path or remove it \
                                 explicitly"
@@ -2136,7 +2264,7 @@ let export_cmd file out prelude syntax =
                   | Error (Export.Atomic_failure message) ->
                       print_diags
                         [
-                          Diag.error ~code:"E1303"
+                          cli_diagnostic ~code:"E1303"
                             (Printf.sprintf "cannot publish export atomically: %s" message);
                         ]))))
 
@@ -2146,10 +2274,11 @@ let build_cmd file out prelude dry_run syntax =
   if dry_run then begin
     (* the consent sheet is an interpreter run: the dry handlers wrap live
        evaluation, and a compiled binary has nothing to wrap after the fact *)
-    prerr_endline
-      "error[E1103]: jacquard build does not support --dry-run; the consent sheet is an \
-       interpreter run (use jacquard run --dry-run)";
-    exit_diags
+    print_diags
+      [
+        cli_diagnostic ~code:"E1103"
+          "jacquard build does not support --dry-run; the consent sheet is an interpreter run.";
+      ]
   end
   else
     match open_ctx ~prelude ~store_dir:None with
@@ -2213,9 +2342,11 @@ let build_cmd file out prelude dry_run syntax =
                     in
                     match baked with
                     | None ->
-                        prerr_endline
-                          "error[E1103]: internal: the manifest pass diverged from the load pass";
-                        exit_diags
+                        print_diags
+                          [
+                            cli_diagnostic ~code:"E1103"
+                              "The native manifest pass diverged from the load pass.";
+                          ]
                     | Some rev_baked -> (
                         match
                           Jacquard_native.Build.build ~store ~tops:(List.rev rev_baked)
@@ -2240,18 +2371,18 @@ let build_cmd file out prelude dry_run syntax =
                                   in
                                   go 0
                                 in
-                                if is_eval then
-                                  Printf.eprintf "error[E1102]: %s %s\n"
-                                    r.Jacquard_native.Compile.where what
-                                else
-                                  Printf.eprintf
-                                    "error[E1101]: not yet compilable in native v1: %s %s\n"
-                                    r.Jacquard_native.Compile.where what)
+                                let code = if is_eval then "E1102" else "E1101" in
+                                let cause =
+                                  if is_eval then r.Jacquard_native.Compile.where ^ " " ^ what
+                                  else
+                                    "Not yet compilable in native v1: "
+                                    ^ r.Jacquard_native.Compile.where ^ " " ^ what
+                                in
+                                print_diagnostic (cli_diagnostic ~code cause))
                               rs;
                             exit_diags
-                        | Error (`Toolchain m) ->
-                            Printf.eprintf "error[E1103]: %s\n" m;
-                            exit_diags)))))
+                        | Error (`Toolchain m) -> print_diags [ cli_diagnostic ~code:"E1103" m ]))))
+        )
 
 let out_arg =
   Arg.(required & opt (some string) None & info [ "o"; "output" ] ~docv:"OUT" ~doc:"Output path.")
@@ -2264,7 +2395,9 @@ let export_t =
        ~doc:
          "Export a .jac source artifact as deterministic canonical .jqd for conformance or \
           debugging; the output is created atomically and never replaces an existing path.")
-    Term.(const export_cmd $ export_file_arg $ out_arg $ prelude_arg $ syntax_arg)
+    Term.(
+      const (configure_diagnostics export_cmd)
+      $ diagnostic_format_arg $ export_file_arg $ out_arg $ prelude_arg $ syntax_arg)
 
 let build_t =
   Cmd.v
@@ -2272,7 +2405,9 @@ let build_t =
        ~doc:
          "Compile a .jac surface or .jqd bootstrap file and its reachable declarations to a \
           standalone native executable without generating an intermediate twin.")
-    Term.(const build_cmd $ file_arg $ out_arg $ prelude_arg $ dry_run_arg $ syntax_arg)
+    Term.(
+      const (configure_diagnostics build_cmd)
+      $ diagnostic_format_arg $ file_arg $ out_arg $ prelude_arg $ dry_run_arg $ syntax_arg)
 
 let tiers_t =
   Cmd.v
@@ -2280,7 +2415,8 @@ let tiers_t =
        ~doc:
          "Tier statistics for the native route (PF.2 phase 1): declarations and call sites by \
           effect row, handler clauses by resume discipline; stamps tier sidecars.")
-    Term.(const tiers_cmd $ test_files_arg $ prelude_arg)
+    Term.(
+      const (configure_diagnostics tiers_cmd) $ diagnostic_format_arg $ test_files_arg $ prelude_arg)
 
 let main =
   Cmd.group
@@ -2303,4 +2439,12 @@ let main =
       build_t;
     ]
 
-let () = exit (Cli_entry.run ~program:"jacquard" (fun () -> Cmd.eval' ~catch:false main))
+let render_selected_diagnostic diagnostic =
+  match !selected_diagnostic_format with
+  | Text -> Diag.to_string diagnostic
+  | Json_v1 -> Diag.to_json_string diagnostic
+
+let () =
+  exit
+    (Cli_entry.run ~program:"jacquard" ~render_diagnostic:render_selected_diagnostic (fun () ->
+         Cmd.eval' ~catch:false main))

--- a/corpus/golden/diags.golden
+++ b/corpus/golden/diags.golden
@@ -1,56 +1,93 @@
-type-mismatch | type-mismatch.jqd:1:1-34: error[E0801]: argument: expected int, got text (type mismatch)
-  hint: the expected side comes from the surrounding context; make both sides agree
-branch-mismatch | branch-mismatch.jqd:1:48-79: error[E0801]: match clause result: expected int, got text (type mismatch)
-  hint: the expected side comes from the surrounding context; make both sides agree
-not-a-function | not-a-function.jqd:1:1-22: error[E0802]: int is not a function
-  hint: only functions, constructors, effect operations, and resumptions apply
-app-arity | app-arity.jqd:1:1-47: error[E0803]: this function expects 1 argument(s), got 2
-  hint: Jacquard calls are uncurried: pass exactly the declared arguments
-op-clause-arity | op-clause-arity.jqd:1:60-120: error[E0803]: op clause for print expects 1 parameter(s), got 2
-resume-arity | resume-arity.jqd:1:71-100: error[E0803]: this resumption expects 1 argument, got 2
-  hint: a resumption accepts exactly the operation's result value
-resume-wrong-type | resume-wrong-type.jqd:1:102-109: error[E0801]: resumption argument: expected (), got int (type mismatch)
-  hint: the expected side comes from the surrounding context; make both sides agree
-ann-mismatch | ann-mismatch.jqd:1:1-26: error[E0804]: annotation mismatch: expected text, got int (type mismatch)
-  hint: the annotation is the contract: change the body or the annotation
-ann-pure-but-prints | ann-pure-but-prints.jqd:1:1-70: error[E0804]: annotation mismatch: expected () ->{} (), got () ->{console | e} () (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
-  hint: the annotation is the contract: change the body or the annotation
-ann-rigid-escape | ann-rigid-escape.jqd:1:1-90: error[E0804]: annotation mismatch: expected (a) ->{} a, got (a) ->{} int (type mismatch)
-  hint: the annotation is the contract: change the body or the annotation
-group-annotation-lies | group-annotation-lies.jqd:1:11-92: error[E0804]: binding liar does not match its annotation: expected (int) ->{} text, got (int) ->{} int (type mismatch)
-groupref-outside | groupref-outside.jqd:1:1-13: error[E0805]: groupref 5 outside its group
-pcon-pattern-arity | pcon-pattern-arity.jqd:1:41-52: error[E0806]: constructor some expects 1 argument(s) in this pattern, got 0
-  hint: constructor patterns bind every declared field
-deftype-arity | deftype-arity.jqd:1:41-79: error[E0810]: type option expects 1 argument(s), got 2
-unbound-tyvar | unbound-tyvar.jqd:1:33-42: error[E0811]: unbound type variable `zz` in declaration
-  hint: declare it in the parameter list of the enclosing declaration
-op-unbound-var | op-unbound-var.jqd:1:29-38: error[E0812]: unbound type variable `zz` in declaration
-  hint: declare it in the parameter list of the enclosing declaration
-nonexhaustive-bool | nonexhaustive-bool.jqd:1:24-31: error[E0813]: this match is not exhaustive: it misses false
-  hint: add a clause matching the witness, or a (pwild) default
-nonexhaustive-nested | nonexhaustive-nested.jqd:1:24-31: error[E0813]: this match is not exhaustive: it misses some(some(false))
-  hint: add a clause matching the witness, or a (pwild) default
-ungranted-effect | error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`)
-  hint: grant it with --allow console, or handle the effect in the program
-effectful-toplevel-body | effectful-toplevel-body.jqd:1:11-78: error[E0815]: top-level definition `sneaky` performs the `net` effect while being defined
-  hint: wrap the body in a lambda and perform the effect when called
-value-restriction | value-restriction.jqd:1:112-119: error[E0818]: local binding `i` comes from a non-value and remains monomorphic under the value restriction
-  hint: eta-expand the binding to a lambda value, or give each use its own binding
-once-double-call | once-double-call.jqd:2:129-150: error[E0816]: once resumption `k` may be consumed twice on one possible execution path; first consumption at once-double-call.jqd:2:107-128, second consumption at once-double-call.jqd:2:129-150
-  hint: a once resumption may be dropped or moved, but it may be consumed at most once on each possible execution path
-once-alias-duplication | once-alias-duplication.jqd:2:157-179: error[E0816]: once resumption `k2` may be consumed twice on one possible execution path; first consumption at once-alias-duplication.jqd:2:135-156, second consumption at once-alias-duplication.jqd:2:157-179
-  hint: a once resumption may be dropped or moved, but it may be consumed at most once on each possible execution path
-once-lambda-capture | once-lambda-capture.jqd:2:108-138: error[E0817]: once resumption `k` escapes into a closure captured here (free use at once-lambda-capture.jqd:2:121-128)
-  hint: pass the once resumption as a Resume-typed parameter instead of capturing it
-once-quote-capture | once-quote-capture.jqd:2:106-131: error[E0817]: once resumption `k` escapes into quoted code captured here (splice at once-quote-capture.jqd:2:122-129)
-  hint: a once resumption cannot cross a quote boundary
-once-constructor-storage | once-constructor-storage.jqd:2:130-137: error[E0817]: once resumption `k` cannot be stored in data
-  hint: call the resumption once, drop it, or move it to a local parameter that is checked as Resume-typed
-once-return | once-return.jqd:2:87-94: error[E0817]: once resumption `k` escapes by being returned from its handler clause
-  hint: call the resumption once, drop it, or move it to a local parameter that is checked as Resume-typed
-secret-generic-inspection | secret-generic-inspection.jqd:1:1-100: error[E0819]: Secret has no Show or serialization instance and generic inspection is redacted
-  hint: keep the value opaque; only `secret.expose` converts Secret to Text, and that operation remains in the Secret effect row
-redundant-clause | redundant-clause.jqd:1:57-85: warning[W0801]: this clause is redundant: earlier clauses match everything it does
-eta-positive | eta-positive.jac:2:21-30: error[E0807]: this position expects a thunk, but `condition` is a bare reference; wrap it in `fn () -> ...`
-  hint: wrap the reference in `fn () -> ...` so the computation is delayed
-strict-recovery | error[E1202]: recovery holes are not valid input to the strict type checker
+type-mismatch | type-mismatch.jqd:1:1-34: error[E0801]: Types do not agree
+  Cause: argument: expected int, got text (type mismatch)
+  Next step: the expected side comes from the surrounding context; make both sides agree
+branch-mismatch | branch-mismatch.jqd:1:48-79: error[E0801]: Types do not agree
+  Cause: match clause result: expected int, got text (type mismatch)
+  Next step: the expected side comes from the surrounding context; make both sides agree
+not-a-function | not-a-function.jqd:1:1-22: error[E0802]: This value is not callable
+  Cause: int is not a function
+  Next step: Apply only a function, constructor, effect operation, or resumption.
+app-arity | app-arity.jqd:1:1-47: error[E0803]: Call arity does not agree
+  Cause: this function expects 1 argument(s), got 2
+  Next step: Pass exactly the declared arguments in this uncurried call.
+op-clause-arity | op-clause-arity.jqd:1:60-120: error[E0803]: Call arity does not agree
+  Cause: op clause for print expects 1 parameter(s), got 2
+  Next step: Pass exactly the number of arguments declared by the callable.
+resume-arity | resume-arity.jqd:1:71-100: error[E0803]: Call arity does not agree
+  Cause: this resumption expects 1 argument, got 2
+  Next step: Pass exactly the operation's result value to the resumption.
+resume-wrong-type | resume-wrong-type.jqd:1:102-109: error[E0801]: Types do not agree
+  Cause: resumption argument: expected (), got int (type mismatch)
+  Next step: the expected side comes from the surrounding context; make both sides agree
+ann-mismatch | ann-mismatch.jqd:1:1-26: error[E0804]: The value does not satisfy its annotation
+  Cause: annotation mismatch: expected text, got int (type mismatch)
+  Next step: the annotation is the contract: change the body or the annotation
+ann-pure-but-prints | ann-pure-but-prints.jqd:1:1-70: error[E0804]: The value does not satisfy its annotation
+  Cause: annotation mismatch: expected () ->{} (), got () ->{console | e} () (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
+  Next step: the annotation is the contract: change the body or the annotation
+ann-rigid-escape | ann-rigid-escape.jqd:1:1-90: error[E0804]: The value does not satisfy its annotation
+  Cause: annotation mismatch: expected (a) ->{} a, got (a) ->{} int (type mismatch)
+  Next step: the annotation is the contract: change the body or the annotation
+group-annotation-lies | group-annotation-lies.jqd:1:11-92: error[E0804]: The value does not satisfy its annotation
+  Cause: binding liar does not match its annotation: expected (int) ->{} text, got (int) ->{} int (type mismatch)
+  Next step: Change the value or its annotation so the two types agree.
+groupref-outside | groupref-outside.jqd:1:1-13: error[E0805]: A referenced declaration has the wrong kind or is unavailable
+  Cause: groupref 5 outside its group
+  Next step: Use an available declaration of the required kind.
+pcon-pattern-arity | pcon-pattern-arity.jqd:1:41-52: error[E0806]: Constructor pattern arity does not agree
+  Cause: constructor some expects 1 argument(s) in this pattern, got 0
+  Next step: Bind every field declared by the constructor.
+deftype-arity | deftype-arity.jqd:1:41-79: error[E0810]: Type constructor arity does not agree
+  Cause: type option expects 1 argument(s), got 2
+  Next step: Apply the type constructor to exactly its declared parameters.
+unbound-tyvar | unbound-tyvar.jqd:1:33-42: error[E0811]: A type, effect, or row name is unresolved
+  Cause: unbound type variable `zz` in declaration
+  Next step: Declare it in the parameter list of the enclosing declaration.
+op-unbound-var | op-unbound-var.jqd:1:29-38: error[E0812]: An effect operation signature contains an unbound variable
+  Cause: unbound type variable `zz` in declaration
+  Next step: Declare it in the parameter list of the enclosing declaration.
+nonexhaustive-bool | nonexhaustive-bool.jqd:1:24-31: error[E0813]: This match is not exhaustive
+  Cause: this match is not exhaustive: it misses false
+  Next step: Add a clause matching the witness or a wildcard default.
+nonexhaustive-nested | nonexhaustive-nested.jqd:1:24-31: error[E0813]: This match is not exhaustive
+  Cause: this match is not exhaustive: it misses some(some(false))
+  Next step: Add a clause matching the witness or a wildcard default.
+ungranted-effect | error[E0814]: The program requires an effect that was not granted
+  Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`).
+  Next step: grant it with --allow console, or handle the effect in the program
+effectful-toplevel-body | effectful-toplevel-body.jqd:1:11-78: error[E0815]: A top-level definition performs effects
+  Cause: top-level definition `sneaky` performs the `net` effect while being defined
+  Next step: Wrap the body in a lambda and perform the effect when called.
+value-restriction | value-restriction.jqd:1:112-119: error[E0818]: A non-value binding cannot be reused polymorphically
+  Cause: local binding `i` comes from a non-value and remains monomorphic under the value restriction
+  Next step: eta-expand the binding to a lambda value, or give each use its own binding
+once-double-call | once-double-call.jqd:2:129-150: error[E0816]: A once resumption may be consumed twice on one execution path.
+  Cause: once resumption `k` may be consumed twice on one possible execution path; first consumption at once-double-call.jqd:2:107-128, second consumption at once-double-call.jqd:2:129-150
+  Next step: a once resumption may be dropped or moved, but it may be consumed at most once on each possible execution path
+once-alias-duplication | once-alias-duplication.jqd:2:157-179: error[E0816]: A once resumption may be consumed twice on one execution path.
+  Cause: once resumption `k2` may be consumed twice on one possible execution path; first consumption at once-alias-duplication.jqd:2:135-156, second consumption at once-alias-duplication.jqd:2:157-179
+  Next step: a once resumption may be dropped or moved, but it may be consumed at most once on each possible execution path
+once-lambda-capture | once-lambda-capture.jqd:2:108-138: error[E0817]: A once resumption escapes its handler clause.
+  Cause: once resumption `k` escapes into a closure captured here (free use at once-lambda-capture.jqd:2:121-128)
+  Next step: Pass the once resumption as a Resume-typed parameter instead of capturing it.
+once-quote-capture | once-quote-capture.jqd:2:106-131: error[E0817]: A once resumption escapes its handler clause.
+  Cause: once resumption `k` escapes into quoted code captured here (splice at once-quote-capture.jqd:2:122-129)
+  Next step: Keep the once resumption outside quoted code.
+once-constructor-storage | once-constructor-storage.jqd:2:130-137: error[E0817]: A once resumption escapes its handler clause.
+  Cause: once resumption `k` cannot be stored in data
+  Next step: call the resumption once, drop it, or move it to a local parameter that is checked as Resume-typed
+once-return | once-return.jqd:2:87-94: error[E0817]: A once resumption escapes its handler clause.
+  Cause: once resumption `k` escapes by being returned from its handler clause
+  Next step: call the resumption once, drop it, or move it to a local parameter that is checked as Resume-typed
+secret-generic-inspection | secret-generic-inspection.jqd:1:1-100: error[E0819]: An opaque Secret was used by generic inspection
+  Cause: Secret has no Show or serialization instance and generic inspection is redacted
+  Next step: keep the value opaque; only `secret.expose` converts Secret to Text, and that operation remains in the Secret effect row
+redundant-clause | redundant-clause.jqd:1:57-85: warning[W0801]: This match clause is redundant
+  Cause: Earlier clauses match every value this clause can match.
+  Next step: Remove the redundant clause or narrow an earlier pattern.
+eta-positive | eta-positive.jac:2:21-30: error[E0807]: A computation was used where a thunk is required
+  Cause: this position expects a thunk, but `condition` is a bare reference; wrap it in `fn () -> ...`
+  Next step: Wrap the reference in `fn () -> ...` so the computation is delayed.
+strict-recovery | error[E1202]: Recovered syntax cannot cross this semantic boundary.
+  Cause: Recovery holes are not valid input to the strict type checker.
+  Next step: Fix the reported syntax damage before checking, hashing, storing, or running it.

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -221,7 +221,9 @@ Returning or storing a Task beyond its creating scope, using it after scope
 close, or using it in a different scope/run is the v0 dynamic defect:
 
 ```text
-error[E0907]: a Task may not escape, outlive, or be used outside the structured scope that created it
+error[E0907]: A scoped task or channel handle is invalid
+  Cause: a Task may not escape, outlive, or be used outside the structured scope that created it: Task 0#1 escaped its creating structured scope
+  Next step: Use the handle only inside the exact async.scope that created it.
 ```
 
 Rank-2 static scoping is future work, not a C1 claim.

--- a/docs/effect-review.md
+++ b/docs/effect-review.md
@@ -65,15 +65,17 @@ handler, grant, or availability promise.
 For official Net, the manifest refusal uses identity-confirmed metadata:
 
 ```text
-error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`)
-  hint: grant it with --allow net, or handle the effect in the program
+error[E0814]: The program requires an effect that was not granted
+  Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`).
+  Next step: grant it with --allow net, or handle the effect in the program
 ```
 
 A colliding user effect stays fully identified and unrated:
 
 ```text
-error[E0814]: this program requires unpackaged:a46cb801752d/net [unrated user effect #a46cb801752d15e51f6c46c91d0c4fa874b337d7186f8b3003230442baad74f1], which is not granted (performed via `package.fetch`)
-  hint: handle the effect in the program (unregistered user effects have no built-in --allow grant)
+error[E0814]: The program requires an effect that was not granted
+  Cause: This program requires unpackaged:a46cb801752d/net [unrated user effect #a46cb801752d15e51f6c46c91d0c4fa874b337d7186f8b3003230442baad74f1], which is not granted (performed via `package.fetch`).
+  Next step: handle the effect in the program (unregistered user effects have no built-in --allow grant)
 ```
 
 These exact outputs are executed by `test/cli/manifest.t`.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,8 +1,37 @@
 # Jacquard diagnostic codes
 
-Every diagnostic the toolchain can emit, with an example that triggers it. Codes are
-stable: never reused, never renumbered. A test enforces that every code emitted anywhere
-in `src/` and `bin/` appears in this catalog.
+Every diagnostic the toolchain can emit, with an example that triggers it. Domain-qualified
+identities are stable: a `(domain, code)` pair is never reused or renumbered. A test enforces that
+every code emitted anywhere in `src/`, `bin/`, or the native runtime appears in this catalog.
+
+## Diagnostic structure and rendering
+
+A diagnostic is structured data, not a preformatted message. Every diagnostic has a domain,
+severity, plain-language summary, technical cause, and exactly one primary next step. A source
+span and stable code may be absent only where the historical boundary has neither; optional
+contrast is reserved for one concrete, plausible confusion and records separate `mistaken` and
+`intended` descriptions.
+
+The default text renderer presents the author-facing fields in this order:
+
+1. source span, when available, on the severity/code header;
+2. plain-language summary;
+3. `Cause:` with the technical reason;
+4. one `Next step:`;
+5. `Contrast:`, only when a specific mistaken/intended distinction applies.
+
+Commands accept `--diagnostic-format=text|json-v1`; `text` remains the default. `json-v1` writes
+one compact JSON object per diagnostic to stderr, preserving emission order and exit status. Its
+schema name is `jacquard-diagnostic-v1`, with `domain`, nullable `code`, `severity`, nullable
+`span`, `summary`, `cause`, and `next_step` fields. A span contains `file`, `start`, and `end`; each
+position contains one-based `line` and `column` plus a zero-based byte `offset`. The `contrast`
+object is omitted when it does not apply. Machine consumers should key stable identities by the
+pair `(domain, code)`, not by code alone, and should tolerate `code: null` for deliberately
+code-less runtime failures. Span ends are exclusive, and columns count UTF-8 bytes rather than
+Unicode scalar values. Treat `cause` as opaque author-facing text: when one diagnostic explains
+another, the child is projected into that text rather than exposed as a second nested JSON schema.
+The JSON encoding is always valid UTF-8: well-formed input is preserved byte-for-byte, while each
+malformed source, path, or host-message byte in a string field is replaced with U+FFFD.
 
 ## Process safety (E00xx)
 
@@ -131,16 +160,17 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 
 ## Runtime and probabilistic inference (E09xx)
 
-| code | meaning | example |
-|------|---------|---------|
-| E0901 | empty posterior (impossible observations) | `observe (bernoulli 0.0) true` |
-| E0902 | runtime failure inside inference | a model dividing by zero |
-| E0903 | model file has no expression | a decls-only file passed to `jacquard infer` |
-| E0904 | observe at the sampling root | `observe` under `jacquard run --allow dist` (D7 default: defect) |
-| E0905 | exhaustive verification budget exceeded | a property over `uniform-int(1, 1000000)` under `jacquard test --exhaustive` |
-| E0906 | a once continuation was resumed more than once | applying the same once resumption twice |
-| E0907 | a Task or ChannelHandle carrier is private, malformed, foreign to the run, escaped, stale, or outside its exact structured scope | returning/storing a Task or ChannelHandle beyond `async.scope`, constructing its private carrier by hash, reusing it after its creating scope closes or in another run, or using a parent/descendant/foreign handle |
-| E0908 | a deterministic scheduler, schedule trace, trace I/O, or same-scope policy operation is illegal for its lifecycle, decision order, registration, continuation ownership, configured positive/transport bound, or strict-replay contract | checking out a suspended task, exceeding a task/decision/input bound, observing or scheduling a terminal child twice, reading/writing an unavailable trace path, parsing an unversioned/malformed trace, or replaying a missing, extra, reordered, impossible, queue-drifted, or operation-drifted event |
+| domain | code | meaning | example |
+|--------|------|---------|---------|
+| inference | E0901 | empty posterior (impossible observations) | `observe (bernoulli 0.0) true` |
+| inference | E0902 | runtime failure inside inference | a model dividing by zero |
+| warp | E0902 | runtime failure during exhaustive property execution | an exhaustive property body dividing by zero |
+| inference | E0903 | model file has no expression | a decls-only file passed to `jacquard infer` |
+| runtime | E0904 | observe at the sampling root | `observe` under `jacquard run --allow dist` (D7 default: defect) |
+| warp | E0905 | exhaustive verification budget exceeded | a property over `uniform-int(1, 1000000)` under `jacquard test --exhaustive` |
+| runtime | E0906 | a once continuation was resumed more than once | applying the same once resumption twice |
+| concurrency | E0907 | a Task or ChannelHandle carrier is private, malformed, foreign to the run, escaped, stale, or outside its exact structured scope | returning/storing a Task or ChannelHandle beyond `async.scope`, constructing its private carrier by hash, reusing it after its creating scope closes or in another run, or using a parent/descendant/foreign handle |
+| concurrency | E0908 | a deterministic scheduler, schedule trace, trace I/O, or same-scope policy operation is illegal for its lifecycle, decision order, registration, continuation ownership, configured positive/transport bound, or strict-replay contract | checking out a suspended task, exceeding a task/decision/input bound, observing or scheduling a terminal child twice, reading/writing an unavailable trace path, parsing an unversioned/malformed trace, or replaying a missing, extra, reordered, impossible, queue-drifted, or operation-drifted event |
 
 ## Warp (E10xx)
 
@@ -148,6 +178,14 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 |------|---------|---------|
 | E1001 | expression at top level of a test file | `jacquard test file.jqd` where the file ends with `(app (var main))` |
 | E1002 | eval under --dry-run | a program whose row includes `eval` run with `--dry-run` |
+
+## Native compilation (E11xx)
+
+| code | meaning | example |
+|------|---------|---------|
+| E1101 | program construct is outside the native v1 compilation subset | compiling a call with more than eight arguments |
+| E1102 | program requires the interpreter tier | compiling a program that uses `eval` |
+| E1103 | native toolchain, grant, or build configuration cannot produce the executable | building with an unsupported `net` grant or unavailable compiler |
 
 ## Surface syntax (E12xx)
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,8 +6,8 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `738`
-- Cram transcript files: `43`
+- Alcotest/QCheck cases: `742`
+- Cram transcript files: `44`
 - Doctest examples: `27` across 8 documents
 
 The test count includes six DX.2 filesystem-boundary cases and six DX.5/DX.7
@@ -17,6 +17,8 @@ transcripts added after the frozen release include `test/cli/export.t`,
 the GM.8 governance-verifier analysis lane. GM.14A adds five compiled
 run-bundle cases and one public verifier transcript. GM.14B adds five compiled
 action-reconciliation cases and one public reconciliation transcript.
+DX.4 adds four compiled diagnostic-contract cases and one public diagnostic
+format transcript.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -27,10 +27,10 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 738 compiled Alcotest/QCheck cases, 43 recursive
+The current successor inventory is exactly 742 compiled Alcotest/QCheck cases, 44 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
-commands in [Reconstruction and verification](#reconstruction-and-verification)
-recompute those counts instead of trusting this paragraph.
+repository release-law checks recompute those counts instead of trusting this
+paragraph.
 
 ## One program under four schedule handlers
 
@@ -738,8 +738,8 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `738`
-- Cram transcript files: `43`
+- Alcotest/QCheck cases: `742`
+- Cram transcript files: `44`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
 `channel-contract` cases plus the `store/9` Channel-private-hash case took the
@@ -754,6 +754,8 @@ inventory without changing the frozen SC arithmetic. GM.14A later adds five
 run-bundle cases and one public CLI transcript, producing `733 / 42 / 27`.
 GM.14B adds five action-reconciliation cases and one public CLI transcript,
 producing `738 / 43 / 27`.
+DX.4 then adds four diagnostic-contract cases and one public diagnostic-format
+transcript, producing the current `742 / 44 / 27` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/jacquard.opam
+++ b/jacquard.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.11"}
   "digestif"
+  "yojson"
   "menhir"
   "cmdliner" {>= "2.1.0" & < "2.2"}
   "alcotest" {with-test}

--- a/runtime/check.sh
+++ b/runtime/check.sh
@@ -38,15 +38,29 @@ expect_fatal() {
   [ "$msg" = "$want" ] || { echo "FAIL: $mode said '$msg', want '$want'"; exit 1; }
   echo "ok fatal $mode"
 }
-expect_fatal div0 2 "arithmetic error: division by zero"
-expect_fatal mod0 2 "arithmetic error: modulo by zero"
-expect_fatal arity-overflow 2 "jacquard runtime: constructor arity exceeds the 65535 limit"
+expect_fatal div0 2 "error: Arithmetic operation failed
+  Cause: arithmetic error: division by zero
+  Next step: Correct the arithmetic inputs and run the program again."
+expect_fatal mod0 2 "error: Arithmetic operation failed
+  Cause: arithmetic error: modulo by zero
+  Next step: Correct the arithmetic inputs and run the program again."
+expect_fatal arity-overflow 2 "error: Native runtime could not continue
+  Cause: jacquard runtime: constructor arity exceeds the 65535 limit
+  Next step: Report this native runtime failure with the program and command."
 expect_fatal secret-code-of-text 2 \
-  "type error: code.of-text got unexpected arguments <secret redacted>"
-expect_fatal unhandled-op 3 'unhandled effect console: operation `print` reached the root without a handler'
-expect_fatal match-fail 2 "no clause matched the value 5"
+  "error: Runtime value has the wrong type
+  Cause: type error: code.of-text got unexpected arguments <secret redacted>
+  Next step: Pass a value of the type required by this operation."
+expect_fatal unhandled-op 3 'error: An effect reached the root without a handler
+  Cause: unhandled effect console: operation `print` reached the root without a handler
+  Next step: Grant the effect at the root or handle it inside the program.'
+expect_fatal match-fail 2 "error: No match clause accepted the value
+  Cause: no clause matched the value 5
+  Next step: Add a clause for this value or a wildcard default."
 expect_fatal once-resume-twice 2 \
-  "error[E0906]: a once continuation may be resumed at most once per captured instance"
+  "error[E0906]: A once continuation was resumed more than once
+  Cause: a once continuation may be resumed at most once per captured instance
+  Next step: Resume each captured once continuation at most once."
 
 # 4. parity kit (task 66): the C ports must reproduce the OCaml goldens
 #    byte-for-byte. Goldens regenerate via `dune exec test/gen_native_parity.exe`.

--- a/runtime/jq_alloc.c
+++ b/runtime/jq_alloc.c
@@ -19,8 +19,7 @@
 #include <string.h>
 
 static void oom(void) {
-  fputs("jacquard runtime: out of memory\n", stderr);
-  exit(2);
+  jq_runtime_error("jacquard runtime: out of memory");
 }
 
 /* the header's n is uint16: arity limits are a representation invariant, and
@@ -28,8 +27,7 @@ static void oom(void) {
    block was the failure mode this guards) */
 static void arity_guard(uint64_t needed, const char *what) {
   if (needed > UINT16_MAX) {
-    fprintf(stderr, "jacquard runtime: %s exceeds the 65535 limit\n", what);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_NATIVE, "jacquard runtime: %s exceeds the 65535 limit", what);
   }
 }
 

--- a/runtime/jq_apply.c
+++ b/runtime/jq_apply.c
@@ -14,14 +14,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void fail(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
-static void fail(const char *fmt, ...) {
+static void fail(jq_error_kind kind, const char *fmt, ...)
+    __attribute__((noreturn, format(printf, 2, 3)));
+static void fail(jq_error_kind kind, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  vfprintf(stderr, fmt, ap);
-  va_end(ap);
-  fputc('\n', stderr);
-  exit(2);
+  jq_runtime_vfailf(kind, fmt, ap);
 }
 
 jq_value jq_apply(JQ_PARAMS) {
@@ -29,14 +27,14 @@ jq_value jq_apply(JQ_PARAMS) {
   uint16_t n = rt->apply_n;
   if (jq_is_int(fn)) {
     char *s = jq_show(fn);
-    fail("type error: %s is not applicable", s);
+    fail(JQ_ERROR_TYPE, "%s is not applicable", s);
   }
   jq_block *b = jq_block_of(fn);
   switch (b->tag) {
   case JQ_CLOSURE: {
     uint16_t arity = jq_closure_arity(fn);
     if (arity != n)
-      fail("arity mismatch: closure of %u parameter(s) applied to %u argument(s)",
+      fail(JQ_ERROR_ARITY, "closure of %u parameter(s) applied to %u argument(s)",
            arity, n);
     jq_fn code = (jq_fn)jq_closure_code(fn);
     JQ_TAIL_RETURN(code, rt, fn, a0, a1, a2, a3, a4, a5, a6, a7);
@@ -50,17 +48,17 @@ jq_value jq_apply(JQ_PARAMS) {
     if (info->arity == UINT32_MAX) {
       if (strcmp(info->name, "text.join-variadic-v1") == 0)
         return jq_i_text_join_variadic_v1(rt, args, n);
-      fail("unknown variadic builtin: %s", info->name);
+      fail(JQ_ERROR_NATIVE, "unknown variadic builtin: %s", info->name);
     }
     if (info->arity != n)
-      fail("arity mismatch: builtin %s expects %u argument(s), got %u",
+      fail(JQ_ERROR_ARITY, "builtin %s expects %u argument(s), got %u",
            info->name, info->arity, n);
     return info->fn(rt, args);
   }
   case JQ_CONSTRUCTOR: {
     const jq_con_info *info = (const jq_con_info *)b->payload[0];
     if (info->arity != n)
-      fail("arity mismatch: constructor %s expects %u argument(s), got %u",
+      fail(JQ_ERROR_ARITY, "constructor %s expects %u argument(s), got %u",
            info->name, info->arity, n);
     jq_value args[JQ_MAX_ARITY] = { a0, a1, a2, a3, a4, a5, a6, a7 };
     jq_drop(fn);
@@ -75,14 +73,15 @@ jq_value jq_apply(JQ_PARAMS) {
   }
   case JQ_RESUME: {
     /* interpreter: rt_arity "a resumption takes exactly one argument" */
-    if (n != 1) fail("arity mismatch: a resumption takes exactly one argument, got %u", n);
+    if (n != 1)
+      fail(JQ_ERROR_ARITY, "a resumption takes exactly one argument, got %u", n);
     jq_value r = jq_resume(rt, fn, a0);
     jq_drop(fn); /* the captured original is reusable: multi-shot */
     return r;
   }
   default: {
     char *s = jq_show(fn);
-    fail("type error: %s is not applicable", s);
+    fail(JQ_ERROR_TYPE, "%s is not applicable", s);
   }
   }
 }
@@ -90,5 +89,5 @@ jq_value jq_apply(JQ_PARAMS) {
 void jq_match_fail(jq_rt *rt, jq_value scrutinee) {
   (void)rt;
   char *s = jq_show(scrutinee);
-  fail("no clause matched the value %s", s);
+  fail(JQ_ERROR_MATCH, "%s", s);
 }

--- a/runtime/jq_code.c
+++ b/runtime/jq_code.c
@@ -18,8 +18,7 @@
 
 jq_value jq_code_node(jq_value head_text, uint16_t argc) {
   if ((uint32_t)1 + 2 * (uint32_t)argc > UINT16_MAX) {
-    fputs("jacquard runtime: form arity exceeds the 32767 limit\n", stderr);
-    exit(2);
+    jq_runtime_error("jacquard runtime: form arity exceeds the 32767 limit");
   }
   jq_block *b = jq_alloc_block(JQ_CODE, 0, (uint16_t)(1 + 2 * argc));
   b->payload[0] = (uint64_t)head_text;
@@ -30,8 +29,7 @@ jq_value jq_code_splice_guard(jq_rt *rt, jq_value v) {
   (void)rt;
   if (jq_is_code(v)) return v;
   char *s = jq_show(v);
-  fprintf(stderr, "type error: unquote splice evaluated to %s, not code\n", s);
-  exit(2);
+  jq_runtime_failf(JQ_ERROR_TYPE, "unquote splice evaluated to %s, not code", s);
 }
 
 /* --- equal_ignoring_meta ------------------------------------------- */
@@ -88,10 +86,7 @@ static void dbuf_add(dbuf *b, const char *s) {
     b->cap = b->cap ? b->cap : 128;
     while (b->len + n + 1 > b->cap) b->cap *= 2;
     b->data = realloc(b->data, b->cap);
-    if (!b->data) {
-      fputs("jacquard runtime: out of memory\n", stderr);
-      exit(2);
-    }
+    if (!b->data) jq_runtime_error("jacquard runtime: out of memory");
   }
   memcpy(b->data + b->len, s, n);
   b->len += n;
@@ -131,10 +126,7 @@ static void divergences(dbuf *out, bool *first, const char *path, jq_value fa, j
   for (uint16_t i = 0; i < n; i++) {
     size_t plen = strlen(path) + jq_text_len(head) + 32;
     char *sub = malloc(plen);
-    if (!sub) {
-      fputs("jacquard runtime: out of memory\n", stderr);
-      exit(2);
-    }
+    if (!sub) jq_runtime_error("jacquard runtime: out of memory");
     snprintf(sub, plen, "%s/%.*s[%u]", path, (int)jq_text_len(head),
              (const char *)jq_text_bytes(head), (unsigned)i);
     uint64_t ka = jq_code_kind(fa, i), kb = jq_code_kind(fb, i);

--- a/runtime/jq_effects.c
+++ b/runtime/jq_effects.c
@@ -101,15 +101,13 @@ jq_value jq_perform(jq_rt *rt, uint32_t op_ord, uint16_t n, const jq_value *args
      exit 2) — task 72's run_until_op contract. */
   const jq_op_info *info = op_ord < rt->n_ops ? rt->op_meta[op_ord] : NULL;
   if (rt->lw) {
-    fprintf(stderr,
-            "arithmetic error: error[E0902]: unhandled effect %s: operation `%s` reached "
-            "the root without a handler\n",
-            rt->unhandled_effect_override ? rt->unhandled_effect_override : "?",
-            info ? info->op_name : "?");
-    exit(2);
+    jq_diagnostic_failf(
+        2, "E0902", "Probabilistic inference stopped on a runtime failure.",
+        "Correct the reported model runtime failure and rerun inference.",
+        "unhandled effect %s: operation `%s` reached the root without a handler",
+        rt->unhandled_effect_override ? rt->unhandled_effect_override : "?",
+        info ? info->op_name : "?");
   }
-  fprintf(stderr,
-          "unhandled effect %s: operation `%s` reached the root without a handler\n",
-          info ? info->effect_name : "?", info ? info->op_name : "?");
-  exit(3);
+  jq_runtime_failf(JQ_ERROR_UNHANDLED, "%s: operation `%s` reached the root without a handler",
+                   info ? info->effect_name : "?", info ? info->op_name : "?");
 }

--- a/runtime/jq_error.c
+++ b/runtime/jq_error.c
@@ -2,18 +2,228 @@
  * SPDX-License-Identifier: Apache-2.0
  * Additional permission applies; see ../RUNTIME-EXCEPTION.md. */
 
-/* Fatal runtime errors (task 65): the interpreter's runtime-failure contract
- * is a rendered message on stderr and exit 2; emitted code and the runtime
- * both route through here. Messages are pinned against `jacquard run`. */
+/* Fatal runtime errors (task 65): native execution renders the same canonical
+ * fields and exits with the same status as Runtime_err.to_diag. */
 
 #include "jq_value.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  const char *summary;
+  const char *cause_prefix;
+  const char *next_step;
+  int status;
+} jq_error_contract;
+
+/* A depth (rather than a bool) makes nested likelihood-weighting drivers
+ * compose. Thread-local storage keeps separate embedded program threads from
+ * sharing the dynamic diagnostic context. */
+static _Thread_local unsigned inference_depth;
+
+void jq_runtime_inference_enter(void) { inference_depth++; }
+
+void jq_runtime_inference_leave(void) {
+  if (inference_depth == 0) abort();
+  inference_depth--;
+}
+
+static void write_indented(const char *text) {
+  for (const char *cursor = text; *cursor; cursor++) {
+    fputc(*cursor, stderr);
+    if (*cursor == '\n' && cursor[1] != '\0') fputs("         ", stderr);
+  }
+}
+
+static const char *inference_summary = "Probabilistic inference stopped on a runtime failure.";
+static const char *inference_next_step =
+    "Correct the reported model runtime failure and rerun inference.";
+
+static void inference_start(unsigned nested_wrappers) {
+  fprintf(stderr, "error[E0902]: %s\n  Cause: ", inference_summary);
+  for (unsigned i = 0; i < nested_wrappers; i++)
+    fprintf(stderr, "E0902: %s (", inference_summary);
+}
+
+static void inference_finish(unsigned nested_wrappers) __attribute__((noreturn));
+static void inference_finish(unsigned nested_wrappers) {
+  for (unsigned i = 0; i < nested_wrappers; i++) fputc(')', stderr);
+  fprintf(stderr, "\n  Next step: %s\n", inference_next_step);
+  exit(2);
+}
+
+static void vwrite_indentedf(const char *format, va_list ap) {
+  va_list measured;
+  va_copy(measured, ap);
+  int length = vsnprintf(NULL, 0, format, measured);
+  va_end(measured);
+  if (length < 0) {
+    fputs("native diagnostic detail could not be formatted", stderr);
+    return;
+  }
+  char *rendered = malloc((size_t)length + 1);
+  if (!rendered) {
+    fputs("native diagnostic detail could not be allocated", stderr);
+    return;
+  }
+  vsnprintf(rendered, (size_t)length + 1, format, ap);
+  write_indented(rendered);
+  free(rendered);
+}
+
+static jq_error_contract contract(jq_error_kind kind) {
+  switch (kind) {
+  case JQ_ERROR_MATCH:
+    return (jq_error_contract){"No match clause accepted the value", "no clause matched the value ",
+                               "Add a clause for this value or a wildcard default.", 2};
+  case JQ_ERROR_UNHANDLED:
+    return (jq_error_contract){"An effect reached the root without a handler", "unhandled effect ",
+                               "Grant the effect at the root or handle it inside the program.", 3};
+  case JQ_ERROR_ARITY:
+    return (jq_error_contract){"Runtime call arity does not agree", "arity mismatch: ",
+                               "Pass exactly the number of arguments required by the callable.", 2};
+  case JQ_ERROR_ARITHMETIC:
+    return (jq_error_contract){"Arithmetic operation failed", "arithmetic error: ",
+                               "Correct the arithmetic inputs and run the program again.", 2};
+  case JQ_ERROR_IO:
+    return (jq_error_contract){"World-effect I/O failed", "io error: ",
+                               "Correct the path, permissions, or external resource and try again.", 2};
+  case JQ_ERROR_TYPE:
+    return (jq_error_contract){"Runtime value has the wrong type", "type error: ",
+                               "Pass a value of the type required by this operation.", 2};
+  case JQ_ERROR_UNRESOLVED:
+    return (jq_error_contract){"Runtime reference is unresolved", "unresolved reference: ",
+                               "Resolve every name and hash before evaluation.", 2};
+  case JQ_ERROR_EVAL:
+    return (jq_error_contract){"Eval rejected its code value", "eval rejected its argument: ",
+                               "Pass validated closed code to eval.", 2};
+  case JQ_ERROR_NATIVE:
+    return (jq_error_contract){"Native runtime could not continue", "",
+                               "Report this native runtime failure with the program and command.", 2};
+  }
+  abort();
+}
+
+void jq_diagnostic_fail(int status, const char *code, const char *summary,
+                        const char *cause, const char *next_step) {
+  if (inference_depth > 0) {
+    unsigned nested_wrappers = inference_depth - 1;
+    inference_start(nested_wrappers);
+    if (code && strcmp(code, "E0901") == 0) {
+      fprintf(stderr, "%s: %s (", code, summary);
+      write_indented(cause);
+      fputc(')', stderr);
+    } else {
+      write_indented(cause);
+    }
+    inference_finish(nested_wrappers);
+  }
+  if (code)
+    fprintf(stderr, "error[%s]: %s\n", code, summary);
+  else
+    fprintf(stderr, "error: %s\n", summary);
+  fputs("  Cause: ", stderr);
+  write_indented(cause);
+  fprintf(stderr, "\n  Next step: %s\n", next_step);
+  exit(status);
+}
+
+void jq_diagnostic_failf(int status, const char *code, const char *summary,
+                         const char *next_step, const char *cause_format, ...) {
+  if (inference_depth > 0) {
+    unsigned nested_wrappers = inference_depth - 1;
+    inference_start(nested_wrappers);
+    if (code && strcmp(code, "E0901") == 0) fprintf(stderr, "%s: %s (", code, summary);
+    va_list inference_ap;
+    va_start(inference_ap, cause_format);
+    vwrite_indentedf(cause_format, inference_ap);
+    va_end(inference_ap);
+    if (code && strcmp(code, "E0901") == 0) fputc(')', stderr);
+    inference_finish(nested_wrappers);
+  }
+  if (code)
+    fprintf(stderr, "error[%s]: %s\n", code, summary);
+  else
+    fprintf(stderr, "error: %s\n", summary);
+  fputs("  Cause: ", stderr);
+  va_list ap;
+  va_start(ap, cause_format);
+  vwrite_indentedf(cause_format, ap);
+  va_end(ap);
+  fprintf(stderr, "\n  Next step: %s\n", next_step);
+  exit(status);
+}
+
+static void start(jq_error_kind kind) {
+  jq_error_contract c = contract(kind);
+  if (inference_depth > 0) {
+    inference_start(inference_depth - 1);
+    fputs(c.cause_prefix, stderr);
+  } else
+    fprintf(stderr, "error: %s\n  Cause: %s", c.summary, c.cause_prefix);
+}
+
+static void finish(jq_error_kind kind) __attribute__((noreturn));
+static void finish(jq_error_kind kind) {
+  jq_error_contract c = contract(kind);
+  if (inference_depth > 0) inference_finish(inference_depth - 1);
+  fprintf(stderr, "\n  Next step: %s\n", c.next_step);
+  exit(c.status);
+}
+
+void jq_runtime_fail(jq_error_kind kind, const char *detail) {
+  start(kind);
+  write_indented(detail);
+  finish(kind);
+}
+
+void jq_runtime_vfailf(jq_error_kind kind, const char *fmt, va_list ap) {
+  start(kind);
+  vwrite_indentedf(fmt, ap);
+  finish(kind);
+}
+
+void jq_runtime_failf(jq_error_kind kind, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  jq_runtime_vfailf(kind, fmt, ap);
+}
 
 void jq_runtime_error(const char *msg) {
-  fprintf(stderr, "%s\n", msg);
-  exit(2);
+  const struct {
+    const char *prefix;
+    jq_error_kind kind;
+  } prefixes[] = {
+      {"no clause matched the value ", JQ_ERROR_MATCH},
+      {"unhandled effect ", JQ_ERROR_UNHANDLED},
+      {"arity mismatch: ", JQ_ERROR_ARITY},
+      {"arithmetic error: ", JQ_ERROR_ARITHMETIC},
+      {"io error: ", JQ_ERROR_IO},
+      {"type error: ", JQ_ERROR_TYPE},
+      {"unresolved reference: ", JQ_ERROR_UNRESOLVED},
+      {"eval rejected its argument: ", JQ_ERROR_EVAL},
+  };
+  if (strncmp(msg, "error[E0906]: ", 14) == 0)
+    jq_diagnostic_fail(2, "E0906", "A once continuation was resumed more than once", msg + 14,
+                       "Resume each captured once continuation at most once.");
+  if (strncmp(msg, "error[E0904]: ", 14) == 0)
+    jq_diagnostic_fail(2, "E0904", "Observation is invalid at the sampling root", msg + 14,
+                       "Move the observation under an inference handler.");
+  if (strncmp(msg, "arithmetic error: error[E0901]: ", 32) == 0)
+    jq_diagnostic_fail(2, "E0901", "The posterior is empty.", msg + 32,
+                       "Change the model or observations so at least one execution branch has nonzero weight.");
+  if (strncmp(msg, "arithmetic error: error[E0902]: ", 32) == 0)
+    jq_diagnostic_fail(2, "E0902", "Probabilistic inference stopped on a runtime failure.", msg + 32,
+                       "Correct the reported model runtime failure and rerun inference.");
+  for (size_t i = 0; i < sizeof prefixes / sizeof prefixes[0]; i++) {
+    size_t n = strlen(prefixes[i].prefix);
+    if (strncmp(msg, prefixes[i].prefix, n) == 0)
+      jq_runtime_fail(prefixes[i].kind, msg + n);
+  }
+  jq_runtime_fail(JQ_ERROR_NATIVE, msg);
 }
 
 /* goldens pinned from the interpreter (jacquard run, 2026-07-05) */

--- a/runtime/jq_frames.c
+++ b/runtime/jq_frames.c
@@ -67,8 +67,7 @@ static jq_value jq_hf_marker(jq_rt *rt, jq_block *f, jq_value v) {
   (void)rt;
   (void)f;
   (void)v;
-  fputs("jacquard runtime: handler frame re-entered as code (internal)\n", stderr);
-  exit(2);
+  jq_runtime_error("jacquard runtime: handler frame re-entered as code (internal)");
 }
 
 static bool is_hf(jq_block *f) { return jq_frame_code(f) == (jq_frame_fn)jq_hf_marker; }

--- a/runtime/jq_grants.c
+++ b/runtime/jq_grants.c
@@ -23,13 +23,11 @@ static void type_err1(const char *msg_prefix, uint16_t got_n, const jq_value *ar
     __attribute__((noreturn));
 static void type_err1(const char *msg_prefix, uint16_t got_n, const jq_value *args, uint16_t n) {
   (void)got_n;
-  fprintf(stderr, "type error: %s", msg_prefix);
-  for (uint16_t i = 0; i < n; i++) {
-    char *s = jq_show(args[i]);
-    fprintf(stderr, "%s%s", i ? ", " : "", s);
-  }
-  fputc('\n', stderr);
-  exit(2);
+  char *first = n > 0 ? jq_show(args[0]) : NULL;
+  char *second = n > 1 ? jq_show(args[1]) : NULL;
+  if (n > 1)
+    jq_runtime_failf(JQ_ERROR_TYPE, "%s%s, %s", msg_prefix, first, second);
+  jq_runtime_failf(JQ_ERROR_TYPE, "%s%s", msg_prefix, first ? first : "");
 }
 
 static bool is_text(jq_value v) {
@@ -89,8 +87,7 @@ jq_value jq_g_sleep(jq_rt *rt, const jq_value *args) {
 
 static void io_err(const char *path) __attribute__((noreturn));
 static void io_err(const char *path) {
-  fprintf(stderr, "io error: %s: %s\n", path, strerror(errno));
-  exit(2);
+  jq_runtime_failf(JQ_ERROR_IO, "%s: %s", path, strerror(errno));
 }
 
 /* the libc calls need a NUL-terminated copy of the path text */
@@ -192,8 +189,7 @@ jq_value jq_g_dist_sample(jq_rt *rt, const jq_value *args) {
   extern jq_value jq_g_dist_draw(jq_rt *, jq_value); /* jq_intrinsics.c */
   if (!jq_is_ptr(args[0]) || jq_block_of(args[0])->tag != JQ_CON) {
     char *s = jq_show(args[0]);
-    fprintf(stderr, "type error: %s is not a distribution value\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "%s is not a distribution value", s);
   }
   return jq_g_dist_draw(rt, args[0]);
 }
@@ -203,14 +199,12 @@ jq_value jq_g_dist_observe(jq_rt *rt, const jq_value *args) {
   /* run_cmd renders Observe_at_root as E0904; inside a weighted run the LW
      driver flattens it to an E0902 diagnostic first (both exit 2) */
   if (rt->lw)
-    fputs("arithmetic error: error[E0902]: observe reached the sampling root handler; "
-          "observation requires an inference driver (use jacquard infer)\n",
-          stderr);
-  else
-    fputs("error[E0904]: observe reached the sampling root handler; observation requires "
-          "an inference driver (use jacquard infer)\n",
-          stderr);
-  exit(2);
+    jq_diagnostic_fail(2, "E0902", "Probabilistic inference stopped on a runtime failure.",
+                       "observe reached the sampling root handler; observation requires an inference driver (use jacquard infer)",
+                       "Correct the reported model runtime failure and rerun inference.");
+  jq_diagnostic_fail(2, "E0904", "Observation is invalid at the sampling root",
+                     "observe reached the sampling root handler; observation requires an inference driver (use jacquard infer)",
+                     "Move the observation under an inference handler.");
 }
 
 /* infer (task 72): the stub completion grant, ported from install_infer.

--- a/runtime/jq_intrinsics.c
+++ b/runtime/jq_intrinsics.c
@@ -20,8 +20,7 @@ static void type_err2(const char *name, const char *kind, jq_value a, jq_value b
     __attribute__((noreturn));
 static void type_err2(const char *name, const char *kind, jq_value a, jq_value b) {
   char *sa = jq_show(a), *sb = jq_show(b);
-  fprintf(stderr, "type error: %s expects two %s, got %s, %s\n", name, kind, sa, sb);
-  exit(2);
+  jq_runtime_failf(JQ_ERROR_TYPE, "%s expects two %s, got %s, %s", name, kind, sa, sb);
 }
 
 static bool is_real(jq_value v) {
@@ -129,8 +128,7 @@ jq_value jq_i_text_length(jq_rt *rt, const jq_value *a) {
   (void)rt;
   if (!is_text(a[0])) {
     char *s = jq_show(a[0]);
-    fprintf(stderr, "type error: text.length got unexpected arguments %s\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "text.length got unexpected arguments %s", s);
   }
   jq_value r = jq_int((int64_t)jq_utf8_count(jq_text_bytes(a[0]), jq_text_len(a[0])));
   jq_drop(a[0]);
@@ -162,11 +160,9 @@ static void text_join_list_error(const jq_value *a, jq_value bad)
     __attribute__((noreturn));
 static void text_join_list_error(const jq_value *a, jq_value bad) {
   char *shown = jq_show(bad);
-  fprintf(stderr, "type error: text.join expects a list of texts, got %s\n", shown);
-  free(shown);
   jq_drop(a[0]);
   jq_drop(a[1]);
-  exit(2);
+  jq_runtime_failf(JQ_ERROR_TYPE, "text.join expects a list of texts, got %s", shown);
 }
 
 jq_value jq_i_text_join(jq_rt *rt, const jq_value *a) {
@@ -210,11 +206,9 @@ jq_value jq_i_text_join_variadic_v1(jq_rt *rt, const jq_value *a, uint16_t n) {
   for (uint16_t i = 0; i < n; i++) {
     if (!is_text(a[i])) {
       char *shown = jq_show(a[i]);
-      fprintf(stderr, "type error: text.join expects Text at argument %u, got %s\n",
-              (unsigned)(i + 1), shown);
-      free(shown);
       for (uint16_t j = 0; j < n; j++) jq_drop(a[j]);
-      exit(2);
+      jq_runtime_failf(JQ_ERROR_TYPE, "text.join expects Text at argument %u, got %s",
+                       (unsigned)(i + 1), shown);
     }
     total += jq_text_len(a[i]);
   }
@@ -258,15 +252,19 @@ jq_value jq_i_text_compare(jq_rt *rt, const jq_value *a) {
 static void type_err_args(const char *name, const jq_value *a, uint16_t n)
     __attribute__((noreturn));
 static void type_err_args(const char *name, const jq_value *a, uint16_t n) {
-  fprintf(stderr, "type error: %s got unexpected arguments ", name);
+  char *shown[JQ_MAX_ARITY] = {0};
+  size_t length = strlen(name) + strlen(" got unexpected arguments ") + 1;
   for (uint16_t i = 0; i < n; i++) {
-    char *s = jq_show(a[i]);
-    fprintf(stderr, "%s%s", i ? ", " : "", s);
-    free(s);
+    shown[i] = jq_show(a[i]);
+    length += strlen(shown[i]) + (i ? 2 : 0);
   }
-  fputc('\n', stderr);
+  char *message = malloc(length);
+  if (!message) jq_runtime_error("jacquard runtime: out of memory");
+  size_t at = (size_t)snprintf(message, length, "%s got unexpected arguments ", name);
+  for (uint16_t i = 0; i < n; i++)
+    at += (size_t)snprintf(message + at, length - at, "%s%s", i ? ", " : "", shown[i]);
   for (uint16_t i = 0; i < n; i++) jq_drop(a[i]);
-  exit(2);
+  jq_runtime_fail(JQ_ERROR_TYPE, message);
 }
 
 /* ASCII whitespace only in this draft, matching the interpreter (documented) */
@@ -372,12 +370,8 @@ static bool is_con_named(jq_value v, const char *name) {
 static void arith_err(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
 static void arith_err(const char *fmt, ...) {
   va_list ap;
-  fputs("arithmetic error: ", stderr);
   va_start(ap, fmt);
-  vfprintf(stderr, fmt, ap);
-  va_end(ap);
-  fputc('\n', stderr);
-  exit(2);
+  jq_runtime_vfailf(JQ_ERROR_ARITHMETIC, fmt, ap);
 }
 
 static jq_value pair2(jq_rt *rt, jq_value x, jq_value p) {
@@ -399,8 +393,7 @@ static void check_entries(jq_value entries) {
       }
     }
     char *s = jq_show(v);
-    fprintf(stderr, "type error: categorical expects a list of pairs, got %s\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "categorical expects a list of pairs, got %s", s);
   }
 }
 
@@ -426,8 +419,7 @@ static void check_dist(jq_value d) {
     return;
   }
   char *s = jq_show(d);
-  fprintf(stderr, "type error: %s is not a distribution value\n", s);
-  exit(2);
+  jq_runtime_failf(JQ_ERROR_TYPE, "%s is not a distribution value", s);
 }
 
 /* the support list, owned; the caller validated the dist. uniform-int is
@@ -714,8 +706,7 @@ jq_value jq_i_code_form(jq_rt *rt, const jq_value *a) {
   uint64_t hn = jq_text_len(a[0]);
   if (!code_head_ok(hs, hn)) {
     char *esc = ocaml_escaped(hs, hn);
-    fprintf(stderr, "type error: code.form: %s is not a valid form head\n", esc);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "code.form: %s is not a valid form head", esc);
   }
   /* walk the cons list twice: count, then fill (the interpreter errors on
      the first non-conforming node with its show) */
@@ -740,8 +731,7 @@ jq_value jq_i_code_form(jq_rt *rt, const jq_value *a) {
   }
   if (bad) {
     char *shown = jq_show(it);
-    fprintf(stderr, "type error: code.form expects a list of code, got %s\n", shown);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "code.form expects a list of code, got %s", shown);
   }
   if (count > (UINT16_MAX - 1) / 2)
     jq_runtime_error("jacquard runtime: form arity exceeds the 32767 limit");
@@ -911,8 +901,7 @@ jq_value jq_i_debug_inspect(jq_rt *rt, const jq_value *a) {
 jq_value jq_i_support(jq_rt *rt, const jq_value *a) {
   if (!jq_is_ptr(a[0]) || jq_block_of(a[0])->tag != JQ_CON) {
     char *s = jq_show(a[0]);
-    fprintf(stderr, "type error: %s is not a distribution value\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "%s is not a distribution value", s);
   }
   check_dist(a[0]);
   jq_value r = support_of(rt, a[0]);
@@ -926,8 +915,7 @@ jq_value jq_i_pmf(jq_rt *rt, const jq_value *a) {
   jq_value d = a[0], v = a[1];
   if (!jq_is_ptr(d) || jq_block_of(d)->tag != JQ_CON) {
     char *s = jq_show(d);
-    fprintf(stderr, "type error: %s is not a distribution value\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "%s is not a distribution value", s);
   }
   check_dist(d);
   double mass;
@@ -1031,8 +1019,7 @@ jq_value jq_lw_sample(jq_rt *rt, jq_value dv) {
   lw_state *st = (lw_state *)rt->lw;
   if (!jq_is_ptr(dv) || jq_block_of(dv)->tag != JQ_CON) {
     char *s = jq_show(dv);
-    fprintf(stderr, "type error: %s is not a distribution value\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "%s is not a distribution value", s);
   }
   check_dist(dv);
   jq_value x = draw_dist(rt, &st->rng, dv);
@@ -1044,8 +1031,7 @@ jq_value jq_lw_observe(jq_rt *rt, jq_value dv, jq_value v) {
   lw_state *st = (lw_state *)rt->lw;
   if (!jq_is_ptr(dv) || jq_block_of(dv)->tag != JQ_CON) {
     char *s = jq_show(dv);
-    fprintf(stderr, "type error: %s is not a distribution value\n", s);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE, "%s is not a distribution value", s);
   }
   check_dist(dv);
   st->weight *= pmf_mass(rt, dv, v);
@@ -1077,9 +1063,9 @@ jq_value jq_i_dist_sample_lw(jq_rt *rt, const jq_value *a) {
     char *s0 = jq_show(a[0]);
     char *s1 = jq_show(a[1]);
     char *s2 = jq_show(a[2]);
-    fprintf(stderr, "type error: dist.sample-lw expects a thunk and two ints, got %s, %s, %s\n",
-            s0, s1, s2);
-    exit(2);
+    jq_runtime_failf(JQ_ERROR_TYPE,
+                     "dist.sample-lw expects a thunk and two ints, got %s, %s, %s", s0, s1,
+                     s2);
   }
   int64_t samples = jq_int_val(a[1]);
   int64_t master = jq_int_val(a[2]);
@@ -1104,9 +1090,11 @@ jq_value jq_i_dist_sample_lw(jq_rt *rt, const jq_value *a) {
     rt->unhandled_effect_override = "(not handled during inference)";
     jq_dup(thunk);
     rt->apply_n = 0;
+    jq_runtime_inference_enter();
     jq_value v = jq_tc_drive(
         rt, jq_apply(rt, thunk, JQ_UNIT, JQ_UNIT, JQ_UNIT, JQ_UNIT, JQ_UNIT, JQ_UNIT,
                      JQ_UNIT, JQ_UNIT));
+    jq_runtime_inference_leave();
     rt->hs_floor = saved_floor;
     rt->lw = saved_lw;
     rt->unhandled_effect_override = saved_override;
@@ -1121,10 +1109,9 @@ jq_value jq_i_dist_sample_lw(jq_rt *rt, const jq_value *a) {
   double total = 0.0;
   for (int64_t i = samples - 1; i >= 0; i--) total += runs[i].weight;
   if (total <= 0.0) {
-    fputs("arithmetic error: error[E0901]: the posterior is empty: every run is "
-          "impossible under the observations\n",
-          stderr);
-    exit(2);
+    jq_diagnostic_fail(2, "E0901", "The posterior is empty.",
+                       "the posterior is empty: every run is impossible under the observations",
+                       "Change the model or observations so at least one execution branch has nonzero weight.");
   }
   /* merge on the rendering key, accumulating per key in the same reverse
      order */

--- a/runtime/jq_main.c
+++ b/runtime/jq_main.c
@@ -39,8 +39,7 @@ int jq_run_main(jq_rt *rt, void (*body)(jq_rt *)) {
   if (pthread_attr_init(&attr) != 0 ||
       pthread_attr_setstacksize(&attr, mb * 1024 * 1024) != 0 ||
       pthread_create(&tid, &attr, trampoline, &r) != 0) {
-    fputs("jacquard runtime: could not start the program thread\n", stderr);
-    return 2;
+    jq_runtime_fail(JQ_ERROR_NATIVE, "jacquard runtime: could not start the program thread");
   }
   pthread_join(tid, NULL);
   /* the handler and frame stacks' backing arrays outlive every balanced

--- a/runtime/jq_rc.c
+++ b/runtime/jq_rc.c
@@ -29,10 +29,7 @@ static void wl_push(worklist *w, jq_block *b) {
   if (w->len == w->cap) {
     w->cap = w->cap ? w->cap * 2 : 64;
     w->items = realloc(w->items, w->cap * sizeof(jq_block *));
-    if (!w->items) {
-      fputs("jacquard runtime: out of memory\n", stderr);
-      exit(2);
-    }
+    if (!w->items) jq_runtime_error("jacquard runtime: out of memory");
   }
   w->items[w->len++] = b;
 }
@@ -88,8 +85,7 @@ void jq_free_walk(jq_block *root) {
     default:
       /* CODE arrives with task 73 and extends this walk; static-only tags
          cannot be freed */
-      fprintf(stderr, "jacquard runtime: free walk hit tag %d\n", b->tag);
-      exit(2);
+      jq_runtime_failf(JQ_ERROR_NATIVE, "jacquard runtime: free walk hit tag %d", b->tag);
     }
     jq_block_free(b);
   }

--- a/runtime/jq_show.c
+++ b/runtime/jq_show.c
@@ -152,9 +152,8 @@ static bool symbol_ok(const uint8_t *s, uint64_t n) {
    unreachable from checked programs (quote payloads parsed, code.form heads
    validated), so the native rendering of the crash is a plain fatal. */
 static void unprintable(const char *what, const uint8_t *s, uint64_t n) {
-  fprintf(stderr, "jacquard runtime: %s %.*s is not printable\n", what, (int)n,
-          (const char *)s);
-  exit(2);
+  jq_runtime_failf(JQ_ERROR_NATIVE, "jacquard runtime: %s %.*s is not printable", what, (int)n,
+                   (const char *)s);
 }
 
 static void scalar_into(jq_buf *b, uint64_t kind, jq_value datum) {

--- a/runtime/jq_value.h
+++ b/runtime/jq_value.h
@@ -33,6 +33,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdarg.h>
 
 _Static_assert(sizeof(void *) == 8, "the jacquard runtime is 64-bit only");
 
@@ -115,8 +116,38 @@ static inline jq_value jq_int_mod(jq_value a, jq_value b) {
   return jq_int(jq_int_val(a) % jq_int_val(b));
 }
 
-/* Fatal runtime error: message to stderr, exit 2 — the interpreter's
-   runtime-failure contract (jq_error.c). */
+/* Canonical native runtime diagnostics. The category fixes the same summary,
+   cause prefix, next step, and exit used by Runtime_err.to_diag. */
+typedef enum {
+  JQ_ERROR_MATCH,
+  JQ_ERROR_UNHANDLED,
+  JQ_ERROR_ARITY,
+  JQ_ERROR_ARITHMETIC,
+  JQ_ERROR_IO,
+  JQ_ERROR_TYPE,
+  JQ_ERROR_UNRESOLVED,
+  JQ_ERROR_EVAL,
+  JQ_ERROR_NATIVE
+} jq_error_kind;
+
+void jq_runtime_fail(jq_error_kind kind, const char *detail) __attribute__((noreturn));
+void jq_runtime_failf(jq_error_kind kind, const char *fmt, ...)
+    __attribute__((noreturn, format(printf, 2, 3)));
+void jq_runtime_vfailf(jq_error_kind kind, const char *fmt, va_list ap)
+    __attribute__((noreturn));
+/* Mark the dynamic extent of one likelihood-weighting model execution so an
+   ordinary runtime failure is reported through the driver's E0902 contract. */
+void jq_runtime_inference_enter(void);
+void jq_runtime_inference_leave(void);
+void jq_diagnostic_fail(int status, const char *code, const char *summary,
+                        const char *cause, const char *next_step)
+    __attribute__((noreturn));
+void jq_diagnostic_failf(int status, const char *code, const char *summary,
+                         const char *next_step, const char *cause_format, ...)
+    __attribute__((noreturn, format(printf, 5, 6)));
+
+/* Compatibility entry point for runtime sites that already carry a fully
+   categorized Runtime_err.to_string-style message. */
 void jq_runtime_error(const char *msg) __attribute__((noreturn));
 jq_value jq_int_div_checked(jq_value a, jq_value b);
 jq_value jq_int_mod_checked(jq_value a, jq_value b);

--- a/scripts/native-parallel-evidence.sh
+++ b/scripts/native-parallel-evidence.sh
@@ -65,8 +65,11 @@ compare_one test/native-parallel/success.jqd success
 compare_one test/native-parallel/fail-map.jqd fail-map
 compare_one test/native-parallel/fail-both.jqd fail-both
 
-test "$(cat "$work/fail-map.i.err")" = "arithmetic error: division by zero"
-test "$(cat "$work/fail-both.i.err")" = "arithmetic error: division by zero"
+expected_division_error='error: Arithmetic operation failed
+  Cause: arithmetic error: division by zero
+  Next step: Correct the arithmetic inputs and run the program again.'
+test "$(cat "$work/fail-map.i.err")" = "$expected_division_error"
+test "$(cat "$work/fail-both.i.err")" = "$expected_division_error"
 grep -q '(var mod)' test/native-parallel/fail-map.jqd
 grep -q '(var mod)' test/native-parallel/fail-both.jqd
 printf 'failure order: map first-of-two and both left-before-right select division before modulo\n'

--- a/src/affine_resume.ml
+++ b/src/affine_resume.ml
@@ -93,11 +93,29 @@ let span_text meta =
   | None -> "an unknown source location"
 
 let span_text_in env meta = span_text (diagnostic_meta env meta)
-let reject ?hint ~code ~meta message = Error (Diag.error ?span:(Meta.span meta) ?hint ~code message)
+
+let reject ?next_step ~code ~meta cause =
+  let summary =
+    match code with
+    | "E0816" -> "A once resumption may be consumed twice on one execution path."
+    | "E0817" -> "A once resumption escapes its handler clause."
+    | _ -> raise (Diag.Bug_invalid_diagnostic ("unknown affine diagnostic code " ^ code))
+  in
+  let next_step =
+    Option.value next_step
+      ~default:
+        (match code with
+        | "E0816" -> "Make every possible execution path consume the resumption at most once."
+        | "E0817" -> "Consume, drop, or transfer the resumption within its affine clause boundary."
+        | _ -> assert false)
+  in
+  Error
+    (Diag.error ?span:(Meta.span meta) ~domain:Checker ~code ~summary ~cause ~next_step
+       ~contrast:None ())
 
 let reject_double first second =
   reject ~code:"E0816" ~meta:second.meta
-    ~hint:
+    ~next_step:
       "a once resumption may be dropped or moved, but it may be consumed at most once on each \
        possible execution path"
     (Printf.sprintf
@@ -120,7 +138,7 @@ let escape_message binder = function
 
 let reject_escape env ~binder ~meta context =
   reject ~code:"E0817" ~meta:(diagnostic_meta env meta)
-    ~hint:
+    ~next_step:
       "call the resumption once, drop it, or move it to a local parameter that is checked as \
        Resume-typed"
     (escape_message binder context)
@@ -458,7 +476,8 @@ let rec analyze ?(result_is_immediately_eliminated = false) (env : env) ~(contex
       match free_alias capture_env body with
       | Some (binder, occurrence) ->
           reject ~code:"E0817" ~meta:(diagnostic_meta env expr.meta)
-            ~hint:"pass the once resumption as a Resume-typed parameter instead of capturing it"
+            ~next_step:
+              "Pass the once resumption as a Resume-typed parameter instead of capturing it."
             (Printf.sprintf
                "once resumption `%s` escapes into a closure captured here (free use at %s)" binder
                (span_text_in env occurrence))
@@ -473,7 +492,7 @@ let rec analyze ?(result_is_immediately_eliminated = false) (env : env) ~(contex
             && not (env.state.defer_out_of_range_transfer && List.length args <> 1)
           then
             reject ~code:"E0817" ~meta:(diagnostic_meta env expr.meta)
-              ~hint:
+              ~next_step:
                 "immediately apply the resumption result exactly once as the function child of a \
                  nested application whose arguments are syntactic values"
               (Printf.sprintf
@@ -559,7 +578,7 @@ let rec analyze ?(result_is_immediately_eliminated = false) (env : env) ~(contex
       | None -> Ok zero
       | Some (binder, occurrence) ->
           reject ~code:"E0817" ~meta:(diagnostic_meta env expr.meta)
-            ~hint:"a once resumption cannot cross a quote boundary"
+            ~next_step:"Keep the once resumption outside quoted code."
             (Printf.sprintf
                "once resumption `%s` escapes into quoted code captured here (splice at %s)" binder
                (span_text_in env occurrence)))
@@ -615,7 +634,7 @@ and check_clause_capture env meta bound clause_body =
   | None -> Ok ()
   | Some (binder, occurrence) ->
       reject ~code:"E0817" ~meta:(diagnostic_meta env meta)
-        ~hint:"do not capture an outer once resumption in a nested handler clause"
+        ~next_step:"Do not capture an outer once resumption in a nested handler clause."
         (Printf.sprintf
            "once resumption `%s` escapes into a nested handler clause captured here (free use at \
             %s)"
@@ -636,7 +655,8 @@ and check_transfer callable index ~binder ~transfer_meta =
   match List.nth_opt callable.params index with
   | Some _ when callable.recursive ->
       reject ~code:"E0817" ~meta:transfer_meta
-        ~hint:"move the resumption only to a non-recursive local helper with a visibly affine body"
+        ~next_step:
+          "Move the resumption only to a non-recursive local helper with a visibly affine body."
         (Printf.sprintf
            "once resumption `%s` cannot be transferred to a recursive parameter because its call \
             count is not locally bounded"
@@ -686,15 +706,16 @@ and check_transfer callable index ~binder ~transfer_meta =
                anchored at this author-visible transfer, while its message may identify a durable
                logical helper occurrence. E0816 deliberately keeps its two distinct normalized
                helper witnesses. *)
-          if diagnostic.Diag.code = "E0817" then
-            Error { diagnostic with Diag.span = Meta.span transfer_meta }
+          if Diag.code diagnostic = Some "E0817" then
+            Error (Diag.with_span (Meta.span transfer_meta) diagnostic)
           else Error diagnostic
       | Error diagnostic -> Error diagnostic)
   | Some parameter ->
       let meta =
         match callable.diagnostic_source with Some _ -> transfer_meta | None -> parameter.meta
       in
-      reject ~code:"E0817" ~meta ~hint:"bind the transferred resumption to one variable or `_`"
+      reject ~code:"E0817" ~meta
+        ~next_step:"Bind the transferred resumption to one variable or `_`."
         (Printf.sprintf
            "once resumption `%s` cannot be transferred through a destructuring parameter" binder)
   | None ->

--- a/src/audit_chain.ml
+++ b/src/audit_chain.ml
@@ -12,7 +12,34 @@ type record = { previous : Hash.t; digest : Hash.t; entry : Form.t }
 
 let domain = "jacquard-audit-chain-v2\000"
 let genesis = Hash.of_string "jacquard-audit-chain-v2-genesis\000"
-let error ~code fmt = Printf.ksprintf (fun message -> Error [ Diag.error ~code message ]) fmt
+
+let diagnostic_summary = function
+  | "E1301" -> "The Audit chain carrier is malformed or noncanonical."
+  | "E1302" -> "The Audit entry or chain version is unsupported."
+  | "E1303" -> "An Audit record has the wrong predecessor."
+  | "E1304" -> "An Audit record digest does not match its contents."
+  | "E1305" -> "The reconstructed Audit head differs from the published head."
+  | "E1306" -> "The Audit chain could not be read or updated safely."
+  | "E1307" -> "The supplied Audit head is malformed."
+  | "E1308" -> "The Audit entry sequence is not contiguous."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown Audit diagnostic code " ^ code))
+
+let diagnostic_next_step = function
+  | "E1301" -> "Regenerate the chain using the canonical audit-chain-v2 writer."
+  | "E1302" -> "Supply released audit-entry-v2 records inside an audit-chain-v2 carrier."
+  | "E1303" -> "Restore the records to their original predecessor-linked order."
+  | "E1304" -> "Restore the original record or append a new canonical record instead of editing it."
+  | "E1305" -> "Verify against the independently published head for this exact chain."
+  | "E1306" -> "Make the chain a stable readable regular file and retry the operation."
+  | "E1307" -> "Pass exactly 64 lowercase hexadecimal digits as the published head."
+  | "E1308" -> "Renumber entries as one non-negative contiguous sequence starting at zero."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown Audit diagnostic code " ^ code))
+
+let diagnostic ~code cause =
+  Diag.error ~domain:Audit ~code ~summary:(diagnostic_summary code) ~cause
+    ~next_step:(diagnostic_next_step code) ~contrast:None ()
+
+let error ~code fmt = Printf.ksprintf (fun cause -> Error [ diagnostic ~code cause ]) fmt
 let form0 names = function { Form.head; args = []; _ } -> List.mem head names | _ -> false
 let hash_form = function { Form.head = "hash"; args = [ Form.Hash _ ]; _ } -> true | _ -> false
 let lit_text = function { Form.head = "lit"; args = [ Form.Text _ ]; _ } -> true | _ -> false
@@ -189,7 +216,7 @@ let parse_record ~file ~line_number line =
   | Error diagnostics ->
       let detail =
         match diagnostics with
-        | diagnostic :: _ -> diagnostic.Diag.message
+        | diagnostic :: _ -> Diag.cause diagnostic
         | [] -> "unknown reader failure"
       in
       error ~code:"E1301" "%s:%d: malformed Audit chain record: %s" file line_number detail
@@ -242,11 +269,9 @@ let verify_string ~file ~expected_head source =
                     Error
                       (List.map
                          (fun diagnostic ->
-                           {
-                             diagnostic with
-                             Diag.message =
-                               Printf.sprintf "%s:%d: %s" file line_number diagnostic.Diag.message;
-                           })
+                           Diag.with_cause
+                             (Printf.sprintf "%s:%d: %s" file line_number (Diag.cause diagnostic))
+                             diagnostic)
                          diagnostics)
                 | Ok computed when not (Hash.equal computed record.digest) ->
                     error ~code:"E1304"
@@ -371,8 +396,8 @@ let append_file ~file ~previous entry =
                           Error
                             (Append_verify
                                [
-                                 Diag.error ~code:"E1308"
-                                   (Printf.sprintf "Audit sequence mismatch: expected %d"
+                                 diagnostic ~code:"E1308"
+                                   (Printf.sprintf "Audit sequence mismatch: expected %d."
                                       next_sequence);
                                ])
                         else

--- a/src/canon.ml
+++ b/src/canon.ml
@@ -37,9 +37,41 @@
 (* Internal control flow only; never escapes this module. *)
 exception Err of Diag.t
 
+let diagnostic_spec = function
+  | "E0201" ->
+      ( Diag.Kernel,
+        "A value failed kernel validation before hashing.",
+        "Validate the kernel form successfully before canonicalization." )
+  | "E0501" ->
+      ( Diag.Canonicalization,
+        "An unresolved reference reached canonicalization.",
+        "Resolve every global reference before hashing the form." )
+  | "E0502" ->
+      ( Diag.Canonicalization,
+        "An unbound local reached canonicalization.",
+        "Bind or resolve the variable before hashing the form." )
+  | "E0503" ->
+      ( Diag.Canonicalization,
+        "A group reference is outside its valid definition group.",
+        "Keep every group reference inside its group and within the member range." )
+  | "E0504" ->
+      ( Diag.Canonicalization,
+        "A malformed unquote reached canonicalization.",
+        "Validate quote and unquote structure before hashing the form." )
+  | "E0505" ->
+      ( Diag.Canonicalization,
+        "A recursive definition group is too symmetric to order canonically.",
+        "Differentiate the recursive members structurally before hashing the group." )
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown canonicalization code " ^ code))
+
 let err ?meta ~code fmt =
   Printf.ksprintf
-    (fun msg -> raise (Err (Diag.error ?span:(Option.bind meta Meta.span) ~code msg)))
+    (fun cause ->
+      let domain, summary, next_step = diagnostic_spec code in
+      raise
+        (Err
+           (Diag.error ?span:(Option.bind meta Meta.span) ~domain ~code ~summary ~cause ~next_step
+              ~contrast:None ())))
     fmt
 
 (* --- primitive encoders (spec/serialization.md) --- *)

--- a/src/channel_handle.ml
+++ b/src/channel_handle.ml
@@ -2,10 +2,13 @@ type run = Concurrency_owner.t
 type t = { run : run; id : Channel_contract.channel_id }
 
 let diagnostic detail =
-  Diag.error ~code:Concurrency_contract.task_escape_code
-    ~hint:"use the channel only inside the exact async.scope and evaluator run that opened it"
-    ("a ChannelHandle may not escape, outlive, or be used outside the structured scope that opened \
-      it: " ^ detail)
+  Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code
+    ~summary:"This channel handle is outside its structured scope."
+    ~cause:
+      ("A ChannelHandle may not escape, outlive, or be used outside the structured scope that "
+     ^ "opened it: " ^ detail)
+    ~next_step:"Use the channel only inside the exact async.scope and evaluator run that opened it."
+    ~contrast:None ()
 
 let create ~run ~id = { run; id }
 

--- a/src/check.ml
+++ b/src/check.ml
@@ -91,9 +91,61 @@ let empty_env = { vars = SMap.empty; restricted = SSet.empty; group = [||] }
 (* Internal control flow only; never escapes this module. *)
 exception Err of Diag.t
 
-let err ?meta ?hint ~code fmt =
+let diagnostic_summary = function
+  | "E0801" -> "Types do not agree"
+  | "E0802" -> "This value is not callable"
+  | "E0803" -> "Call arity does not agree"
+  | "E0804" -> "The value does not satisfy its annotation"
+  | "E0805" -> "A referenced declaration has the wrong kind or is unavailable"
+  | "E0806" -> "Constructor pattern arity does not agree"
+  | "E0807" -> "A computation was used where a thunk is required"
+  | "E0810" -> "Type constructor arity does not agree"
+  | "E0811" -> "A type, effect, or row name is unresolved"
+  | "E0812" -> "An effect operation signature contains an unbound variable"
+  | "E0813" -> "This match is not exhaustive"
+  | "E0814" -> "The program requires an effect that was not granted"
+  | "E0815" -> "A top-level definition performs effects"
+  | "E0816" -> "A once resumption may be consumed more than once"
+  | "E0817" -> "A once resumption escapes its handler clause"
+  | "E0818" -> "A non-value binding cannot be reused polymorphically"
+  | "E0819" -> "An opaque Secret was used by generic inspection"
+  | "E0907" -> "A scoped task or channel handle is invalid"
+  | code -> "Checker rejected the program (" ^ code ^ ")"
+
+let diagnostic_next_step = function
+  | "E0801" -> "Make the actual type agree with the type required by its context."
+  | "E0802" -> "Call only a function, constructor, effect operation, or resumption."
+  | "E0803" -> "Pass exactly the number of arguments declared by the callable."
+  | "E0804" -> "Change the value or its annotation so the two types agree."
+  | "E0805" -> "Use an available declaration of the required kind."
+  | "E0806" -> "Match every field declared by the constructor."
+  | "E0807" -> "Wrap the computation in `fn () -> ...` to delay it."
+  | "E0810" -> "Apply the type constructor to exactly its declared parameters."
+  | "E0811" -> "Declare or resolve this name before using it."
+  | "E0812" -> "Bind the variable in the effect declaration's parameter list."
+  | "E0813" -> "Add a clause for the missing witness or a wildcard default."
+  | "E0814" -> "Grant the effect at the root or handle it inside the program."
+  | "E0815" -> "Move the effect behind a function or handle it in the definition."
+  | "E0816" -> "Consume the once resumption on at most one possible path."
+  | "E0817" -> "Consume the once resumption directly inside its handler clause."
+  | "E0818" -> "Eta-expand the binding or give each use its own binding."
+  | "E0819" -> "Keep the value opaque or expose it explicitly with `secret.expose`."
+  | "E0907" -> "Use the handle only inside the exact async.scope that created it."
+  | _ -> "Correct the rejected checker input and try again."
+
+let err ?meta ?next_step ?(contrast = None) ~code fmt =
   Printf.ksprintf
-    (fun msg -> raise (Err (Diag.error ?span:(Option.bind meta Meta.span) ?hint ~code msg)))
+    (fun cause ->
+      let domain =
+        if String.equal code Concurrency_contract.task_escape_code then Diag.Concurrency
+        else Diag.Checker
+      in
+      raise
+        (Err
+           (Diag.error ?span:(Option.bind meta Meta.span) ~domain ~code
+              ~summary:(diagnostic_summary code) ~cause
+              ~next_step:(Option.value next_step ~default:(diagnostic_next_step code))
+              ~contrast ())))
     fmt
 
 (* Stored declarations have already crossed the public resolver/checker boundary. Their resolved
@@ -160,12 +212,12 @@ let eta_expansion_candidate ctx expected actual =
       Types.unifiable expected (TArrow ([], open_row ctx.level [], actual))
   | _ -> false
 
-let unify_or ctx ?meta ?hint ~what expected actual =
+let unify_or ctx ?meta ?next_step ~what expected actual =
   try Types.unify expected actual
   with Unify_error detail ->
     err ?meta
-      ~hint:
-        (Option.value hint
+      ~next_step:
+        (Option.value next_step
            ~default:"the expected side comes from the surrounding context; make both sides agree")
       ~code:"E0801" "%s: expected %s, got %s (%s)" what (show_ty ctx expected) (show_ty ctx actual)
       detail
@@ -174,7 +226,7 @@ let unify_join_or ctx ?meta ~what expected actual =
   try Types.join_into ~level:ctx.level expected actual
   with Unify_error detail ->
     err ?meta
-      ~hint:"the expected side comes from the surrounding context; make both sides agree"
+      ~next_step:"the expected side comes from the surrounding context; make both sides agree"
       ~code:"E0801" "%s: expected %s, got %s (%s)" what (show_ty ctx expected) (show_ty ctx actual)
       detail
 
@@ -189,7 +241,7 @@ let type_arity ctx ?meta (h : Hash.t) : int =
   | Ok { Store.decl = { Kernel.it = Kernel.DefType { tvars; _ }; _ }; role = Store.Whole; _ } ->
       List.length tvars
   | Ok _ -> err ?meta ~code:"E0805" "hash %s is not a type" (Hash.to_hex h)
-  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds))
+  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds))
 
 (* ------------------------------------------------------------------ *)
 (* Annotation conversion                                               *)
@@ -278,7 +330,7 @@ and conv_row ctx cenv ~effectself (r : Kernel.row) : row =
 let rec con_scheme ctx ?meta (h : Hash.t) : scheme =
   if Concurrency_contract.is_task_private_hash h || Channel_contract.is_channel_private_hash h then
     err ?meta ~code:Concurrency_contract.task_escape_code
-      ~hint:"opaque scoped handles are created only by their trusted scheduler operations"
+      ~next_step:"Use the trusted scheduler operation that creates this opaque scoped handle."
       "the opaque scoped-handle carrier is scheduler-private and cannot be constructed by Jacquard \
        code";
   match locate ctx h with
@@ -301,7 +353,7 @@ let rec con_scheme ctx ?meta (h : Hash.t) : scheme =
       let ty = match fields with [] -> result | fields -> TArrow (fields, empty_row, result) in
       { ty; gen_level = ctx.level }
   | Ok _ -> err ?meta ~code:"E0805" "hash %s is not a constructor" (Hash.to_hex h)
-  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds))
+  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds))
 
 (* Does a declaration type mention [name] as a (tref name)? Drives the self-in-argument
    case below without disturbing free-variable freshening elsewhere. *)
@@ -327,7 +379,7 @@ and conv_decl_ty ctx cenv ?(unbound_code = "E0811") ?(effectself = None) ~self (
       match List.assoc_opt a cenv.tvs with
       | Some v -> v
       | None ->
-          err ~meta ~hint:"declare it in the parameter list of the enclosing declaration"
+          err ~meta ~next_step:"Declare it in the parameter list of the enclosing declaration."
             ~code:unbound_code "unbound type variable `%s` in declaration" a)
   | Kernel.TApp ({ Kernel.it = Kernel.TRef (Kernel.Named n); _ }, args) when n = self_name -> (
       (* recursive application must match the declared parameters *)
@@ -455,7 +507,7 @@ let op_scheme ctx ?meta (h : Hash.t) : scheme =
       in
       { ty = TArrow (params, operation_row, result); gen_level = ctx.level }
   | Ok _ -> err ?meta ~code:"E0805" "hash %s is not an operation" (Hash.to_hex h)
-  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds))
+  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds))
 
 (** [operation_mode ctx h] returns the identity-bearing multiplicity declared for operation [h]. It
     reports E0805 if [h] does not locate an operation, so callers never silently treat malformed
@@ -466,7 +518,7 @@ let operation_mode ctx ?meta (h : Hash.t) : Kernel.op_mode =
     ->
       (List.nth ops i).Kernel.op_mode
   | Ok _ -> err ?meta ~code:"E0805" "hash %s is not an operation" (Hash.to_hex h)
-  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds))
+  | Error ds -> err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds))
 
 (** [contains_group_ref expression] reports whether [expression] can recur through its definition
     group. The affine-resumption checker uses it to reject transfers into helpers whose number of
@@ -601,7 +653,7 @@ let rec infer_pat ctx (p : Kernel.pat) : ty * (string * ty) list =
       match (repr con_ty, ps) with
       | TArrow (fields, _, result), ps ->
           if List.length fields <> List.length ps then
-            err ~meta ~hint:"constructor patterns bind every declared field" ~code:"E0806"
+            err ~meta ~next_step:"Bind every field declared by the constructor." ~code:"E0806"
               "constructor %s expects %d argument(s) in this pattern, got %d" (name_of ctx h)
               (List.length fields) (List.length ps);
           let bindings =
@@ -675,7 +727,7 @@ let rec term_scheme ctx ?meta (h : Hash.t) : scheme =
           match Store.locate ctx.store h with
           | Ok _ -> ()
           | Error ds ->
-              err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds))
+              err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds))
       in
       match Hashtbl.find_opt ctx.builtin_sigs h with
       | Some s -> s
@@ -692,7 +744,7 @@ let rec term_scheme ctx ?meta (h : Hash.t) : scheme =
               end
           | Ok _ -> err ?meta ~code:"E0805" "hash %s is not a term" (Hash.to_hex h)
           | Error ds ->
-              err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds))))
+              err ?meta ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds))))
 
 and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(required : Hash.t list)
     (e : Kernel.expr) : ty =
@@ -751,7 +803,7 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
       match repr fn_ty with
       | TArrow (params, frow, result) ->
           if List.length params <> List.length args then
-            err ~meta ~hint:"Jacquard calls are uncurried: pass exactly the declared arguments"
+            err ~meta ~next_step:"Pass exactly the declared arguments in this uncurried call."
               ~code:"E0803" "this function expects %d argument(s), got %d" (List.length params)
               (List.length args);
           (let kind =
@@ -783,7 +835,7 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
                    || Option.equal String.equal (Meta.name fn.meta) (Some "debug.inspect"))
               then
                 err ~meta:diagnostic_meta ~code:"E0819"
-                  ~hint:
+                  ~next_step:
                     "keep the value opaque; only `secret.expose` converts Secret to Text, and that \
                      operation remains in the Secret effect row"
                   "Secret has no Show or serialization instance and generic inspection is redacted";
@@ -792,20 +844,21 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
                 match restricted_callee with
                 | Some name ->
                     err ~meta:fn.meta ~code:"E0818"
-                      ~hint:
+                      ~next_step:
                         "eta-expand the binding to a lambda value, or give each use its own binding"
                       "local binding `%s` comes from a non-value and remains monomorphic under the \
                        value restriction"
                       name
                 | None when eta ->
                     err ~meta:arg.meta ~code:"E0807"
-                      ~hint:"wrap the reference in `fn () -> ...` so the computation is delayed"
+                      ~next_step:
+                        "Wrap the reference in `fn () -> ...` so the computation is delayed."
                       "this position expects a thunk, but `%s` is a bare reference; wrap it in `fn \
                        () -> ...`"
                       (Option.value ~default:"this value" (Meta.name arg.meta))
                 | None ->
                     err ~meta:diagnostic_meta
-                      ~hint:
+                      ~next_step:
                         "the expected side comes from the surrounding context; make both sides \
                          agree"
                       ~code:"E0801" "%s: expected %s, got %s (%s)" what (show_ty ctx expected)
@@ -829,7 +882,7 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
           result
       | TResume (param, frow, result) ->
           if List.length args <> 1 then
-            err ~meta ~hint:"a resumption accepts exactly the operation's result value"
+            err ~meta ~next_step:"Pass exactly the operation's result value to the resumption."
               ~code:"E0803" "this resumption expects 1 argument, got %d" (List.length args);
           ctx.tier_apps <- (frow, Tier.KFn) :: ctx.tier_apps;
           let arg = List.hd args and actual = List.hd arg_tys in
@@ -854,10 +907,11 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
       | t ->
           if surface_form_is meta [ "pipe" ] then
             let rhs_meta = Meta.surface_container "pipe-rhs" meta in
-            err ~meta:rhs_meta ~hint:"the right-hand side of `|>` must be callable" ~code:"E0802"
+            err ~meta:rhs_meta ~next_step:"Make the right-hand side of `|>` callable." ~code:"E0802"
               "the `|>` right-hand side has type %s, which is not a function" (show_ty ctx t)
           else
-            err ~meta ~hint:"only functions, constructors, effect operations, and resumptions apply"
+            err ~meta
+              ~next_step:"Apply only a function, constructor, effect operation, or resumption."
               ~code:"E0802" "%s is not a function" (show_ty ctx t))
   | Kernel.Let { isrec = false; binder; value; body } -> (
       match binder.Kernel.it with
@@ -1069,7 +1123,7 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
       (try Types.unify expected actual
        with Unify_error detail ->
          err ~meta
-           ~hint:
+           ~next_step:
              (Option.value
                 ~default:"the annotation is the contract: change the body or the annotation"
                 (handler_mismatch_hint subject detail))
@@ -1133,7 +1187,8 @@ and check_group ?recovery_group ctx (decl : Kernel.decl) : unit =
         | None -> (
             match Canon.hash_decl decl with
             | Ok { Canon.decl_hash; named } -> (decl_hash, List.map snd named)
-            | Error ds -> err ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_string ds)))
+            | Error ds ->
+                err ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string ds)))
       in
       let decl_hash, member_hashes = hashes in
       ctx.checking <- decl_hash :: ctx.checking;
@@ -1167,7 +1222,7 @@ and check_group ?recovery_group ctx (decl : Kernel.decl) : unit =
               | [] -> ()
               | h :: _ ->
                   err ~meta:b.Kernel.bmeta ~code:"E0815"
-                    ~hint:"wrap the body in a lambda and perform the effect when called"
+                    ~next_step:"Wrap the body in a lambda and perform the effect when called."
                     "top-level definition `%s` performs the `%s` effect while being defined"
                     b.Kernel.bname (name_of ctx h));
               match b.Kernel.annot with
@@ -1179,12 +1234,12 @@ and check_group ?recovery_group ctx (decl : Kernel.decl) : unit =
                   with Unify_error detail ->
                     let hint = handler_mismatch_hint b.Kernel.value detail in
                     if surface_form_is b.Kernel.bmeta [ "equation-definition" ] then
-                      err ?hint ~meta:b.Kernel.value.meta ~code:"E0804"
+                      err ?next_step:hint ~meta:b.Kernel.value.meta ~code:"E0804"
                         "equation definition `%s` does not match its signature: expected %s, got \
                          %s (%s)"
                         b.Kernel.bname (show_ty ctx rigid) (show_ty ctx vty) detail
                     else
-                      err ?hint ~meta:b.Kernel.bmeta ~code:"E0804"
+                      err ?next_step:hint ~meta:b.Kernel.bmeta ~code:"E0804"
                         "binding %s does not match its annotation: expected %s, got %s (%s)"
                         b.Kernel.bname (show_ty ctx rigid) (show_ty ctx vty) detail)
               | None ->
@@ -1362,10 +1417,10 @@ let rec check_matches ctx : Diag.t list =
       let matrix = List.map (fun (c : Kernel.clause) -> [ c.Kernel.cpat ]) arms in
       (match useful ctx [ scrutinee_ty ] matrix with
       | Some [ w ] ->
-          err ~meta:site_meta ~hint:"add a clause matching the witness, or a (pwild) default"
+          err ~meta:site_meta ~next_step:"Add a clause matching the witness or a wildcard default."
             ~code:"E0813" "this match is not exhaustive: it misses %s" (show_witness w)
       | Some _ ->
-          err ~meta:site_meta ~hint:"add a (pwild) default clause" ~code:"E0813"
+          err ~meta:site_meta ~next_step:"Add a wildcard default clause." ~code:"E0813"
             "this match is not exhaustive"
       | None -> ());
       (* redundancy: clause i is useless if rows 0..i-1 already cover its pattern *)
@@ -1388,8 +1443,11 @@ let rec check_matches ctx : Diag.t list =
             in
             if covers then
               warnings :=
-                Diag.warning ?span:(Meta.span c.Kernel.cmeta) ~code:"W0801"
-                  "this clause is redundant: earlier clauses match everything it does"
+                Diag.warning ?span:(Meta.span c.Kernel.cmeta) ~domain:Checker ~code:"W0801"
+                  ~summary:"This match clause is redundant"
+                  ~cause:"Earlier clauses match every value this clause can match."
+                  ~next_step:"Remove the redundant clause or narrow an earlier pattern."
+                  ~contrast:None ()
                 :: !warnings)
         arms)
     (List.rev ctx.sites);
@@ -1526,7 +1584,15 @@ let make_ctx (store : Store.t) : (ctx, Diag.t list) result =
   let lookup name =
     match Store.lookup_kind store name Resolve.KType with
     | Some { Resolve.hash; _ } -> Ok hash
-    | None -> Error [ Diag.error ~code:"E0805" (Printf.sprintf "primitive type `%s` missing" name) ]
+    | None ->
+        Error
+          [
+            Diag.error ~domain:Checker ~code:"E0805"
+              ~summary:"A required primitive type is unavailable"
+              ~cause:(Printf.sprintf "Primitive type `%s` is missing from the store." name)
+              ~next_step:"Load the complete prelude before creating the checker context."
+              ~contrast:None ();
+          ]
   in
   match
     (lookup "int", lookup "real", lookup "text", lookup "code", lookup "hash", lookup "secret")
@@ -1779,8 +1845,11 @@ let manifest_errors ctx ?(grantable = []) ~(granted : Hash.t list) (row : row) :
                --allow grant)"
         in
         Some
-          (Diag.error ~code:"E0814" ~hint
-             (Printf.sprintf "this program requires %s, which is not granted%s" requirement via)))
+          (Diag.error ~domain:Checker ~code:"E0814"
+             ~summary:"The program requires an effect that was not granted"
+             ~cause:
+               (Printf.sprintf "This program requires %s, which is not granted%s." requirement via)
+             ~next_step:hint ~contrast:None ()))
     row.effects
 
 (** Registry of every diagnostic code the checker can emit (W3.7's coverage check keys on this list;

--- a/src/cli_entry.ml
+++ b/src/cli_entry.ml
@@ -9,15 +9,24 @@ let backtrace_lines exception_value backtrace =
   if String.equal rendered "" then Printexc.to_string exception_value
   else Printexc.to_string exception_value ^ "\n" ^ rendered
 
-(** [run ~program ~err evaluate] evaluates the CLI with Cmdliner's exception capture disabled so a
-    missed structural [Stack_overflow] is classified as E0003. Other uncaught exceptions retain the
-    conventional Cmdliner-style report and internal-error exit status 125. *)
-let run ~program ?(err = Format.err_formatter) evaluate =
+(** [run ~program ~err ~render_diagnostic evaluate] evaluates the CLI with Cmdliner's exception
+    capture disabled so a missed structural [Stack_overflow] is classified as E0003. The supplied
+    renderer lets the process boundary honor the selected diagnostic format. Other uncaught
+    exceptions retain the conventional Cmdliner-style report and internal-error exit status 125. *)
+let run ~program ?(err = Format.err_formatter) ?(render_diagnostic = Diag.to_string) evaluate =
   match evaluate () with
   | status -> status
   | exception Stack_overflow ->
-      Format.fprintf err
-        "error[E0003]: input exhausted the host stack before a structural nesting guard@.";
+      let diagnostic =
+        Diag.error ~domain:Process ~code:"E0003"
+          ~summary:"Input exhausted the host stack before a structural nesting guard"
+          ~cause:
+            "An unbounded internal traversal reached the host stack limit before Jacquard could \
+             report its local depth boundary."
+          ~next_step:"Reduce the input nesting and report the missing structural guard."
+          ~contrast:None ()
+      in
+      Format.fprintf err "%s@." (render_diagnostic diagnostic);
       diagnostic_error
   | exception exception_value ->
       let backtrace = Printexc.get_raw_backtrace () in

--- a/src/diag.ml
+++ b/src/diag.ml
@@ -1,40 +1,328 @@
-(** Diagnostics carried by every fallible library function.
+(** Structured diagnostics carried by every fallible library function.
 
     Library code returns [('a, Diag.t list) result]; exceptions are reserved for internal invariant
-    violations and are prefixed [Bug_]. Codes are short stable strings like ["E0001"] (errors) or
-    ["W0001"] (warnings) that tests and docs key on; once released a code is never reused or
-    renumbered. *)
+    violations and are prefixed [Bug_]. A diagnostic keeps its human explanation as typed fields so
+    text and machine renderers cannot disagree about their meaning or order. *)
 
 type severity = Error | Warning | Info
 
+type domain =
+  | Process
+  | Reader
+  | Kernel
+  | Resolution
+  | Canonicalization
+  | Store
+  | Prelude
+  | Checker
+  | Runtime
+  | Inference
+  | Warp
+  | Surface
+  | Native
+  | Export
+  | Audit
+  | Governance
+  | Concurrency
+  | Cli
+
+type contrast = { mistaken : string; intended : string }
+
 type t = {
+  domain : domain;
   severity : severity;
   span : Span.t option;
-  code : string;  (** stable identifier, e.g. ["E0001"] *)
-  message : string;
-  hint : string option;
+  code : string option;
+  summary : string;
+  cause : string;
+  next_step : string;
+  contrast : contrast option;
 }
 
-(** [make ~severity ~code msg] builds a diagnostic; [span] and [hint] are optional. Never fails. *)
-let make ?span ?hint ~severity ~code message = { severity; span; code; message; hint }
+exception Bug_invalid_diagnostic of string
 
-(** [error ~code msg] is [make ~severity:Error]. *)
-let error ?span ?hint ~code message = make ?span ?hint ~severity:Error ~code message
+let contains_newline value = String.contains value '\n' || String.contains value '\r'
 
-(** [warning ~code msg] is [make ~severity:Warning]. *)
-let warning ?span ?hint ~code message = make ?span ?hint ~severity:Warning ~code message
+let require_nonempty field value =
+  if String.trim value = "" then
+    raise (Bug_invalid_diagnostic (Printf.sprintf "%s must not be empty" field))
 
-(** [info ~code msg] is [make ~severity:Info]. *)
-let info ?span ?hint ~code message = make ?span ?hint ~severity:Info ~code message
+let require_single_line field value =
+  require_nonempty field value;
+  if contains_newline value then
+    raise (Bug_invalid_diagnostic (Printf.sprintf "%s must be a single line" field))
+
+let valid_code code =
+  String.length code = 5
+  && (code.[0] = 'E' || code.[0] = 'W' || code.[0] = 'I')
+  &&
+  let rec digits index =
+    index = String.length code
+    ||
+    let char = code.[index] in
+    char >= '0' && char <= '9' && digits (index + 1)
+  in
+  digits 1
+
+let expected_code_prefix = function Error -> 'E' | Warning -> 'W' | Info -> 'I'
+
+let validate_span = function
+  | None -> ()
+  | Some ({ Span.file; start_pos; end_pos } : Span.t) ->
+      if String.equal file "" then
+        raise (Bug_invalid_diagnostic "diagnostic span file must not be empty");
+      let end_precedes_start =
+        end_pos.line < start_pos.line
+        || (end_pos.line = start_pos.line && end_pos.col < start_pos.col)
+      in
+      if
+        start_pos.line < 1 || start_pos.col < 1 || start_pos.offset < 0 || end_pos.line < 1
+        || end_pos.col < 1 || end_pos.offset < start_pos.offset || end_precedes_start
+      then
+        raise
+          (Bug_invalid_diagnostic
+             "diagnostic spans require one-based lines/columns, nonnegative offsets, and an \
+              exclusive end at or after the start")
+
+let validate_code ~domain ~severity = function
+  | None ->
+      if domain <> Runtime || severity <> Error then
+        raise
+          (Bug_invalid_diagnostic "only historical runtime errors may emit a code-less diagnostic")
+  | Some code ->
+      if not (valid_code code) then
+        raise
+          (Bug_invalid_diagnostic
+             (Printf.sprintf "diagnostic code %S must match [EWI][0-9]{4}" code));
+      let expected = expected_code_prefix severity in
+      if code.[0] <> expected then
+        raise
+          (Bug_invalid_diagnostic
+             (Printf.sprintf "diagnostic code %S does not match %s severity" code
+                (match severity with Error -> "error" | Warning -> "warning" | Info -> "info")))
+
+(** [contrast ~mistaken ~intended] records one locally plausible confusion. Both descriptions are
+    required single lines; generic advice belongs in [next_step], not here. *)
+let contrast ~mistaken ~intended =
+  require_single_line "contrast mistaken form" mistaken;
+  require_single_line "contrast intended form" intended;
+  { mistaken; intended }
+
+(** [make] is the canonical constructor. Summary and next step are deliberately single-line fields;
+    a technical cause may span lines and is indented safely by the text renderer. Historically
+    code-less runtime failures use [code = None] rather than receiving invented identities. *)
+let make ?span ?code ~domain ~severity ~summary ~cause ~next_step ~contrast () =
+  validate_code ~domain ~severity code;
+  validate_span span;
+  require_single_line "diagnostic summary" summary;
+  require_nonempty "diagnostic cause" cause;
+  require_single_line "diagnostic next step" next_step;
+  Option.iter
+    (fun value ->
+      require_single_line "contrast mistaken form" value.mistaken;
+      require_single_line "contrast intended form" value.intended)
+    contrast;
+  { domain; severity; span; code; summary; cause; next_step; contrast }
+
+(** [error] builds an error diagnostic under the same validation contract as {!make}. *)
+let error ?span ?code ~domain ~summary ~cause ~next_step ~contrast () =
+  make ?span ?code ~domain ~severity:Error ~summary ~cause ~next_step ~contrast ()
+
+(** [warning] builds a warning diagnostic under the same validation contract as {!make}. *)
+let warning ?span ?code ~domain ~summary ~cause ~next_step ~contrast () =
+  make ?span ?code ~domain ~severity:Warning ~summary ~cause ~next_step ~contrast ()
+
+(** [info] builds an informational diagnostic under the same validation contract as {!make}. *)
+let info ?span ?code ~domain ~summary ~cause ~next_step ~contrast () =
+  make ?span ?code ~domain ~severity:Info ~summary ~cause ~next_step ~contrast ()
+
+let domain t = t.domain
+let severity t = t.severity
+let span t = t.span
+let code t = t.code
+let code_or_uncoded t = Option.value ~default:"uncoded" t.code
+let summary t = t.summary
+let cause t = t.cause
+let next_step t = t.next_step
+let contrastive_hint t = t.contrast
+let mistaken value = value.mistaken
+let intended value = value.intended
+
+let with_span span t =
+  validate_span span;
+  { t with span }
+
+let with_cause cause t =
+  require_nonempty "diagnostic cause" cause;
+  { t with cause }
 
 (** Lowercase severity keyword as rendered in output: ["error"], ["warning"], ["info"]. *)
 let severity_to_string = function Error -> "error" | Warning -> "warning" | Info -> "info"
 
-(** One-line rendering: [FILE:SPAN: severity[CODE]: message], with an indented hint line when a hint
-    is present. The exact shape is golden-tested; change it deliberately. *)
-let to_string { severity; span; code; message; hint } =
-  let where = match span with Some s -> Span.to_string s ^ ": " | None -> "" in
-  let hint = match hint with Some h -> "\n  hint: " ^ h | None -> "" in
-  Printf.sprintf "%s%s[%s]: %s%s" where (severity_to_string severity) code message hint
+let domain_to_string = function
+  | Process -> "process"
+  | Reader -> "reader"
+  | Kernel -> "kernel"
+  | Resolution -> "resolution"
+  | Canonicalization -> "canonicalization"
+  | Store -> "store"
+  | Prelude -> "prelude"
+  | Checker -> "checker"
+  | Runtime -> "runtime"
+  | Inference -> "inference"
+  | Warp -> "warp"
+  | Surface -> "surface"
+  | Native -> "native"
+  | Export -> "export"
+  | Audit -> "audit"
+  | Governance -> "governance"
+  | Concurrency -> "concurrency"
+  | Cli -> "cli"
+
+(** [json_utf8 value] preserves well-formed UTF-8 byte-for-byte and replaces each malformed input
+    byte with U+FFFD. Diagnostic prose may contain arbitrary source, path, or host-error bytes, but
+    the JSON v1 wire format must always remain valid UTF-8. *)
+let json_utf8 value =
+  let length = String.length value in
+  let byte index = if index < length then Char.code value.[index] else -1 in
+  let continuation index = index < length && byte index land 0xc0 = 0x80 in
+  let width offset =
+    let first = byte offset in
+    if first < 0x80 then Some 1
+    else if first >= 0xc2 && first <= 0xdf && continuation (offset + 1) then Some 2
+    else if first >= 0xe0 && first <= 0xef then
+      let second = byte (offset + 1) in
+      let second_ok =
+        if first = 0xe0 then second >= 0xa0 && second <= 0xbf
+        else if first = 0xed then second >= 0x80 && second <= 0x9f
+        else second >= 0x80 && second <= 0xbf
+      in
+      if second_ok && continuation (offset + 2) then Some 3 else None
+    else if first >= 0xf0 && first <= 0xf4 then
+      let second = byte (offset + 1) in
+      let second_ok =
+        if first = 0xf0 then second >= 0x90 && second <= 0xbf
+        else if first = 0xf4 then second >= 0x80 && second <= 0x8f
+        else second >= 0x80 && second <= 0xbf
+      in
+      if second_ok && continuation (offset + 2) && continuation (offset + 3) then Some 4 else None
+    else None
+  in
+  let rec first_invalid offset =
+    if offset >= length then None
+    else match width offset with Some size -> first_invalid (offset + size) | None -> Some offset
+  in
+  match first_invalid 0 with
+  | None -> value
+  | Some invalid ->
+      let buffer = Buffer.create (length + 3) in
+      Buffer.add_substring buffer value 0 invalid;
+      let rec repair offset =
+        if offset < length then
+          match width offset with
+          | Some size ->
+              Buffer.add_substring buffer value offset size;
+              repair (offset + size)
+          | None ->
+              Buffer.add_string buffer "\xef\xbf\xbd";
+              repair (offset + 1)
+      in
+      repair invalid;
+      Buffer.contents buffer
+
+(** [to_cause_string diagnostic] is the loss-aware projection used when one structured diagnostic
+    explains another. It retains the child code, summary, and technical detail without importing a
+    second primary action or contrast into the wrapper. *)
+let to_cause_string diagnostic =
+  let identity =
+    match diagnostic.code with
+    | Some code -> Printf.sprintf "%s: %s" code diagnostic.summary
+    | None -> diagnostic.summary
+  in
+  Printf.sprintf "%s (%s)" identity diagnostic.cause
+
+let render_labeled label value =
+  match String.split_on_char '\n' value with
+  | [] -> assert false
+  | first :: rest ->
+      let continuation = String.make (String.length label + 4) ' ' in
+      String.concat "\n" (("  " ^ label ^ ": " ^ first) :: List.map (( ^ ) continuation) rest)
+
+(** Canonical human rendering in semantic reading order: optional span, summary, cause, exactly one
+    next step, then an applicable contrast. Spanless diagnostics begin at severity without a noisy
+    placeholder. *)
+let to_string t =
+  let where = match t.span with Some value -> Span.to_string value ^ ": " | None -> "" in
+  let identity =
+    match t.code with
+    | Some value -> Printf.sprintf "%s[%s]" (severity_to_string t.severity) value
+    | None -> severity_to_string t.severity
+  in
+  let lines =
+    [
+      Printf.sprintf "%s%s: %s" where identity t.summary;
+      render_labeled "Cause" t.cause;
+      render_labeled "Next step" t.next_step;
+    ]
+  in
+  let lines =
+    match t.contrast with
+    | None -> lines
+    | Some value ->
+        lines
+        @ [
+            render_labeled "Contrast"
+              (Printf.sprintf "mistaken: %s; intended: %s" value.mistaken value.intended);
+          ]
+  in
+  String.concat "\n" lines
+
+let position_to_yojson (position : Span.pos) =
+  `Assoc
+    [
+      ("line", `Int position.line); ("column", `Int position.col); ("offset", `Int position.offset);
+    ]
+
+let span_to_yojson (span : Span.t) =
+  `Assoc
+    [
+      ("file", `String (json_utf8 span.file));
+      ("start", position_to_yojson span.start_pos);
+      ("end", position_to_yojson span.end_pos);
+    ]
+
+(** [to_yojson] exposes exactly the canonical fields under the versioned JSON v1 contract. The
+    optional contrast key is absent when no specific nearby confusion applies. *)
+let to_yojson t =
+  let fields =
+    [
+      ("schema", `String "jacquard-diagnostic-v1");
+      ("domain", `String (domain_to_string t.domain));
+      ("code", Option.fold ~none:`Null ~some:(fun value -> `String (json_utf8 value)) t.code);
+      ("severity", `String (severity_to_string t.severity));
+      ("span", Option.fold ~none:`Null ~some:span_to_yojson t.span);
+      ("summary", `String (json_utf8 t.summary));
+      ("cause", `String (json_utf8 t.cause));
+      ("next_step", `String (json_utf8 t.next_step));
+    ]
+  in
+  let fields =
+    match t.contrast with
+    | None -> fields
+    | Some value ->
+        fields
+        @ [
+            ( "contrast",
+              `Assoc
+                [
+                  ("mistaken", `String (json_utf8 value.mistaken));
+                  ("intended", `String (json_utf8 value.intended));
+                ] );
+          ]
+  in
+  `Assoc fields
+
+(** One compact JSON object suitable for JSON Lines output. *)
+let to_json_string t = Yojson.Safe.to_string (to_yojson t)
 
 let pp fmt t = Format.pp_print_string fmt (to_string t)

--- a/src/diag.mli
+++ b/src/diag.mli
@@ -1,0 +1,128 @@
+(** Canonical structured diagnostics for the Jacquard library and command line. *)
+
+type severity = Error | Warning | Info
+
+type domain =
+  | Process
+  | Reader
+  | Kernel
+  | Resolution
+  | Canonicalization
+  | Store
+  | Prelude
+  | Checker
+  | Runtime
+  | Inference
+  | Warp
+  | Surface
+  | Native
+  | Export
+  | Audit
+  | Governance
+  | Concurrency
+  | Cli
+
+type contrast
+type t
+
+exception Bug_invalid_diagnostic of string
+
+val contrast : mistaken:string -> intended:string -> contrast
+(** Build one specific mistaken/intended comparison. Empty or multiline descriptions raise
+    {!Bug_invalid_diagnostic}. *)
+
+val make :
+  ?span:Span.t ->
+  ?code:string ->
+  domain:domain ->
+  severity:severity ->
+  summary:string ->
+  cause:string ->
+  next_step:string ->
+  contrast:contrast option ->
+  unit ->
+  t
+(** Canonical smart constructor. Summary and next step must be non-empty single lines; cause must be
+    non-empty; codes must match [[EWI][0-9]{4}] and agree with severity. Only historical runtime
+    failures may omit a code. Attached spans require a non-empty file, one-based lines and columns,
+    nonnegative offsets, and an exclusive end at or after the start. Contract violations raise
+    {!Bug_invalid_diagnostic}. *)
+
+val error :
+  ?span:Span.t ->
+  ?code:string ->
+  domain:domain ->
+  summary:string ->
+  cause:string ->
+  next_step:string ->
+  contrast:contrast option ->
+  unit ->
+  t
+
+val warning :
+  ?span:Span.t ->
+  ?code:string ->
+  domain:domain ->
+  summary:string ->
+  cause:string ->
+  next_step:string ->
+  contrast:contrast option ->
+  unit ->
+  t
+
+val info :
+  ?span:Span.t ->
+  ?code:string ->
+  domain:domain ->
+  summary:string ->
+  cause:string ->
+  next_step:string ->
+  contrast:contrast option ->
+  unit ->
+  t
+
+val domain : t -> domain
+val severity : t -> severity
+val span : t -> Span.t option
+val code : t -> string option
+
+val code_or_uncoded : t -> string
+(** [code_or_uncoded diagnostic] returns its stable code, or ["uncoded"] for the deliberately
+    code-less runtime boundary. It is intended for human display and test assertions; machine
+    consumers should use {!code} and preserve nullability. *)
+
+val summary : t -> string
+val cause : t -> string
+val next_step : t -> string
+val contrastive_hint : t -> contrast option
+val mistaken : contrast -> string
+val intended : contrast -> string
+
+val with_span : Span.t option -> t -> t
+(** [with_span span diagnostic] changes only the source anchor, for boundaries that deliberately
+    re-anchor a stored diagnostic at its author-visible use site. *)
+
+val with_cause : string -> t -> t
+(** [with_cause cause diagnostic] replaces only the technical cause after validating that it is
+    non-empty; wrappers use this to add transport context without flattening structured fields. *)
+
+val severity_to_string : severity -> string
+val domain_to_string : domain -> string
+
+val to_cause_string : t -> string
+(** Project a diagnostic into technical-cause prose for a structured wrapper. This preserves the
+    child code, summary, and cause, but deliberately excludes its next step and contrast so the
+    wrapper still owns exactly one primary action. *)
+
+val to_string : t -> string
+(** Render optional span/header, summary, cause, one next step, and optional contrast in that order.
+*)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Render the stable [jacquard-diagnostic-v1] machine structure. Well-formed UTF-8 is preserved
+    byte-for-byte; every malformed input byte in a string field is replaced with U+FFFD. *)
+
+val to_json_string : t -> string
+(** Render one compact, valid-UTF-8 JSON object suitable for JSON Lines output. *)
+
+val pp : Format.formatter -> t -> unit

--- a/src/dune
+++ b/src/dune
@@ -10,4 +10,4 @@
   Task_handle
   Channel_handle
   Schedule_control)
- (libraries digestif unix))
+ (libraries digestif unix yojson))

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -217,8 +217,12 @@ let with_scheduler_task_run _capability ctx ~run ~scope_path operation =
       ctx.task_scope_path <- previous_path)
     operation
 
-let task_message diagnostics =
-  String.concat "; " (List.map (fun diagnostic -> diagnostic.Diag.message) diagnostics)
+let task_message diagnostics = String.concat "; " (List.map Diag.cause diagnostics)
+
+let task_diagnostic ?(summary = "A scoped task or channel handle is invalid")
+    ?(next_step = "Use the handle only inside the exact async.scope that created it.") cause =
+  Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code ~summary ~cause
+    ~next_step ~contrast:None ()
 
 let foreign_evaluator_context kind =
   Runtime_err.Invalid_task_handle (Printf.sprintf "%s belongs to another evaluator run" kind)
@@ -230,8 +234,9 @@ let validate_task_value ctx ~scope_path = function
   | _ ->
       Error
         [
-          Diag.error ~code:Concurrency_contract.task_escape_code
-            "expected an opaque scheduler-owned Task handle";
+          task_diagnostic ~summary:"Task operation received an invalid handle"
+            ~next_step:"Pass the Task handle returned by async.spawn in this async.scope."
+            "The operation expected an opaque scheduler-owned Task handle.";
         ]
 
 (** Structural carrier validation only: live-channel membership remains scheduler-owned and every
@@ -241,8 +246,9 @@ let validate_channel_value ctx ~scope_path = function
   | _ ->
       Error
         [
-          Diag.error ~code:Concurrency_contract.task_escape_code
-            "expected an opaque scheduler-owned ChannelHandle";
+          task_diagnostic ~summary:"Channel operation received an invalid handle"
+            ~next_step:"Pass the ChannelHandle returned by channel.open in this async.scope."
+            "The operation expected an opaque scheduler-owned ChannelHandle.";
         ]
 
 let rec scope_prefix prefix path =
@@ -269,8 +275,8 @@ let reject_task_escape ctx ~scope_path root =
     | Error task_diagnostics -> diagnostics := List.rev_append task_diagnostics !diagnostics
     | Ok id when scope_prefix scope_path id.scope_path ->
         diagnostics :=
-          Diag.error ~code:Concurrency_contract.task_escape_code
-            ~hint:"do not return or store a Task beyond its creating async.scope"
+          task_diagnostic ~summary:Concurrency_contract.task_escape_message
+            ~next_step:"Keep the Task inside the async.scope that created it."
             (Concurrency_contract.task_escape_message ^ ": Task "
             ^ Concurrency_contract.trace_task_id id
             ^ " escaped its creating structured scope")
@@ -282,9 +288,9 @@ let reject_task_escape ctx ~scope_path root =
     | Error channel_diagnostics -> diagnostics := List.rev_append channel_diagnostics !diagnostics
     | Ok id when scope_prefix scope_path id.scope_path ->
         diagnostics :=
-          Diag.error ~code:Concurrency_contract.task_escape_code
-            ~hint:"do not return or store a ChannelHandle beyond its creating async.scope"
-            ("a ChannelHandle may not escape its creating structured scope: Channel "
+          task_diagnostic ~summary:"A ChannelHandle escaped its structured scope"
+            ~next_step:"Keep the ChannelHandle inside the async.scope that created it."
+            ("A ChannelHandle may not escape its creating structured scope: Channel "
             ^ Channel_contract.trace_channel_id id
             ^ " escaped")
           :: !diagnostics
@@ -414,13 +420,13 @@ and match_pats vs ps env =
 let locate ctx ~trusted h =
   match if trusted then Store.locate_internal ctx.store h else Store.locate ctx.store h with
   | Ok l -> l
-  | Error ds -> rt (Runtime_err.Unresolved (String.concat "; " (List.map Diag.to_string ds)))
+  | Error ds -> rt (Runtime_err.Unresolved (String.concat "; " (List.map Diag.to_cause_string ds)))
 
 (* Source-order member hashes of a defterm decl, for GroupRef. *)
 let group_hashes (decl : Kernel.decl) : Hash.t array =
   match Canon.hash_decl decl with
   | Ok { Canon.named; _ } -> Array.of_list (List.map snd named)
-  | Error ds -> rt (Runtime_err.Unresolved (String.concat "; " (List.map Diag.to_string ds)))
+  | Error ds -> rt (Runtime_err.Unresolved (String.concat "; " (List.map Diag.to_cause_string ds)))
 
 let con_value ctx ~trusted h =
   if Concurrency_contract.is_task_private_hash h || Channel_contract.is_channel_private_hash h then
@@ -458,7 +464,8 @@ let rec live_splices ?(level = 0) (f : Form.t) : Kernel.expr list =
     | [ Form.F splice ] -> (
         match Kernel.expr_of_form splice with
         | Ok e -> [ e ]
-        | Error ds -> rt (Runtime_err.Unresolved (String.concat "; " (List.map Diag.to_string ds))))
+        | Error ds ->
+            rt (Runtime_err.Unresolved (String.concat "; " (List.map Diag.to_cause_string ds))))
     | _ -> rt_type "malformed unquote in quote payload"
   else
     let level =

--- a/src/exhaustive_schedule.ml
+++ b/src/exhaustive_schedule.ml
@@ -113,7 +113,12 @@ let trace_of_path = function
 
 let validate_bounds bounds =
   let invalid field value =
-    Diag.error ~code:"E0908" (Printf.sprintf "exhaustive %s must be positive, found %d" field value)
+    Diag.error ~domain:Concurrency ~code:"E0908"
+      ~summary:"Exhaustive-schedule bound must be positive"
+      ~cause:
+        (Printf.sprintf "The %s is %d; exhaustive bounds must be greater than zero." field value)
+      ~next_step:(Printf.sprintf "Set the %s to a positive integer." field)
+      ~contrast:None ()
   in
   let diagnostics =
     [

--- a/src/governance_reconcile.ml
+++ b/src/governance_reconcile.ml
@@ -10,7 +10,39 @@ type report = {
 }
 
 let ( let* ) = Result.bind
-let error ~code fmt = Printf.ksprintf (fun message -> Error [ Diag.error ~code message ]) fmt
+
+let diagnostic_spec = function
+  | "E1510" ->
+      ( "The governance reconciliation bundle is malformed, unsupported, or unsafe to read.",
+        "Regenerate one canonical governance-reconciliation-bundle-v1 from stable evidence." )
+  | "E1511" ->
+      ( "The action journal chain or published head is inconsistent.",
+        "Restore the original predecessor-linked journal and its independently published head." )
+  | "E1512" ->
+      ( "An action attempt or receipt carries the wrong semantic identity.",
+        "Recompute the identity from the exact unchanged attempt or receipt subject." )
+  | "E1513" ->
+      ( "The action journal repeats an attempt or receipt identity.",
+        "Keep one Attempted entry and at most one Receipt for each attempt identity." )
+  | "E1514" ->
+      ( "An action receipt appears before its attempt.",
+        "Place each Receipt after its matching Attempted journal entry." )
+  | "E1515" ->
+      ( "The action evidence contradicts the verified governance run.",
+        "Restore exact Call, branch, authorization, completion, and outcome agreement." )
+  | "E1516" ->
+      ( "Valid action evidence still requires operator reconciliation.",
+        "Reconcile the reported missing receipt or completion before retrying or closing the run."
+      )
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown reconciliation code " ^ code))
+
+let error ~code fmt =
+  Printf.ksprintf
+    (fun cause ->
+      let summary, next_step = diagnostic_spec code in
+      Error [ Diag.error ~domain:Governance ~code ~summary ~cause ~next_step ~contrast:None () ])
+    fmt
+
 let journal_domain = "jacquard-governance-action-journal-v1\000"
 let journal_genesis = Hash.of_string "jacquard-governance-action-journal-v1-genesis\000"
 let form head values = Form.form head (List.map (fun value -> Form.F value) values)
@@ -638,7 +670,7 @@ let verify_string ~store ~file source =
       | Error diagnostics ->
           let detail =
             match diagnostics with
-            | diagnostic :: _ -> diagnostic.Diag.message
+            | diagnostic :: _ -> Diag.cause diagnostic
             | [] -> "unknown reader failure"
           in
           error ~code:"E1510" "%s: malformed governance reconciliation bundle: %s" file detail

--- a/src/governance_run_bundle.ml
+++ b/src/governance_run_bundle.ml
@@ -10,7 +10,41 @@ type report = {
 }
 
 let ( let* ) = Result.bind
-let error ~code fmt = Printf.ksprintf (fun message -> Error [ Diag.error ~code message ]) fmt
+
+let diagnostic_spec = function
+  | "E1500" ->
+      ( "The governance run bundle is malformed, unsupported, or unsafe to read.",
+        "Regenerate one canonical governance-run-bundle-v1 from stable verified artifacts." )
+  | "E1501" ->
+      ( "A governance artifact is malformed or carries the wrong identity.",
+        "Restore the exact canonical artifact and its matching carried identity." )
+  | "E1502" ->
+      ( "A governance artifact identity appears more than once.",
+        "Keep exactly one artifact for each semantic identity." )
+  | "E1503" ->
+      ( "An Audit entry references an artifact missing from the run bundle.",
+        "Add the exact referenced artifact to the fixed bundle section." )
+  | "E1504" ->
+      ( "Governance Audit ordering or artifact linkage is inconsistent.",
+        "Restore the unique earlier linked evaluation, proposal, or completion record." )
+  | "E1505" ->
+      ( "A Proposal disagrees with one of its linked governance artifacts.",
+        "Regenerate the Proposal from the exact linked Call, policy, assessment, and authority." )
+  | "E1506" ->
+      ( "Transformed Call lineage is missing or cyclic.",
+        "Supply an acyclic parent chain rooted in a bundled Call." )
+  | "E1507" ->
+      ( "A bundled governance artifact is not used by the Audit chain.",
+        "Remove the unrelated artifact or link the exact required artifact from the Audit chain." )
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown run-bundle code " ^ code))
+
+let error ~code fmt =
+  Printf.ksprintf
+    (fun cause ->
+      let summary, next_step = diagnostic_spec code in
+      Error [ Diag.error ~domain:Governance ~code ~summary ~cause ~next_step ~contrast:None () ])
+    fmt
+
 let hash_code value = Form.form "hash" [ Form.Hash value ]
 let code_hash value = Hash.of_string (Printer.print_compact value)
 let version = function { Form.head = "governance-v0"; args = []; _ } -> true | _ -> false
@@ -861,7 +895,7 @@ let verify_string ~store ~file source =
       | Error diagnostics ->
           let detail =
             match diagnostics with
-            | diagnostic :: _ -> diagnostic.Diag.message
+            | diagnostic :: _ -> Diag.cause diagnostic
             | [] -> "unknown reader failure"
           in
           error ~code:"E1500" "%s: malformed governance run bundle: %s" file detail

--- a/src/governance_verify.ml
+++ b/src/governance_verify.ml
@@ -113,7 +113,17 @@ type vocabulary = {
 }
 
 let span meta = Meta.span meta
-let diagnostic ?hint meta code message = Diag.error ?span:(span meta) ?hint ~code message
+
+let diagnostic_summary code =
+  match List.assoc_opt code diagnostic_codes with
+  | Some meaning -> String.capitalize_ascii meaning
+  | None -> "Governance verification failed"
+
+let diagnostic meta code cause =
+  Diag.error ?span:(span meta) ~domain:Governance ~code ~summary:(diagnostic_summary code) ~cause
+    ~next_step:"Restore the canonical governed structure described by this diagnostic."
+    ~contrast:None ()
+
 let hex hash = Hash.to_hex hash
 
 let pinned_hash name spelling =
@@ -364,7 +374,7 @@ let check_pure_term checker ~result_type ~expected_result ~expected_name ~allow_
       [
         diagnostic term.meta "E1405"
           (Printf.sprintf "%s cannot be checked: %s" term.label
-             (String.concat "; " (List.map Diag.to_string diagnostics)));
+             (String.concat "; " (List.map Diag.to_cause_string diagnostics)));
       ]
   | Ok scheme -> (
       let inferred = Types.repr scheme.Types.ty in
@@ -516,7 +526,7 @@ let validate_facade store (contract : contract) =
       [
         diagnostic contract.meta "E1401"
           (Printf.sprintf "facade effect cannot be resolved: %s"
-             (String.concat "; " (List.map Diag.to_string diagnostics)));
+             (String.concat "; " (List.map Diag.to_cause_string diagnostics)));
       ]
   | Ok { Store.decl = { Kernel.it = Kernel.DefEffect { ops; _ }; _ }; role = Store.Whole; _ } ->
       let mode_errors =

--- a/src/infer_dist.ml
+++ b/src/infer_dist.ml
@@ -26,7 +26,20 @@ type weighted = { value : Value.t; weight : float }
 type posterior = { entries : (Value.t * float) list }
 (** normalized, sorted by probability descending then rendering for determinism *)
 
-let err ~code fmt = Printf.ksprintf (fun msg -> Error [ Diag.error ~code msg ]) fmt
+let diagnostic ~code cause =
+  let summary, next_step =
+    match code with
+    | "E0901" ->
+        ( "The posterior is empty.",
+          "Change the model or observations so at least one execution branch has nonzero weight." )
+    | "E0902" ->
+        ( "Probabilistic inference stopped on a runtime failure.",
+          "Correct the reported model runtime failure and rerun inference." )
+    | _ -> raise (Diag.Bug_invalid_diagnostic ("unknown inference diagnostic code " ^ code))
+  in
+  Diag.error ~domain:Inference ~code ~summary ~cause ~next_step ~contrast:None ()
+
+let err ~code fmt = Printf.ksprintf (fun cause -> Error [ diagnostic ~code cause ]) fmt
 
 (* --- distribution values --- *)
 
@@ -187,7 +200,7 @@ let enumerate (ctx : Eval.ctx) (model : Eval.state) : (posterior, Diag.t list) r
                (Printf.sprintf "enumerate: unexpected op %s/%d" name (List.length args)))
   in
   match explore model 1.0 with
-  | Error e -> Error [ Diag.error ~code:"E0902" (Runtime_err.to_string e) ]
+  | Error error -> Error [ diagnostic ~code:"E0902" (Runtime_err.to_string error) ]
   | Ok () ->
       let total = List.fold_left (fun acc { weight; _ } -> acc +. weight) 0.0 !leaves in
       if total <= 0.0 then
@@ -314,10 +327,10 @@ let likelihood_weighting (ctx : Eval.ctx) ~seed ~samples (model : unit -> Eval.s
       match one_run rng state 1.0 with Error e -> Error e | Ok () -> k_runs initial (i + 1)
   in
   match Eval.validate_state_once ctx initial with
-  | Error e -> Error [ Diag.error ~code:"E0902" (Runtime_err.to_string e) ]
+  | Error error -> Error [ diagnostic ~code:"E0902" (Runtime_err.to_string error) ]
   | Ok initial -> (
       match k_runs initial 0 with
-      | Error e -> Error [ Diag.error ~code:"E0902" (Runtime_err.to_string e) ]
+      | Error error -> Error [ diagnostic ~code:"E0902" (Runtime_err.to_string error) ]
       | Ok () ->
           let total = List.fold_left (fun acc { weight; _ } -> acc +. weight) 0.0 !runs in
           if total <= 0.0 then

--- a/src/kernel.ml
+++ b/src/kernel.ml
@@ -127,9 +127,48 @@ exception Err of Diag.t
     below the host stack limit so untrusted forms fail with E0214 instead of [Stack_overflow]. *)
 let max_nesting_depth = 10_000
 
+let diagnostic_summary = function
+  | "E0201" -> "This value is not a kernel form in this position."
+  | "E0202" -> "A kernel form has the wrong number of arguments."
+  | "E0203" -> "A kernel form argument has the wrong sort."
+  | "E0204" -> "An unquote appears outside a quote."
+  | "E0205" -> "A lambda parameter uses a refutable pattern."
+  | "E0206" -> "A let binder uses a refutable pattern."
+  | "E0207" -> "A recursive let binder is not a variable."
+  | "E0208" -> "A recursive let value is not a lambda."
+  | "E0209" -> "A match expression has no clauses."
+  | "E0210" -> "A reference has an invalid kind."
+  | "E0211" -> "A let expression has an invalid recursion flag."
+  | "E0212" -> "A handler has the wrong number of return clauses."
+  | "E0213" -> "An effect operation has an invalid explicit mode."
+  | "E0214" -> "Kernel form nesting exceeds the structural limit."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown kernel diagnostic code " ^ code))
+
+let diagnostic_next_step = function
+  | "E0201" -> "Replace it with a kernel form valid for this grammar position."
+  | "E0202" -> "Supply exactly the arguments required by this kernel form."
+  | "E0203" -> "Replace the argument with the required form or scalar sort."
+  | "E0204" -> "Move the unquote inside a quote or remove the unquote wrapper."
+  | "E0205" -> "Use an irrefutable variable, wildcard, tuple, or as-pattern parameter."
+  | "E0206" -> "Use an irrefutable variable, wildcard, tuple, or as-pattern binder."
+  | "E0207" -> "Bind recursive let with one variable."
+  | "E0208" -> "Make the recursive let value a lambda."
+  | "E0209" -> "Add at least one exhaustive match clause."
+  | "E0210" -> "Use term, con, or op as the reference kind."
+  | "E0211" -> "Use rec or nonrec as the let recursion flag."
+  | "E0212" -> "Keep exactly one return clause in the handler."
+  | "E0213" -> "Write once explicitly or omit the mode for multi."
+  | "E0214" -> "Reduce the nesting depth below the structural limit."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown kernel diagnostic code " ^ code))
+
 let err ?meta ~code fmt =
   Printf.ksprintf
-    (fun msg -> raise (Err (Diag.error ?span:(Option.bind meta Meta.span) ~code msg)))
+    (fun cause ->
+      raise
+        (Err
+           (Diag.error ?span:(Option.bind meta Meta.span) ~domain:Kernel ~code
+              ~summary:(diagnostic_summary code) ~cause ~next_step:(diagnostic_next_step code)
+              ~contrast:None ())))
     fmt
 
 let expect_arity (f : Form.t) n =

--- a/src/native/emit.ml
+++ b/src/native/emit.ml
@@ -843,8 +843,8 @@ let emit_fn st (f : fn) : unit =
         (List.rev fr.rps);
       line buf "default:;";
       line buf "}";
-      line buf "fputs(\"jacquard runtime: unknown resume point (internal)\\n\", stderr);";
-      line buf "exit(2);";
+      line buf
+        "jq_runtime_fail(JQ_ERROR_NATIVE, \"jacquard runtime: unknown resume point (internal)\");";
       buf.indent <- buf.indent - 1;
       line buf "}"
     end;
@@ -1091,8 +1091,8 @@ let main_source (prog : program) ~precise ~(v_true : Hash.t) ~(v_false : Hash.t)
       (* a capture always resolves inside its expression (any capturing handler is
          within it); a sentinel here is an internal bug, never a semantic outcome *)
       line st.ub
-        "if (_v == JQ_SUSPEND) { fputs(\"jacquard runtime: a capture escaped its expression \
-         (internal)\\n\", stderr); exit(2); }";
+        "if (_v == JQ_SUSPEND) jq_runtime_fail(JQ_ERROR_NATIVE, \"jacquard runtime: a capture \
+         escaped its expression (internal)\");";
       (* the flush is parity: the interpreter's per-expression print is OCaml's
          print_endline, which flushes stdout — without it a later expression's
          stderr (warning or refusal) would overtake THIS value in a merged
@@ -1124,9 +1124,9 @@ let main_source (prog : program) ~precise ~(v_true : Hash.t) ~(v_false : Hash.t)
   line st.ub "if (strncmp(argv[i], \"--infer-cache\", 13) == 0) {";
   st.ub.indent <- st.ub.indent + 1;
   line st.ub
-    "fputs(\"error[E1103]: native binaries do not cache completions yet (the cache entry format \
-     needs task 73's reader); rerun without --infer-cache\\n\", stderr);";
-  line st.ub "return 1;";
+    "jq_diagnostic_fail(1, \"E1103\", \"Native build could not complete\", \"Native binaries do \
+     not cache completions yet because the cache entry format needs the native reader.\", \"Run \
+     without --infer-cache.\");";
   st.ub.indent <- st.ub.indent - 1;
   line st.ub "}";
   line st.ub "const char *nm = NULL;";
@@ -1156,9 +1156,9 @@ let main_source (prog : program) ~precise ~(v_true : Hash.t) ~(v_false : Hash.t)
       line st.ub "}")
     implemented;
   line st.ub
-    "fprintf(stderr, \"error[E1103]: native binaries implement only the console, clock, fs, dist, \
-     and infer grants so far (task 72); cannot grant `%%s`\\n\", nm);";
-  line st.ub "return 1;";
+    "jq_diagnostic_failf(1, \"E1103\", \"Native build could not complete\", \"Use a supported \
+     native grant or run the program with the interpreter.\", \"Native binaries implement only the \
+     console, clock, fs, dist, and infer grants; cannot grant `%%s`.\", nm);";
   st.ub.indent <- st.ub.indent - 1;
   line st.ub "}";
   line st.ub "return jq_run_main(&rt0, jq_program);";

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -13,7 +13,27 @@
     case-insensitive effect name from the CLI to the matching installer. Pure effects (abort etc.)
     deliberately has no root handler: an unhandled [abort] is supposed to die. *)
 
-let err ~code fmt = Printf.ksprintf (fun msg -> Error [ Diag.error ~code msg ]) fmt
+let diagnostic_summary = function
+  | "E0701" -> "Prelude directory is unavailable"
+  | "E0702" -> "Prelude contents are incomplete or have the wrong kind"
+  | "E0703" -> "Requested effect is not root-grantable"
+  | code -> "Prelude loading failed (" ^ code ^ ")"
+
+let diagnostic_next_step = function
+  | "E0701" -> "Pass --prelude with the path to a complete prelude directory."
+  | "E0702" -> "Restore the named declaration with the required prelude kind."
+  | "E0703" -> "Handle this effect inside the program instead of granting it at the root."
+  | _ -> "Correct the prelude configuration and try again."
+
+let err ~code fmt =
+  Printf.ksprintf
+    (fun cause ->
+      Error
+        [
+          Diag.error ~domain:Prelude ~code ~summary:(diagnostic_summary code) ~cause
+            ~next_step:(diagnostic_next_step code) ~contrast:None ();
+        ])
+    fmt
 
 let read_file path =
   let ic = open_in_bin path in
@@ -643,10 +663,22 @@ let wire_builtins (ctx : Eval.ctx) : (unit, Diag.t list) result =
               Infer_dist.likelihood_weighting ctx ~seed ~samples (fun () ->
                   Eval.apply_state ctx thunk [])
             with
-            | Error ds ->
-                (* E0901/E0902 flatten to a runtime error here; the diagnostic text (with
-                   its code) rides in the message *)
-                Error (Runtime_err.Arithmetic (String.concat "; " (List.map Diag.to_string ds)))
+            | Error [ diagnostic ] -> Error (Runtime_err.Diagnostic diagnostic)
+            | Error diagnostics ->
+                (* Inference currently returns exactly one diagnostic. Keep this boundary total if
+                   that API later reports several failures, while retaining a structured primary
+                   inference identity instead of misclassifying them as arithmetic. *)
+                let cause =
+                  match diagnostics with
+                  | [] -> "the inference driver failed without reporting a cause"
+                  | diagnostics -> String.concat "; " (List.map Diag.to_cause_string diagnostics)
+                in
+                Error
+                  (Runtime_err.Diagnostic
+                     (Diag.error ~domain:Inference ~code:"E0902"
+                        ~summary:"Probabilistic inference stopped on a runtime failure." ~cause
+                        ~next_step:"Correct the reported model runtime failure and rerun inference."
+                        ~contrast:None ()))
             | Ok p -> (
                 match
                   ( Store.lookup_kind store "mk-pair" Resolve.KCon,
@@ -1043,7 +1075,7 @@ let install_eval (ctx : Eval.ctx) : (unit, Diag.t list) result =
       Eval.register_root_handler ctx eval_op (fun args ->
           match args with
           | [ Value.VCode payload ] -> (
-              let diags_msg ds = String.concat "; " (List.map Diag.to_string ds) in
+              let diags_msg ds = String.concat "; " (List.map Diag.to_cause_string ds) in
               match Kernel.expr_of_form payload with
               | Error ds -> Error (Runtime_err.Eval_error (diags_msg ds))
               | Ok e -> (
@@ -1241,7 +1273,15 @@ let builtin_signatures (store : Store.t) : ((Hash.t * Types.scheme) list, Diag.t
             ])
     | Error _, _, _ -> Ok base
     | Ok _, (None | Some _), (None | Some _) ->
-        Error [ Diag.error ~code:"E0908" "invalid frozen Async scope identities" ]
+        Error
+          [
+            Diag.error ~domain:Concurrency ~code:"E0908"
+              ~summary:"Frozen Async scope identities are invalid"
+              ~cause:
+                "The prelude's frozen Async declarations do not have their expected identities."
+              ~next_step:"Rebuild the complete, version-matched prelude and try again."
+              ~contrast:None ();
+          ]
   in
   (* int-compare ships with ring 0; its ordering result type lives in 02-data *)
   let* base =

--- a/src/reader.ml
+++ b/src/reader.ml
@@ -48,12 +48,52 @@ exception Err of Diag.t
 (** Maximum active form nodes accepted by the bootstrap reader. *)
 let max_nesting_depth = 10_000
 
-let error st ~code ?hint msg ~start_pos =
+let diagnostic_summary = function
+  | "E0101" -> "The source contains an unexpected character."
+  | "E0102" -> "A text literal is not closed."
+  | "E0103" -> "A text literal contains an invalid escape."
+  | "E0104" -> "A hash literal is malformed."
+  | "E0105" -> "A numeric literal is malformed."
+  | "E0106" -> "The source ended before the form was complete."
+  | "E0107" -> "A bootstrap form has an invalid head."
+  | "E0108" -> "The source contains an unmatched closing parenthesis."
+  | "E0109" -> "An integer is outside Jacquard's supported range."
+  | "E0110" -> "A bootstrap group contains a non-form value."
+  | "E0111" -> "A quoted symbol is malformed."
+  | "E0112" -> "A bare symbol is malformed."
+  | "E0113" -> "A bootstrap file has a non-form top-level value."
+  | "E0114" -> "This entry point received more than one top-level form."
+  | "E0115" -> "Bootstrap form nesting exceeds the structural limit."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown reader diagnostic code " ^ code))
+
+let diagnostic_next_step = function
+  | "E0101" -> "Remove the character or replace it with valid bootstrap syntax."
+  | "E0102" -> "Close the text literal with a double quote before the end of the line or file."
+  | "E0103" -> "Replace the escape with one of the supported text escapes."
+  | "E0104" -> "Write a hash as the required number of lowercase hexadecimal digits."
+  | "E0105" -> "Rewrite the value as one valid integer or real literal."
+  | "E0106" -> "Complete the open form and its closing parenthesis."
+  | "E0107" -> "Use a lowercase kernel-form head."
+  | "E0108" -> "Remove the unmatched parenthesis or add its missing opening form."
+  | "E0109" -> "Choose an integer inside the documented 63-bit native range."
+  | "E0110" -> "Wrap each group element in a bootstrap form."
+  | "E0111" -> "Rewrite the quoted symbol using the documented symbol grammar."
+  | "E0112" -> "Rewrite the name using the documented bare-symbol grammar."
+  | "E0113" -> "Wrap the top-level value in a kernel form."
+  | "E0114" -> "Pass exactly one top-level form to this entry point."
+  | "E0115" -> "Reduce the nesting depth below the structural limit."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown reader diagnostic code " ^ code))
+
+let error st ~code ?next_step msg ~start_pos =
   let span =
     Span.make ~file:st.file ~start_pos
       ~end_pos:{ Span.line = st.line; col = st.col; offset = st.off }
   in
-  raise (Err (Diag.error ~span ?hint ~code msg))
+  raise
+    (Err
+       (Diag.error ~span ~domain:Reader ~code ~summary:(diagnostic_summary code) ~cause:msg
+          ~next_step:(Option.value next_step ~default:(diagnostic_next_step code))
+          ~contrast:None ()))
 
 let pos st = { Span.line = st.line; col = st.col; offset = st.off }
 let peek st = if st.off < String.length st.src then Some st.src.[st.off] else None
@@ -219,7 +259,7 @@ let classify_number st ~start_pos s =
   | LIntOverflow ->
       error st ~code:"E0109" ~start_pos
         (Printf.sprintf "integer literal %s does not fit in a native int" s)
-        ~hint:"Jacquard integers are 63-bit native ints (decision D2)"
+        ~next_step:"Choose a value representable as a Jacquard 63-bit native integer (decision D2)."
 
 let read_text st =
   let start_pos = pos st in
@@ -280,7 +320,7 @@ let read_text st =
         | Some c ->
             error st ~code:"E0103" ~start_pos:esc_start
               (Printf.sprintf "invalid escape sequence \\%c" c)
-              ~hint:"valid escapes: \\\\ \\\" \\n \\t \\r \\xHH")
+              ~next_step:"Use one of these escapes: \\\\ \\\" \\n \\t \\r \\xHH.")
     | Some c ->
         advance st;
         Buffer.add_char buf c;
@@ -321,7 +361,7 @@ and read_form_body st : Form.t =
   if not (valid_head head) then
     error st ~code:"E0107" ~start_pos
       (Printf.sprintf "invalid head symbol %S" head)
-      ~hint:"heads are lowercase: [a-z][a-z0-9-]*";
+      ~next_step:"Rewrite the head to match [a-z][a-z0-9-]*.";
   let rec args acc =
     skip_ws st;
     match peek st with
@@ -352,7 +392,7 @@ and read_form_body st : Form.t =
   let span = Span.make ~file:st.file ~start_pos ~end_pos:(pos st) in
   if head = "group" && not (List.for_all (function Form.F _ -> true | _ -> false) args) then
     error st ~code:"E0110" ~start_pos "group elements must be forms"
-      ~hint:"a bare ( ... ) argument list may only contain forms";
+      ~next_step:"Make every item in the bare argument list a form.";
   let meta = Meta.with_span span Meta.empty in
   let meta =
     match leading with
@@ -384,7 +424,9 @@ and read_arg st : Form.arg =
       | None ->
           error st ~code:"E0104" ~start_pos
             (Printf.sprintf "invalid hash literal #%s" s)
-            ~hint:(Printf.sprintf "a hash is %d lowercase hex characters" (2 * Hash.digest_size)))
+            ~next_step:
+              (Printf.sprintf "Write the hash as %d lowercase hexadecimal characters."
+                 (2 * Hash.digest_size)))
   | Some c when is_digit c || c = '+' || c = '-' -> (
       let s = read_atom st in
       match classify_number st ~start_pos s with
@@ -452,5 +494,17 @@ let parse_one ~file s : (Form.t, Diag.t list) result =
   match parse_string ~file s with
   | Error ds -> Error ds
   | Ok [ f ] -> Ok f
-  | Ok [] -> Error [ Diag.error ~code:"E0106" "expected a form, found end of input" ]
-  | Ok (_ :: _ :: _) -> Error [ Diag.error ~code:"E0114" "expected exactly one top-level form" ]
+  | Ok [] ->
+      Error
+        [
+          Diag.error ~domain:Reader ~code:"E0106" ~summary:(diagnostic_summary "E0106")
+            ~cause:"Expected a form, but found end of input."
+            ~next_step:(diagnostic_next_step "E0106") ~contrast:None ();
+        ]
+  | Ok (_ :: _ :: _) ->
+      Error
+        [
+          Diag.error ~domain:Reader ~code:"E0114" ~summary:(diagnostic_summary "E0114")
+            ~cause:"Expected exactly one top-level form." ~next_step:(diagnostic_next_step "E0114")
+            ~contrast:None ();
+        ]

--- a/src/recovery_marker.ml
+++ b/src/recovery_marker.ml
@@ -86,4 +86,8 @@ let top = function
   | Kernel.Decl declaration -> decl declaration
 
 let diagnostic boundary =
-  Diag.error ~code:"E1202" (Printf.sprintf "recovery holes are not valid input to %s" boundary)
+  Diag.error ~domain:Surface ~code:"E1202"
+    ~summary:"Recovered syntax cannot cross this semantic boundary."
+    ~cause:(Printf.sprintf "Recovery holes are not valid input to %s." boundary)
+    ~next_step:"Fix the reported syntax damage before checking, hashing, storing, or running it."
+    ~contrast:None ()

--- a/src/resolve.ml
+++ b/src/resolve.ml
@@ -79,25 +79,44 @@ type state = { names : names; mutable diags : Diag.t list }
 let report st d = st.diags <- d :: st.diags
 let rec take n = function [] -> [] | x :: xs -> if n <= 0 then [] else x :: take (n - 1) xs
 
-let suggest st ~locals name =
-  let candidates =
-    List.sort_uniq String.compare (locals @ st.names.all_names ())
-    |> List.filter (fun c -> c <> name && edit_distance name c <= 2)
-  in
-  match candidates with
-  | [] -> None
-  | [ c ] -> Some (Printf.sprintf "did you mean `%s`?" c)
-  | cs -> Some (Printf.sprintf "did you mean one of: %s?" (String.concat ", " (take 3 cs)))
+let suggestions st ~locals name =
+  List.sort_uniq String.compare (locals @ st.names.all_names ())
+  |> List.filter (fun candidate -> candidate <> name && edit_distance name candidate <= 2)
+  |> take 3
 
 let unknown st ~meta ~locals ~what name =
+  let candidates = suggestions st ~locals name in
+  let contrast =
+    match candidates with
+    | [ candidate ] ->
+        Some
+          (Diag.contrast
+             ~mistaken:(Printf.sprintf "the unknown name `%s`" name)
+             ~intended:(Printf.sprintf "the in-scope name `%s`" candidate))
+    | [] | _ :: _ :: _ -> None
+  in
+  let cause =
+    match candidates with
+    | [] -> Printf.sprintf "No %s named `%s` is in scope." what name
+    | values ->
+        Printf.sprintf "No %s named `%s` is in scope; nearby names are %s." what name
+          (String.concat ", " (List.map (Printf.sprintf "`%s`") values))
+  in
   report st
-    (Diag.error ?span:(Meta.span meta) ?hint:(suggest st ~locals name) ~code:"E0301"
-       (Printf.sprintf "unknown %s `%s`" what name))
+    (Diag.error ?span:(Meta.span meta) ~domain:Resolution ~code:"E0301"
+       ~summary:"This reference names something that is not in scope." ~cause
+       ~next_step:"Correct the reference to an in-scope name or declaration." ~contrast ())
 
 let kind_mismatch st ~meta name ~expected ~got =
   report st
-    (Diag.error ?span:(Meta.span meta) ~code:"E0302"
-       (Printf.sprintf "`%s` is %s, but this position needs %s" name (kind_to_string got) expected))
+    (Diag.error ?span:(Meta.span meta) ~domain:Resolution ~code:"E0302"
+       ~summary:"This reference has the wrong kind for its position."
+       ~cause:
+         (Printf.sprintf "`%s` is %s, but this position needs %s." name (kind_to_string got)
+            expected)
+       ~next_step:"Reference a declaration of the required kind in this position."
+       ~contrast:(Some (Diag.contrast ~mistaken:(kind_to_string got) ~intended:expected))
+       ())
 
 (* Resolve a non-term reference position (pcon/opclause/tref/eref): kind-directed, so among
    all bindings of the name the one with the expected kind wins. *)
@@ -127,8 +146,10 @@ let pat_vars_seen st seen (p : Kernel.pat) : string list =
   let bind meta x =
     if Hashtbl.mem seen x then
       report st
-        (Diag.error ?span:(Meta.span meta) ~code:"E0304"
-           (Printf.sprintf "variable `%s` is bound more than once in this pattern" x))
+        (Diag.error ?span:(Meta.span meta) ~domain:Resolution ~code:"E0304"
+           ~summary:"A pattern binds the same variable more than once."
+           ~cause:(Printf.sprintf "Variable `%s` is bound more than once in this pattern." x)
+           ~next_step:"Rename or remove the duplicate pattern binding." ~contrast:None ())
     else begin
       Hashtbl.add seen x ();
       acc := x :: !acc
@@ -261,10 +282,19 @@ let rec resolve_expr_in st ~group ~locals (e : Kernel.expr) : Kernel.expr =
                 in
                 if hint = None && losers <> [] then
                   report st
-                    (Diag.warning ?span:(Meta.span e.Kernel.meta) ~code:"W0301"
-                       (Printf.sprintf
-                          "`%s` is bound as %s and also as %s; the %s wins in value position" x
-                          (kind_to_string kind) (String.concat " and " losers) (kind_to_string kind)));
+                    (Diag.warning ?span:(Meta.span e.Kernel.meta) ~domain:Resolution ~code:"W0301"
+                       ~summary:"This bare name is ambiguous across value kinds."
+                       ~cause:
+                         (Printf.sprintf
+                            "`%s` is bound as %s and also as %s; %s wins in value position." x
+                            (kind_to_string kind) (String.concat " and " losers)
+                            (kind_to_string kind))
+                       ~next_step:"Use a kind-tagged escaped name to select the intended binding."
+                       ~contrast:
+                         (Some
+                            (Diag.contrast ~mistaken:"an ambiguous bare value name"
+                               ~intended:"a kind-tagged escaped name"))
+                       ());
                 { Kernel.it = Kernel.Ref (hash, refkind); meta = Meta.with_name x e.Kernel.meta }
             | None -> (
                 match entries with
@@ -336,8 +366,13 @@ let rec resolve_expr_in st ~group ~locals (e : Kernel.expr) : Kernel.expr =
             let seen, bound = pats_vars st params in
             if Hashtbl.mem seen resume then
               report st
-                (Diag.error ?span:(Meta.span ometa) ~code:"E0304"
-                   (Printf.sprintf "resume name `%s` duplicates an op clause parameter" resume));
+                (Diag.error ?span:(Meta.span ometa) ~domain:Resolution ~code:"E0304"
+                   ~summary:"An operation clause binds the same variable twice."
+                   ~cause:
+                     (Printf.sprintf "Resume name `%s` duplicates an operation-clause parameter."
+                        resume)
+                   ~next_step:"Rename the resume binder or the duplicate operation parameter."
+                   ~contrast:None ());
             {
               Kernel.op;
               params = List.map (resolve_pat st ~locals) params;
@@ -401,9 +436,12 @@ let resolve_decl_in st (d : Kernel.decl) : Kernel.decl =
           (fun b ->
             if Hashtbl.mem seen b.Kernel.bname then
               report st
-                (Diag.error ?span:(Meta.span b.Kernel.bmeta) ~code:"E0303"
-                   (Printf.sprintf "binding `%s` appears more than once in this group"
-                      b.Kernel.bname))
+                (Diag.error ?span:(Meta.span b.Kernel.bmeta) ~domain:Resolution ~code:"E0303"
+                   ~summary:"A definition group contains a duplicate binding name."
+                   ~cause:
+                     (Printf.sprintf "Binding `%s` appears more than once in this group."
+                        b.Kernel.bname)
+                   ~next_step:"Rename or remove the duplicate definition binding." ~contrast:None ())
             else Hashtbl.add seen b.Kernel.bname ())
           bindings;
         Kernel.DefTerm (List.map (resolve_binding st ~group) bindings)
@@ -457,7 +495,7 @@ let resolve_decl_in st (d : Kernel.decl) : Kernel.decl =
 let run st f x =
   let v = f st x in
   let errors, warnings =
-    List.partition (fun d -> d.Diag.severity = Diag.Error) (List.rev st.diags)
+    List.partition (fun diagnostic -> Diag.severity diagnostic = Diag.Error) (List.rev st.diags)
   in
   match errors with [] -> Ok (v, warnings) | ds -> Error ds
 

--- a/src/round_robin.ml
+++ b/src/round_robin.ml
@@ -142,12 +142,12 @@ let invalid_capacity_value requested =
        { con = invalid_capacity_hash; name = "invalid-capacity"; args = [ Value.VInt requested ] })
 
 let runtime_of_diagnostics diagnostics =
-  let message =
-    String.concat "; " (List.map (fun diagnostic -> diagnostic.Diag.message) diagnostics)
-  in
+  let message = String.concat "; " (List.map Diag.cause diagnostics) in
   if
     List.exists
-      (fun diagnostic -> String.equal diagnostic.Diag.code Concurrency_contract.task_escape_code)
+      (fun diagnostic ->
+        Option.equal String.equal (Diag.code diagnostic)
+          (Some Concurrency_contract.task_escape_code))
       diagnostics
   then Runtime_err.Invalid_task_handle message
   else Runtime_err.Scheduler_error message
@@ -162,11 +162,15 @@ let result_text = function
 let zero_metrics =
   Structured_scope.{ open_scopes = 0; live_tasks = 0; runnable_tasks = 0; owned_resumes = 0 }
 
+let scheduler_diagnostic ?(summary = "Deterministic scheduler state is invalid")
+    ?(next_step = "Restart the schedule from a valid recorded or seeded state.") cause =
+  Diag.error ~domain:Concurrency ~code:"E0908" ~summary ~cause ~next_step ~contrast:None ()
+
 let seeded_chooser seed =
   let rng = Infer_dist.Rng.make seed in
   fun ~sequence:_ ~runnable ->
     match runnable with
-    | [] -> Error [ Diag.error ~code:"E0908" "seeded scheduler cannot choose from an empty queue" ]
+    | [] -> Error [ scheduler_diagnostic "seeded scheduler cannot choose from an empty queue" ]
     | _ -> Ok (List.nth runnable (Infer_dist.Rng.bounded_int rng (List.length runnable)))
 
 let control_configuration = function
@@ -180,7 +184,7 @@ let control_configuration = function
   | Replay_schedule trace ->
       Error
         [
-          Diag.error ~code:"E0908"
+          scheduler_diagnostic
             (Printf.sprintf "unsupported schedule scheduler identity %s" trace.scheduler);
         ]
   | Fork_schedule { trace; decision; chosen } ->
@@ -276,7 +280,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
       if !task_count >= bounds.max_tasks then (
         budget_refusal := Some Task_limit;
         let diagnostics =
-          [ Diag.error ~code:"E0908" (Printf.sprintf "task bound %d exceeded" bounds.max_tasks) ]
+          [ scheduler_diagnostic (Printf.sprintf "task bound %d exceeded" bounds.max_tasks) ]
         in
         fatal_diagnostics := diagnostics;
         Error diagnostics)
@@ -298,8 +302,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
       else
         Error
           [
-            Diag.error ~code:"E0908"
-              ("round-robin queue drifted from frozen " ^ relation ^ " relation");
+            scheduler_diagnostic ("round-robin queue drifted from frozen " ^ relation ^ " relation");
           ]
     in
     let append_after_suspend run handle =
@@ -458,13 +461,13 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
           let* result =
             match view.result with
             | Some result -> Ok result
-            | None -> Error [ Diag.error ~code:"E0908" "awakened await target is not terminal" ]
+            | None -> Error [ scheduler_diagnostic "awakened await target is not terminal" ]
           in
           Ok (Eval.apply_state ctx continuation [ task_result_value result ])
       | Global_nested_wait _ ->
-          Error [ Diag.error ~code:"E0908" "nested scope parent woke before scope completion" ]
+          Error [ scheduler_diagnostic "nested scope parent woke before scope completion" ]
       | Global_channel _ ->
-          Error [ Diag.error ~code:"E0908" "channel waiter woke without an operation result" ]
+          Error [ scheduler_diagnostic "channel waiter woke without an operation result" ]
     in
     let fail_task run handle error =
       task_errors := (run, handle, error) :: !task_errors;
@@ -786,7 +789,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
                         make_scope_run nested_scope nested_body parent
                           Concurrency_contract.Fail_fast
                         |> Result.map_error (fun error ->
-                            [ Diag.error ~code:"E0908" (Runtime_err.to_string error) ])
+                            [ scheduler_diagnostic (Runtime_err.to_string error) ])
                       in
                       run.next_nested <- run.next_nested + 1;
                       all_scopes := nested_run :: !all_scopes;
@@ -837,7 +840,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
                   | Ok value -> Ok value
                   | Error error ->
                       routed_error := Some error;
-                      Error [ Diag.error ~code:"E0908" (Runtime_err.to_string error) ])
+                      Error [ scheduler_diagnostic (Runtime_err.to_string error) ])
                 ~continue:(fun owned value ->
                   let continuation =
                     match owned with
@@ -852,13 +855,13 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
       | [] when Structured_scope.channel_deadlocked root_scope ->
           Error
             [
-              Diag.error ~code:"E0908"
+              scheduler_diagnostic
                 "async deadlock: all remaining live tasks are blocked on channels";
             ]
       | [] -> Ok ()
       | _ when !sequence >= bounds.max_decisions ->
           budget_refusal := Some Decision_limit;
-          Error [ Diag.error ~code:"E0908" "decision bound exceeded" ]
+          Error [ scheduler_diagnostic "decision bound exceeded" ]
       | runnable ->
           let* runnable_ids = queue_ids [] runnable in
           let* chosen_id =
@@ -870,7 +873,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
               { sequence = !sequence; runnable = runnable_ids; chosen = chosen_id }
           in
           let rec take_chosen acc = function
-            | [] -> Error [ Diag.error ~code:"E0908" "chosen replay task is not runnable" ]
+            | [] -> Error [ scheduler_diagnostic "chosen replay task is not runnable" ]
             | ((run, handle) as task) :: rest ->
                 let* task_id = id run handle in
                 if Concurrency_contract.compare_task_id task_id decision.chosen = 0 then
@@ -916,12 +919,12 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
           let* body =
             match body_view.result with
             | Some body -> Ok body
-            | None -> Error [ Diag.error ~code:"E0908" "root scope body did not terminate" ]
+            | None -> Error [ scheduler_diagnostic "root scope body did not terminate" ]
           in
           let* aggregate =
             match root_run.aggregate with
             | Some aggregate -> Ok aggregate
-            | None -> Error [ Diag.error ~code:"E0908" "root scope did not drain" ]
+            | None -> Error [ scheduler_diagnostic "root scope did not drain" ]
           in
           let* () = reject_results root_run body aggregate in
           let* schedule = Schedule_control.finish schedule_control in

--- a/src/runtime_err.ml
+++ b/src/runtime_err.ml
@@ -23,17 +23,20 @@ type t =
   | Type_error of string  (** applying a non-function, spliced non-code, and similar *)
   | Unresolved of string  (** an unresolved name or dangling hash reached evaluation *)
   | Eval_error of string  (** the gated [eval] op rejected its payload at the boundary *)
+  | Diagnostic of Diag.t
+      (** a subsystem diagnostic that must retain its domain, code, and remediation when it crosses
+          the evaluator's single-error channel *)
 
+(** [to_string error] renders compact technical cause text for embedding in another failure. *)
 let to_string = function
   | Match_failure scrutinee -> Printf.sprintf "no clause matched the value %s" scrutinee
   | Io msg -> Printf.sprintf "io error: %s" msg
   | Observe_at_root ->
       "observe reached the sampling root handler; observation requires an inference driver (use \
        jacquard infer)"
-  | Once_resumed_twice ->
-      "error[E0906]: a once continuation may be resumed at most once per captured instance"
-  | Invalid_task_handle message -> "error[E0907]: " ^ message
-  | Scheduler_error message -> "error[E0908]: " ^ message
+  | Once_resumed_twice -> "a once continuation may be resumed at most once per captured instance"
+  | Invalid_task_handle message -> message
+  | Scheduler_error message -> message
   | Unhandled { effect_; op } ->
       Printf.sprintf "unhandled effect %s: operation `%s` reached the root without a handler"
         effect_ op
@@ -42,5 +45,54 @@ let to_string = function
   | Type_error msg -> "type error: " ^ msg
   | Unresolved msg -> "unresolved reference: " ^ msg
   | Eval_error msg -> "eval rejected its argument: " ^ msg
+  | Diagnostic diagnostic -> Diag.to_cause_string diagnostic
+
+(** [to_diag error] projects a runtime failure into the canonical structured diagnostic contract.
+    Embedded subsystem diagnostics retain their existing identity. Only ordinary runtime failures
+    with historically assigned public codes carry one; the rest remain deliberately code-less
+    instead of inventing new release identities. Secret-bearing values must already be redacted by
+    {!Value.show} before they enter a runtime error. *)
+let to_diag error =
+  let make ?code ~domain ~summary ~next_step () =
+    Diag.error ?code ~domain ~summary ~cause:(to_string error) ~next_step ~contrast:None ()
+  in
+  match error with
+  | Diagnostic diagnostic -> diagnostic
+  | Match_failure _ ->
+      make ~domain:Runtime ~summary:"No match clause accepted the value"
+        ~next_step:"Add a clause for this value or a wildcard default." ()
+  | Unhandled _ ->
+      make ~domain:Runtime ~summary:"An effect reached the root without a handler"
+        ~next_step:"Grant the effect at the root or handle it inside the program." ()
+  | Arity _ ->
+      make ~domain:Runtime ~summary:"Runtime call arity does not agree"
+        ~next_step:"Pass exactly the number of arguments required by the callable." ()
+  | Arithmetic _ ->
+      make ~domain:Runtime ~summary:"Arithmetic operation failed"
+        ~next_step:"Correct the arithmetic inputs and run the program again." ()
+  | Io _ ->
+      make ~domain:Runtime ~summary:"World-effect I/O failed"
+        ~next_step:"Correct the path, permissions, or external resource and try again." ()
+  | Observe_at_root ->
+      make ~domain:Runtime ~code:"E0904" ~summary:"Observation is invalid at the sampling root"
+        ~next_step:"Move the observation under an inference handler." ()
+  | Once_resumed_twice ->
+      make ~domain:Runtime ~code:"E0906" ~summary:"A once continuation was resumed more than once"
+        ~next_step:"Resume each captured once continuation at most once." ()
+  | Invalid_task_handle _ ->
+      make ~domain:Concurrency ~code:"E0907" ~summary:"A scoped task or channel handle is invalid"
+        ~next_step:"Use the handle only inside the exact async.scope that created it." ()
+  | Scheduler_error _ ->
+      make ~domain:Concurrency ~code:"E0908" ~summary:"Deterministic scheduler operation failed"
+        ~next_step:"Correct the schedule state or operation and try again." ()
+  | Type_error _ ->
+      make ~domain:Runtime ~summary:"Runtime value has the wrong type"
+        ~next_step:"Pass a value of the type required by this operation." ()
+  | Unresolved _ ->
+      make ~domain:Runtime ~summary:"Runtime reference is unresolved"
+        ~next_step:"Resolve every name and hash before evaluation." ()
+  | Eval_error _ ->
+      make ~domain:Runtime ~summary:"Eval rejected its code value"
+        ~next_step:"Pass validated closed code to eval." ()
 
 let pp fmt t = Format.pp_print_string fmt (to_string t)

--- a/src/schedule_control.ml
+++ b/src/schedule_control.ml
@@ -44,8 +44,10 @@ type t = {
 let error message =
   Error
     [
-      Diag.error ~code:"E0908" ~hint:"re-record the schedule or use an explicit valid fork"
-        ("schedule replay drift: " ^ message);
+      Diag.error ~domain:Concurrency ~code:"E0908"
+        ~summary:"The requested schedule replay step is invalid."
+        ~cause:("Schedule replay drift: " ^ message)
+        ~next_step:"Re-record the schedule or use an explicit valid fork." ~contrast:None ();
     ]
 
 let equal_id left right = Concurrency_contract.compare_task_id left right = 0

--- a/src/schedule_trace.ml
+++ b/src/schedule_trace.ml
@@ -39,8 +39,9 @@ type t = {
 let error message =
   Error
     [
-      Diag.error ~code:"E0908" ~hint:"record a fresh canonical v1 schedule trace"
-        ("invalid schedule trace: " ^ message);
+      Diag.error ~domain:Concurrency ~code:"E0908" ~summary:"The schedule trace is invalid."
+        ~cause:("Invalid schedule trace: " ^ message)
+        ~next_step:"Record a fresh canonical v1 schedule trace." ~contrast:None ();
     ]
 
 let id_text = Concurrency_contract.trace_task_id

--- a/src/scheduler_core.ml
+++ b/src/scheduler_core.ml
@@ -59,8 +59,11 @@ type ('resume, 'value) prepared_channel_wake = {
 }
 
 let diagnostic message =
-  Diag.error ~code:"E0908" ~hint:"scheduler task state was not advanced"
-    ("invalid structured-concurrency scheduler state: " ^ message)
+  Diag.error ~domain:Concurrency ~code:"E0908"
+    ~summary:"The structured-concurrency scheduler state is invalid."
+    ~cause:("Invalid structured-concurrency scheduler state: " ^ message)
+    ~next_step:"Advance the scheduler task state according to the documented transition."
+    ~contrast:None ()
 
 let error message = Error [ diagnostic message ]
 let equal_id left right = Concurrency_contract.compare_task_id left right = 0
@@ -163,8 +166,15 @@ let task_handle _capability scheduler = function
   | _ ->
       Error
         [
-          Diag.error ~code:Concurrency_contract.task_escape_code
-            "Async operation expected an opaque Task handle";
+          Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code
+            ~summary:"This Async operation did not receive a valid task handle."
+            ~cause:"The operation expected an opaque Task value."
+            ~next_step:"Pass the Task returned by async.spawn in the same structured scope."
+            ~contrast:
+              (Some
+                 (Diag.contrast ~mistaken:"an ordinary value"
+                    ~intended:"the opaque Task returned by async.spawn"))
+            ();
         ]
 
 let validate_run_handle scheduler handle = Task_handle.validate_run ~run:scheduler.run handle

--- a/src/scope_policy.ml
+++ b/src/scope_policy.ml
@@ -22,9 +22,11 @@ type 'value aggregate =
 let diagnostic message =
   Error
     [
-      Diag.error ~code:"E0908"
-        ~hint:"record each child terminal state once in scheduler decision order"
-        ("invalid structured-concurrency scope policy: " ^ message);
+      Diag.error ~domain:Concurrency ~code:"E0908"
+        ~summary:"Structured-concurrency scope policy is invalid"
+        ~cause:("The scope policy state is inconsistent: " ^ message)
+        ~next_step:"Record each child terminal state once in scheduler decision order."
+        ~contrast:None ();
     ]
 
 let child_name child = Concurrency_contract.trace_task_id child.id

--- a/src/store.ml
+++ b/src/store.ml
@@ -36,7 +36,42 @@ let object_path t h = Filename.concat (objects_dir t) (Hash.to_hex h ^ ".jqd")
    .jqd, so the identity self-check at open never sees them, and renames never touch
    them — the metadata law extended to the file system. *)
 let origin_path t h = Filename.concat (objects_dir t) (Hash.to_hex h ^ ".origin")
-let err ~code fmt = Printf.ksprintf (fun msg -> Error [ Diag.error ~code msg ]) fmt
+
+let diagnostic_spec = function
+  | "E0601" ->
+      ( "The content store does not contain the requested hash.",
+        "Add the referenced declaration to this store before using it." )
+  | "E0602" ->
+      ( "The content store does not contain the requested name.",
+        "Choose a name currently bound in this store." )
+  | "E0603" ->
+      ( "The content store contains corrupt data.",
+        "Restore the store from trusted canonical objects or rebuild it from source." )
+  | "E0604" ->
+      ("This store target cannot be named.", "Name an individual definition member instead.")
+  | "E0605" ->
+      ( "The requested store name is invalid.",
+        "Rewrite the name using the documented lowercase dotted-name grammar." )
+  | "E0606" ->
+      ( "A requested diff source or store does not exist.",
+        "Pass two existing source files or two existing store directories." )
+  | "E0607" ->
+      ( "This name is bound to more than one declaration kind.",
+        "Pass an explicit kind to select the intended binding." )
+  | "E0608" -> ("The requested store kind is invalid.", "Choose term, con, op, type, or effect.")
+  | "E0609" ->
+      ( "The diff operands are invalid or incompatible.",
+        "Pass two readable source files or two readable store directories of the same kind." )
+  | "E0610" ->
+      ( "A diff source contains a runnable top-level expression.",
+        "Compare declaration-only source artifacts or stores." )
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown store diagnostic code " ^ code))
+
+let diagnostic ~code cause =
+  let summary, next_step = diagnostic_spec code in
+  Diag.error ~domain:Store ~code ~summary ~cause ~next_step ~contrast:None ()
+
+let err ~code fmt = Printf.ksprintf (fun cause -> Error [ diagnostic ~code cause ]) fmt
 
 let kind_sym = function
   | Resolve.KTerm -> "term"
@@ -54,9 +89,12 @@ let kind_of_sym = function
   | _ -> None
 
 let private_name_diagnostic name hash =
-  Diag.error ~code:Concurrency_contract.task_escape_code
-    ~hint:"Task and Channel handles are created only inside a structured scheduler scope"
-    (Printf.sprintf "name `%s` cannot expose scheduler-private hash %s" name (Hash.to_hex hash))
+  Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code
+    ~summary:"A scheduler-private handle cannot be published through the store."
+    ~cause:
+      (Printf.sprintf "Name `%s` cannot expose scheduler-private hash %s." name (Hash.to_hex hash))
+    ~next_step:"Create and use Task and Channel handles only inside a structured scheduler scope."
+    ~contrast:None ()
 
 let scheduler_private_hash hash =
   Concurrency_contract.is_task_private_hash hash || Channel_contract.is_channel_private_hash hash
@@ -169,7 +207,7 @@ let open_store root : (t, Diag.t list) result =
         | file :: rest -> (
             let path = Filename.concat (objects_dir t) file in
             match load_object ~file:path (read_file path) with
-            | Error ds -> Error (Diag.error ~code:"E0603" ("corrupt object " ^ file) :: ds)
+            | Error ds -> Error (diagnostic ~code:"E0603" ("Corrupt object " ^ file ^ ".") :: ds)
             | Ok (decl, hs) ->
                 if Filename.remove_extension file <> Hash.to_hex hs.Canon.decl_hash then
                   err ~code:"E0603" "object %s does not hash to its file name" file

--- a/src/structured_scope.ml
+++ b/src/structured_scope.ml
@@ -39,9 +39,10 @@ type ('resume, 'value) t = {
 }
 
 let escape_diagnostic detail =
-  Diag.error ~code:Concurrency_contract.task_escape_code
-    ~hint:"do not return or store a Task beyond its creating async.scope"
-    (Concurrency_contract.task_escape_message ^ ": " ^ detail)
+  Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code
+    ~summary:Concurrency_contract.task_escape_message
+    ~cause:(Concurrency_contract.task_escape_message ^ ": " ^ detail)
+    ~next_step:"Keep the handle inside the async.scope that created it." ~contrast:None ()
 
 let closed_error () = Error [ escape_diagnostic "the handle's structured scope is already closed" ]
 let ensure_open scope operation = if scope.closed then closed_error () else operation ()
@@ -112,8 +113,11 @@ let channel_open scope ~capacity =
         | exception Channel_contract.Bug_invalid_channel_id detail ->
             Error
               [
-                Diag.error ~code:"E0908" ~hint:"channel state was not allocated"
-                  ("invalid structured-concurrency scheduler state: " ^ detail);
+                Diag.error ~domain:Concurrency ~code:"E0908"
+                  ~summary:"Structured-concurrency scheduler state is invalid"
+                  ~cause:("The channel state could not be allocated: " ^ detail)
+                  ~next_step:"Recreate the async scope and open the channel again." ~contrast:None
+                  ();
               ])
 
 let same_channel_id left right = Channel_contract.compare_channel_id left right = 0
@@ -141,8 +145,11 @@ let channel_handle _capability scope = function
   | _ ->
       Error
         [
-          Diag.error ~code:Concurrency_contract.task_escape_code
-            "Channel operation expected an opaque ChannelHandle";
+          Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code
+            ~summary:"Channel operation received an invalid handle"
+            ~cause:"The channel operation expected an opaque ChannelHandle value."
+            ~next_step:"Pass the ChannelHandle returned by channel.open within this async.scope."
+            ~contrast:None ();
         ]
 
 let prepare_channel_wake scope channel_id task_id result ~map_resume =

--- a/src/surface_check.ml
+++ b/src/surface_check.ml
@@ -163,40 +163,42 @@ module String_set = Set.Make (String)
 let warning_case (pattern : Surface_ast.pat) name =
   Diag.warning
     ?span:(Meta.span pattern.Surface_ast.meta)
-    ~code:"W1201"
-    ~hint:
+    ~domain:Surface ~code:"W1201"
+    ~summary:"Lowercase pattern binds instead of matching a constructor"
+    ~cause:
       (Printf.sprintf
-         "`%s` is an always-matching binder; use the PascalCase constructor spelling to match the \
-          constructor"
-         name)
-    (Printf.sprintf "binding pattern `%s` shadows an in-scope constructor that differs only in case"
-       name)
+         "Binding pattern `%s` shadows an in-scope constructor that differs only in case." name)
+    ~next_step:"Use the constructor's PascalCase spelling in this pattern."
+    ~contrast:
+      (Some
+         (Diag.contrast
+            ~mistaken:(Printf.sprintf "`%s` matches the constructor" name)
+            ~intended:"A lowercase pattern always binds a new name"))
+    ()
 
 let warning_wide (pattern : Surface_ast.pat) fields =
   Diag.warning
     ?span:(Meta.span pattern.Surface_ast.meta)
-    ~code:"W1202"
-    ~hint:
-      "D36 keeps labeled constructor patterns unavailable for now; keep positional matches to four \
-       fields or fewer"
-    (Printf.sprintf
-       "this positional constructor pattern has %d fields; labeled constructor patterns are the \
-        future fix"
-       fields)
+    ~domain:Surface ~code:"W1202" ~summary:"Constructor pattern is difficult to review"
+    ~cause:
+      (Printf.sprintf
+         "This positional constructor pattern has %d fields; labeled constructor patterns are not \
+          available in 0.1."
+         fields)
+    ~next_step:"Keep positional constructor patterns to four fields or fewer." ~contrast:None ()
 
 let large_match_scrutinee_lines = 4
 
 let warning_large_scrutinee (subject : Surface_ast.expr) lines =
   Diag.warning
     ?span:(Meta.span subject.Surface_ast.meta)
-    ~code:"W1203"
-    ~hint:
-      "introduce a `let` binding before the match and match on that name; formatting never hoists \
-       expressions automatically"
-    (Printf.sprintf
-       "this match scrutinee spans %d lines; scrutinees longer than %d lines are difficult to \
-        review"
-       lines large_match_scrutinee_lines)
+    ~domain:Surface ~code:"W1203" ~summary:"Match scrutinee is difficult to review"
+    ~cause:
+      (Printf.sprintf
+         "This match scrutinee spans %d lines; scrutinees longer than %d lines obscure the branch \
+          conditions."
+         lines large_match_scrutinee_lines)
+    ~next_step:"Bind the expression with `let`, then match on that name." ~contrast:None ()
 
 let span_line_count meta =
   Option.map (fun span -> span.Span.end_pos.line - span.Span.start_pos.line + 1) (Meta.span meta)
@@ -328,7 +330,7 @@ let definition_units tops =
   loop [] tops
 
 let diagnostic_offset diagnostic =
-  match diagnostic.Diag.span with Some span -> span.Span.start_pos.offset | None -> max_int
+  match Diag.span diagnostic with Some span -> span.Span.start_pos.offset | None -> max_int
 
 let sort_diagnostics diagnostics =
   List.stable_sort
@@ -336,7 +338,10 @@ let sort_diagnostics diagnostics =
     diagnostics
 
 let same_diagnostic left right =
-  left.Diag.code = right.Diag.code && left.span = right.span && left.message = right.message
+  Diag.code left = Diag.code right
+  && Diag.span left = Diag.span right
+  && String.equal (Diag.summary left) (Diag.summary right)
+  && String.equal (Diag.cause left) (Diag.cause right)
 
 let deduplicate diagnostics =
   List.fold_left

--- a/src/surface_lex.ml
+++ b/src/surface_lex.ml
@@ -78,8 +78,36 @@ exception Bug_lex_error of Diag.t
 let pos state = { Span.line = state.line; col = state.col; offset = state.off }
 let span state start_pos = Span.make ~file:state.file ~start_pos ~end_pos:(pos state)
 
-let fail state start_pos code message =
-  raise (Bug_lex_error (Diag.error ~span:(span state start_pos) ~code message))
+let diagnostic_summary = function
+  | "E1210" -> "The source contains an unexpected surface character."
+  | "E1211" -> "A surface identifier is malformed."
+  | "E1212" -> "A surface numeric literal is malformed or too large."
+  | "E1213" -> "A surface string literal is not closed."
+  | "E1214" -> "A surface string contains an invalid escape."
+  | "E1215" -> "A kind-tagged escaped name is malformed."
+  | "E1216" -> "A kind-tagged hash reference is malformed."
+  | "E1217" -> "An internal group reference is malformed."
+  | "E1218" -> "A surface string contains invalid UTF-8."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown surface lexer code " ^ code))
+
+let diagnostic_next_step = function
+  | "E1210" -> "Remove the character or replace it with valid surface syntax."
+  | "E1211" -> "Rewrite the identifier using the surface name grammar or a kind-tagged escape."
+  | "E1212" -> "Rewrite the value as one valid supported integer or real literal."
+  | "E1213" -> "Close the string with a double quote before the end of the line or file."
+  | "E1214" -> "Replace the escape with one supported by surface strings."
+  | "E1215" -> "Use a valid term, con, or op kind tag and close the escaped name."
+  | "E1216" -> "Write a full lowercase hash followed by a valid reference-kind suffix."
+  | "E1217" -> "Write the internal reference as #group followed by a non-negative index."
+  | "E1218" -> "Replace the invalid bytes with valid UTF-8 text."
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown surface lexer code " ^ code))
+
+let fail state start_pos code cause =
+  raise
+    (Bug_lex_error
+       (Diag.error ~span:(span state start_pos) ~domain:Surface ~code
+          ~summary:(diagnostic_summary code) ~cause ~next_step:(diagnostic_next_step code)
+          ~contrast:None ()))
 
 let peek state = if state.off < String.length state.src then Some state.src.[state.off] else None
 
@@ -540,14 +568,15 @@ let recover_after_error state start_pos start_char diagnostic =
   match start_char with
   | Some '"' ->
       let after_offset =
-        if diagnostic.Diag.code = "E1213" then start_pos.Span.offset
+        if Diag.code diagnostic = Some "E1213" then start_pos.Span.offset
         else
-          match diagnostic.span with
+          match Diag.span diagnostic with
           | Some error_span -> error_span.Span.end_pos.offset
           | None -> state.off
       in
       resynchronize_string state start_pos ~after_offset;
-      if diagnostic.Diag.code = "E1213" then { diagnostic with span = Some (span state start_pos) }
+      if Diag.code diagnostic = Some "E1213" then
+        Diag.with_span (Some (span state start_pos)) diagnostic
       else diagnostic
   | _ ->
       (if state.off = start_pos.Span.offset then
@@ -570,7 +599,7 @@ let lex_recover ~file src : recovery =
     | token -> loop (token :: tokens) diagnostics
     | exception Bug_lex_error diagnostic ->
         let diagnostic = recover_after_error state start_pos start_char diagnostic in
-        let invalid_span = Option.value diagnostic.Diag.span ~default:(span state start_pos) in
+        let invalid_span = Option.value (Diag.span diagnostic) ~default:(span state start_pos) in
         let invalid = { token = Invalid diagnostic; span = invalid_span } in
         ignore (update_context state invalid);
         loop (invalid :: tokens) (diagnostic :: diagnostics)
@@ -607,7 +636,7 @@ let show_token = function
   | Semi -> ";"
   | Newline -> "newline"
   | RawCandidate { closed; _ } -> if closed then "raw-candidate" else "raw-candidate(unclosed)"
-  | Invalid diagnostic -> "invalid(" ^ diagnostic.Diag.code ^ ")"
+  | Invalid diagnostic -> "invalid(" ^ Option.value ~default:"uncoded" (Diag.code diagnostic) ^ ")"
   | Eof -> "eof"
 
 let show located = Printf.sprintf "%s %s" (Span.to_string located.span) (show_token located.token)

--- a/src/surface_lower.ml
+++ b/src/surface_lower.ml
@@ -5,8 +5,57 @@
 
 let ( let* ) = Result.bind
 
-let error ?meta ~code message =
-  Error [ Diag.error ?span:(Option.bind meta Meta.span) ~code message ]
+let diagnostic_spec = function
+  | "E0204" ->
+      ( Diag.Kernel,
+        "An unquote appears outside a quote.",
+        "Move the unquote inside a quote or remove the unquote wrapper." )
+  | "E0205" ->
+      ( Diag.Kernel,
+        "A lambda parameter uses a refutable pattern.",
+        "Use an irrefutable variable, wildcard, tuple, or as-pattern parameter." )
+  | "E0206" ->
+      ( Diag.Kernel,
+        "A let binder uses a refutable pattern.",
+        "Use an irrefutable variable, wildcard, tuple, or as-pattern binder." )
+  | "E0209" -> (Diag.Kernel, "A match expression has no clauses.", "Add at least one match clause.")
+  | "E1202" ->
+      ( Diag.Surface,
+        "Recovered syntax cannot be lowered.",
+        "Fix the reported syntax damage before lowering the source." )
+  | "E1230" ->
+      ( Diag.Surface,
+        "This surface node is outside the supported lowering boundary.",
+        "Rewrite the node using the currently supported surface forms." )
+  | "E1231" ->
+      (Diag.Surface, "An expression block is empty.", "Add a final expression to the block.")
+  | "E1232" ->
+      ( Diag.Surface,
+        "A local let is the final item in a block.",
+        "Add an expression after the local let to produce the block value." )
+  | "E1233" ->
+      ( Diag.Surface,
+        "A local recursive or function binding is malformed.",
+        "Rewrite the binding with one supported name, parameter list, and body." )
+  | "E1234" ->
+      ( Diag.Surface,
+        "A generated lowering node has no real source span.",
+        "Preserve source spans on every surface node passed to lowering." )
+  | "E1235" ->
+      ( Diag.Surface,
+        "A surface declaration is missing its required file context.",
+        "Lower the complete ordered top-level file instead of this isolated declaration." )
+  | "E1236" ->
+      ( Diag.Surface,
+        "An effect operation mode is missing or invalid.",
+        "Declare the operation explicitly as once or multi." )
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown surface lowering code " ^ code))
+
+let diagnostic ?span ~code cause =
+  let domain, summary, next_step = diagnostic_spec code in
+  Diag.error ?span ~domain ~code ~summary ~cause ~next_step ~contrast:None ()
+
+let error ?meta ~code cause = Error [ diagnostic ?span:(Option.bind meta Meta.span) ~code cause ]
 
 let rec map_results f = function
   | [] -> Ok []
@@ -303,8 +352,8 @@ and lower_block ~quote_depth block_meta = function
       in
       Error
         [
-          Diag.error ?span ~code:"E1232"
-            "a block must end in an expression; a final local `let` has no value";
+          diagnostic ?span ~code:"E1232"
+            "A block must end in an expression; a final local `let` has no value.";
         ]
   | Surface_ast.Expr value :: rest ->
       let* value = lower_expr_node ~quote_depth value in
@@ -610,8 +659,12 @@ let duplicate_definition_diagnostics definitions =
       | Surface_ast.Definition { name; _ } ->
           if Hashtbl.mem seen name then
             Some
-              (Diag.error ?span:(Meta.span top.meta) ~code:"E0303"
-                 (Printf.sprintf "binding `%s` appears more than once in this definition run" name))
+              (Diag.error ?span:(Meta.span top.meta) ~domain:Resolution ~code:"E0303"
+                 ~summary:"A definition run contains a duplicate binding name."
+                 ~cause:
+                   (Printf.sprintf "Binding `%s` appears more than once in this definition run."
+                      name)
+                 ~next_step:"Rename or remove the duplicate definition binding." ~contrast:None ())
           else begin
             Hashtbl.add seen name ();
             None

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -49,9 +49,60 @@ let diagnostic_token state token =
   | Some limit, Surface_lex.Eof when state.index >= limit -> state.tokens.(limit)
   | (Some _ | None), _ -> token
 
+let diagnostic_contract code =
+  match code with
+  | "E0212" ->
+      ( Diag.Kernel,
+        "Handler return clauses are invalid",
+        "Keep exactly one return clause in the handler." )
+  | "E1202" ->
+      ( Diag.Surface,
+        "Recovered syntax cannot be compiled",
+        "Fix every syntax error before checking or hashing the file." )
+  | "E1221" ->
+      ( Diag.Surface,
+        "A delimited construct is not closed",
+        "Close the construct with the expected delimiter." )
+  | "E1223" ->
+      ( Diag.Surface,
+        "Block items need a separator",
+        "Insert a newline or `;` between the block items." )
+  | "E1224" ->
+      ( Diag.Surface,
+        "A signature is detached from its definition",
+        "Place the matching definition immediately after its signature." )
+  | "E1225" ->
+      ( Diag.Surface,
+        "A type or effect declaration is incomplete",
+        "Complete the declaration structure shown at this location." )
+  | "E1226" ->
+      ( Diag.Surface,
+        "Handler or staging syntax is invalid",
+        "Rewrite this construct using the required handler or staging form." )
+  | "E1227" ->
+      ( Diag.Surface,
+        "Surface syntax nesting is too deep",
+        "Reduce the nesting before parsing the file again." )
+  | "E1233" ->
+      ( Diag.Surface,
+        "A local recursive binding is malformed",
+        "Use a lowercase function name followed by its parameters." )
+  | "E1236" ->
+      ( Diag.Surface,
+        "An effect operation mode is invalid",
+        "Give each operation exactly one compatible `once` or `multi` mode." )
+  | "E1220" | _ ->
+      ( Diag.Surface,
+        "Surface syntax is invalid",
+        "Correct the syntax at this location and parse the file again." )
+
 let report_code state token code message =
   let token = diagnostic_token state token in
-  state.diagnostics <- Diag.error ~span:token.Surface_lex.span ~code message :: state.diagnostics
+  let domain, summary, next_step = diagnostic_contract code in
+  state.diagnostics <-
+    Diag.error ~span:token.Surface_lex.span ~domain ~code ~summary ~cause:message ~next_step
+      ~contrast:None ()
+    :: state.diagnostics
 
 let report state token message = report_code state token "E1220" message
 
@@ -65,19 +116,25 @@ let with_nesting state f =
     let token = diagnostic_token state (current state) in
     raise
       (Nesting_limit
-         (Diag.error ~span:token.Surface_lex.span ~code:"E1227"
-            (Printf.sprintf "surface syntax nesting exceeds the limit of %d" max_nesting_depth)))
+         (Diag.error ~span:token.Surface_lex.span ~code:"E1227" ~domain:Surface
+            ~summary:"Surface syntax nesting is too deep"
+            ~cause:
+              (Printf.sprintf "Surface syntax nesting exceeds the limit of %d." max_nesting_depth)
+            ~next_step:"Reduce the nesting before parsing the file again." ~contrast:None ()))
   end;
   state.nesting_depth <- state.nesting_depth + 1;
   Fun.protect ~finally:(fun () -> state.nesting_depth <- state.nesting_depth - 1) f
 
 let report_construct_code state ~opening ~failure ~code ~construct message =
   let failure = diagnostic_token state failure in
-  let hint =
-    Printf.sprintf "the %s opened at %s" construct (Span.to_string opening.Surface_lex.span)
+  let opening_context =
+    Printf.sprintf " The %s opened at %s." construct (Span.to_string opening.Surface_lex.span)
   in
+  let domain, summary, next_step = diagnostic_contract code in
   state.diagnostics <-
-    Diag.error ~span:failure.Surface_lex.span ~hint ~code message :: state.diagnostics
+    Diag.error ~span:failure.Surface_lex.span ~domain ~code ~summary
+      ~cause:(message ^ opening_context) ~next_step ~contrast:None ()
+    :: state.diagnostics
 
 let report_unclosed state ~opening ~failure ~construct message =
   report_construct_code state ~opening ~failure ~code:"E1221" ~construct message
@@ -221,11 +278,11 @@ let shift_raw_span content_span span =
 
 let shift_raw_diagnostic raw content_span (diagnostic : Diag.t) =
   let span =
-    match diagnostic.span with
+    match Diag.span diagnostic with
     | Some span -> Some (shift_raw_span content_span span)
     | None -> Some raw.Surface_lex.span
   in
-  { diagnostic with Diag.span }
+  Diag.with_span span diagnostic
 
 let rec shift_raw_form content_span (form : Form.t) =
   let meta =
@@ -248,7 +305,9 @@ let parse_raw_candidate state raw (candidate : Surface_lex.raw_candidate) =
         Span.make ~file:candidate.content_span.file ~start_pos:position ~end_pos:position
       in
       state.diagnostics <-
-        Diag.error ~span ~code:"E1221" "expected `}` before end of raw `jqd` form"
+        Diag.error ~span ~domain:Surface ~code:"E1221" ~summary:"A raw `jqd` form is not closed"
+          ~cause:"Expected `}` before the end of the raw `jqd` form."
+          ~next_step:"Add `}` to close the raw `jqd` form." ~contrast:None ()
         :: state.diagnostics
   in
   match Reader.parse_one ~file:candidate.content_span.Span.file candidate.source with
@@ -1868,7 +1927,7 @@ and parse_forall state ~allow_newlines keyword =
         own_indexed "forall-rvar" (List.length !rowvars) token;
         rowvars := name :: !rowvars;
         ignore (advance state)
-    | Surface_lex.Invalid { Diag.code = "E1211"; _ } -> (
+    | Surface_lex.Invalid diagnostic when Diag.code diagnostic = Some "E1211" -> (
         match forall_name_before_dot state token with
         | Some name ->
             if !in_rows then begin
@@ -3230,8 +3289,12 @@ let parse_tokens ~source tokens =
         | None -> top
         | Some span ->
             let diagnostic =
-              Diag.error ?span ~code:"E1227"
-                (Printf.sprintf "surface syntax nesting exceeds the limit of %d" max_nesting_depth)
+              Diag.error ?span ~domain:Surface ~code:"E1227"
+                ~summary:"Surface syntax nesting is too deep"
+                ~cause:
+                  (Printf.sprintf "Surface syntax nesting exceeds the limit of %d."
+                     max_nesting_depth)
+                ~next_step:"Reduce the nesting before parsing the file again." ~contrast:None ()
             in
             state.diagnostics <- diagnostic :: state.diagnostics;
             quarantine_overdeep_top state span top)
@@ -3245,7 +3308,7 @@ let recover_string ~file src : Surface_ast.recovered =
   let recovered = Surface_lex.lex_recover ~file src in
   let parsed = parse_tokens ~source:src recovered.tokens in
   let diagnostic_offset diagnostic =
-    match diagnostic.Diag.span with Some span -> span.Span.start_pos.offset | None -> max_int
+    match Diag.span diagnostic with Some span -> span.Span.start_pos.offset | None -> max_int
   in
   let diagnostics =
     List.stable_sort
@@ -3258,14 +3321,15 @@ let recover_string ~file src : Surface_ast.recovered =
     is the boundary that prevents holes from reaching lowering, canonicalization, or execution. *)
 let strict (recovered : Surface_ast.recovered) : (Surface_ast.top list, Diag.t list) result =
   let errors =
-    List.filter (fun d -> d.Diag.severity = Diag.Error) recovered.Surface_ast.diagnostics
+    List.filter (fun d -> Diag.severity d = Diag.Error) recovered.Surface_ast.diagnostics
   in
   if errors <> [] then Error recovered.diagnostics
   else if List.exists Surface_ast.has_holes_top recovered.items then
     Error
       [
-        Diag.error ~code:"E1202"
-          "surface parser recovery left holes; fix the syntax before checking or hashing";
+        Diag.error ~domain:Surface ~code:"E1202" ~summary:"Recovered syntax cannot be compiled"
+          ~cause:"Surface parser recovery left holes in the syntax tree."
+          ~next_step:"Fix every syntax error before checking or hashing the file." ~contrast:None ();
       ]
   else Ok recovered.items
 

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -1054,8 +1054,11 @@ let pp_op_fragment context lookup fmt (clause : Kernel.opclause) =
 let fragment_error form =
   Error
     [
-      Diag.error ~code:"E1203"
-        (Printf.sprintf "`%s` is not a self-contained surface fragment" form.Form.head);
+      Diag.error ~domain:Surface ~code:"E1203"
+        ~summary:"Kernel form has no self-contained surface fragment"
+        ~cause:(Printf.sprintf "`%s` is not a self-contained surface fragment." form.Form.head)
+        ~next_step:"Render this form in its enclosing declaration or expression context."
+        ~contrast:None ();
     ]
 
 (** [print_fragment] renders a kernel form even when it is an interior pattern, type, row, or

--- a/src/task_handle.ml
+++ b/src/task_handle.ml
@@ -4,10 +4,12 @@ type t = { run : run; scope_path : int list; spawn_index : int }
 let create_run = Concurrency_owner.create
 
 let diagnostic detail =
-  Diag.error ~code:Concurrency_contract.task_escape_code
-    ~hint:
-      "use the handle only with async.await or async.cancel inside its creating structured scope"
-    (Concurrency_contract.task_escape_message ^ ": " ^ detail)
+  Diag.error ~domain:Concurrency ~code:Concurrency_contract.task_escape_code
+    ~summary:"This task handle is outside its structured scope."
+    ~cause:(Concurrency_contract.task_escape_message ^ ": " ^ detail)
+    ~next_step:
+      "Use the handle only with async.await or async.cancel inside its creating structured scope."
+    ~contrast:None ()
 
 let checked_id scope_path spawn_index =
   match Concurrency_contract.task_id ~scope_path ~spawn_index with

--- a/src/warp.ml
+++ b/src/warp.ml
@@ -535,12 +535,16 @@ let run_prop_exhaustive ctx ~budget (thunk : Value.t) : (verdict * string, Diag.
   match explore (Eval.apply_state ctx thunk []) 1.0 [] with
   | exception Budget site ->
       Error
-        (Diag.error ~code:"E0905"
-           (Printf.sprintf
-              "exhaustive verification exceeded its budget: %s; raise --budget or shrink the \
-               generators"
-              site))
-  | Error e -> Error (Diag.error ~code:"E0902" e)
+        (Diag.error ~domain:Warp ~code:"E0905"
+           ~summary:"Exhaustive verification exceeded its budget"
+           ~cause:(Printf.sprintf "Verification exhausted its budget at %s." site)
+           ~next_step:"Raise --budget or shrink the generators." ~contrast:None ())
+  | Error cause ->
+      Error
+        (Diag.error ~domain:Warp ~code:"E0902"
+           ~summary:"Property execution failed during exhaustive verification" ~cause
+           ~next_step:"Fix the reported runtime failure and run the property again." ~contrast:None
+           ())
   | Ok () -> (
       match !failure with
       | Some v -> Ok (v, "prop: falsified exhaustively")
@@ -933,7 +937,13 @@ let render_outcome (t : totals) (o : outcome) : string list =
         (match note with Some n -> " (" ^ n ^ ")" | None -> "")
         (if o.cached then " [cached]" else "")
       :: List.map (fun l -> "  - " ^ l) soft
-      @ match hard with Some h -> [ "  ! " ^ h ] | None -> [])
+      @
+      match hard with
+      | None -> []
+      | Some h -> (
+          match String.split_on_char '\n' h with
+          | [] -> []
+          | first :: rest -> ("  ! " ^ first) :: List.map (fun line -> "    " ^ line) rest))
   | None, Some note when String.length note >= 7 && String.sub note 0 7 = "refused" ->
       t.refused <- t.refused + 1;
       [ Printf.sprintf "REFUSED %s: %s" o.display (String.sub note 9 (String.length note - 9)) ]

--- a/test/cli/check.t
+++ b/test/cli/check.t
@@ -15,8 +15,9 @@ An unknown name is a diagnostic with a near-miss suggestion:
   > (app (var ad) (lit 1) (lit 2))
   > EOF
   $ jacquard check typo.jqd
-  typo.jqd:1:6-14: error[E0301]: unknown name `ad`
-    hint: did you mean one of: add, ask, eq?
+  typo.jqd:1:6-14: error[E0301]: This reference names something that is not in scope.
+    Cause: No name named `ad` is in scope; nearby names are `add`, `ask`, `eq`.
+    Next step: Correct the reference to an in-scope name or declaration.
   [1]
 
 Grammar violations are caught before resolution:
@@ -25,7 +26,9 @@ Grammar violations are caught before resolution:
   > (lam ((plit 1)) (lit 0))
   > EOF
   $ jacquard check badgrammar.jqd
-  badgrammar.jqd:1:7-15: error[E0205]: `lam` parameters must be irrefutable patterns (pwild, pvar, or ptuple/pas of those)
+  badgrammar.jqd:1:7-15: error[E0205]: A lambda parameter uses a refutable pattern.
+    Cause: `lam` parameters must be irrefutable patterns (pwild, pvar, or ptuple/pas of those)
+    Next step: Use an irrefutable variable, wildcard, tuple, or as-pattern parameter.
   [1]
 
 DX.5 pins both input carriers at the structural boundary. Inputs at 10,000 active nodes are
@@ -36,7 +39,7 @@ accepted; one more node fails closed with a carrier-specific diagnostic and exit
   $ jacquard check depth-at.jqd
   ok
   $ jacquard check depth-over.jqd > depth-over-jqd.out 2>&1; status=$?; grep -o 'error\[E0115\]:.*' depth-over-jqd.out; echo "exit:$status"
-  error[E0115]: bootstrap form nesting exceeds the limit of 10000
+  error[E0115]: Bootstrap form nesting exceeds the structural limit.
   exit:1
 
   $ awk 'BEGIN { for (i=0; i<9999; i++) printf "("; printf "0"; for (i=0; i<9999; i++) printf ")"; printf "\n" }' > depth-at.jac
@@ -44,7 +47,7 @@ accepted; one more node fails closed with a carrier-specific diagnostic and exit
   $ jacquard check depth-at.jac
   ok
   $ jacquard check depth-over.jac > depth-over-jac.out 2>&1; status=$?; grep -o 'error\[E1227\]:.*' depth-over-jac.out; echo "exit:$status"
-  error[E1227]: surface syntax nesting exceeds the limit of 10000
+  error[E1227]: Surface syntax nesting is too deep
   exit:1
 
 The iterative postfix and pipe parsers build left-deep trees without recursive descent. Their

--- a/test/cli/demos.t
+++ b/test/cli/demos.t
@@ -7,8 +7,9 @@ The public M1 surface demos stay green through the actual jac alias.
   $ jac run ../../demos/basics/m1-choose.jac
   cons(1, cons(2, nil))
   $ jac run ../../demos/basics/m1-gated.jac
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   [3]
   $ jac run ../../demos/basics/m1-gated.jac --allow eval
   42
@@ -31,8 +32,9 @@ The stdlib worked example (SL.9): word frequency, top 3, console-only manifest.
 Without the grant it refuses before reading anything:
 
   $ jac run ../../demos/tooling/word-count.jac
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `main`)
-    hint: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `main`).
+    Next step: grant it with --allow console, or handle the effect in the program
   [3]
 
 The probabilistic cookbook (PB.1): VOI, dream mode, self-consistency, drift

--- a/test/cli/diagnostics.t
+++ b/test/cli/diagnostics.t
@@ -1,0 +1,125 @@
+The default text renderer preserves the five-part reading order. A span, when present, anchors the
+header; the plain summary, technical cause, and exactly one primary next step follow. Contrast is
+omitted unless there is one specific nearby confusion.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ cat > parser.jqd <<'EOF'
+  > (lit 1
+  > EOF
+  $ jacquard run parser.jqd
+  parser.jqd:1:1-2:1: error[E0106]: The source ended before the form was complete.
+    Cause: unclosed form: expected `)`
+    Next step: Complete the open form and its closing parenthesis.
+  [1]
+
+The opt-in json-v1 renderer is JSON Lines: one complete, versioned object per diagnostic, in the
+same emission order and on stderr. Optional fields are null when structurally present and absent
+when they do not apply.
+
+  $ jacquard run parser.jqd --diagnostic-format=json-v1 2> parser.json; echo "exit:$?"
+  exit:1
+  $ python3 - parser.json <<'PY'
+  > import json, sys
+  > lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+  > item = json.loads(lines[0])
+  > print(len(lines), item["schema"], item["domain"], item["code"], item["severity"])
+  > print(item["span"]["start"], item["summary"])
+  > print(item["cause"])
+  > print(item["next_step"])
+  > print("contrast" in item)
+  > PY
+  1 jacquard-diagnostic-v1 reader E0106 error
+  {'line': 1, 'column': 1, 'offset': 0} The source ended before the form was complete.
+  unclosed form: expected `)`
+  Complete the open form and its closing parenthesis.
+  False
+
+Resolution uses a typed contrast only for a concrete mistaken/intended distinction.
+
+  $ cat > contrast.jqd <<'EOF'
+  > (ann (lit 1) (tref add))
+  > EOF
+  $ jacquard check contrast.jqd --diagnostic-format=json-v1 2> contrast.json; echo "exit:$?"
+  exit:1
+  $ python3 - contrast.json <<'PY'
+  > import json, sys
+  > item = json.load(open(sys.argv[1], encoding="utf-8"))
+  > print(item["code"], item["contrast"])
+  > PY
+  E0302 {'mistaken': 'a term', 'intended': 'a type'}
+
+Capability refusal keeps its established exit 3 while using the same schema and one next step.
+
+  $ cat > capability.jqd <<'EOF'
+  > (app (var print) (lit "hello"))
+  > EOF
+  $ jacquard run capability.jqd --diagnostic-format=json-v1 2> capability.json; echo "exit:$?"
+  exit:3
+  $ python3 - capability.json <<'PY'
+  > import json, sys
+  > item = json.load(open(sys.argv[1], encoding="utf-8"))
+  > print(item["domain"], item["code"], item["span"], item["next_step"])
+  > PY
+  checker E0814 None grant it with --allow console, or handle the effect in the program
+
+Historically code-less runtime failures remain code-less rather than receiving an invented stable
+identity. Their exit remains 2.
+
+  $ cat > runtime.jqd <<'EOF'
+  > (app (var div) (lit 1) (lit 0))
+  > EOF
+  $ jacquard run runtime.jqd --diagnostic-format=json-v1 2> runtime.json; echo "exit:$?"
+  exit:2
+  $ python3 - runtime.json <<'PY'
+  > import json, sys
+  > item = json.load(open(sys.argv[1], encoding="utf-8"))
+  > print(item["domain"], item["code"], item["summary"], item["cause"])
+  > PY
+  runtime None Arithmetic operation failed arithmetic error: division by zero
+
+Governance failures use their own domain even when they share the same renderer and exit channel.
+
+  $ jacquard governance reconcile governance-reconciliation-gap-v1.jqd --diagnostic-format=json-v1 2> governance.json >/dev/null; echo "exit:$?"
+  exit:1
+  $ python3 - governance.json <<'PY'
+  > import json, sys
+  > item = json.load(open(sys.argv[1], encoding="utf-8"))
+  > print(item["domain"], item["code"], item["severity"], item["span"])
+  > print(item["next_step"])
+  > PY
+  governance E1516 error None
+  Reconcile the remaining action evidence before retrying or rolling back.
+
+Recovery diagnostics remain ordered JSON Lines rather than being collapsed into one object or a
+single prose message.
+
+  $ cat > recovery.jac <<'EOF'
+  > let x = ;
+  > let y = ;
+  > EOF
+  $ jacquard check recovery.jac --diagnostic-format=json-v1 2> recovery.json; echo "exit:$?"
+  exit:1
+  $ python3 - recovery.json <<'PY'
+  > import json, sys
+  > items = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+  > print(len(items), [item["code"] for item in items])
+  > print([(item["span"]["start"]["line"], item["span"]["start"]["column"]) for item in items])
+  > print(all(item["next_step"] and "contrast" not in item for item in items))
+  > PY
+  4 ['E1220', 'E1220', 'E1220', 'E1220']
+  [(1, 1), (1, 5), (2, 1), (2, 5)]
+  True
+
+Arbitrary source bytes cannot break the JSON Lines encoding. Each malformed UTF-8 byte in a
+string field is rendered as U+FFFD, and the complete diagnostic remains strict UTF-8 JSON.
+
+  $ printf '\377\n' > invalid-utf8.jac
+  $ jacquard check invalid-utf8.jac --diagnostic-format=json-v1 2> invalid-utf8.json; echo "exit:$?"
+  exit:1
+  $ python3 - invalid-utf8.json <<'PY'
+  > import json, sys
+  > text = open(sys.argv[1], "rb").read().decode("utf-8")
+  > items = [json.loads(line) for line in text.splitlines()]
+  > print([(item["code"], item["cause"].encode("unicode_escape").decode("ascii")) for item in items])
+  > PY
+  [('E1210', 'unexpected surface character `\\ufffd`')]

--- a/test/cli/dist.t
+++ b/test/cli/dist.t
@@ -17,8 +17,9 @@ value; the seed makes runs reproducible.
 Without the grant, the manifest refuses to start (exit 3):
 
   $ jacquard run die.jqd
-  error[E0814]: this program requires dist [uncertainty/none] — denote and condition finite possibilities, which is not granted (performed via `sample`)
-    hint: grant it with --allow dist, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires dist [uncertainty/none] — denote and condition finite possibilities, which is not granted (performed via `sample`).
+    Next step: grant it with --allow dist, or handle the effect in the program
   [3]
 
 Observe reaching the sampling root is a defect (decision D7's default): jacquard
@@ -29,7 +30,9 @@ run cannot condition, only jacquard infer can.
   > JACQUARD
 
   $ jacquard run obs.jqd --allow dist --seed 1
-  error[E0904]: observe reached the sampling root handler; observation requires an inference driver (use jacquard infer)
+  error[E0904]: Observation is invalid at the sampling root
+    Cause: observe reached the sampling root handler; observation requires an inference driver (use jacquard infer)
+    Next step: Move the observation under an inference handler.
   [2]
 
 The die model runs unchanged under exact enumeration — same program, different

--- a/test/cli/escrow.t
+++ b/test/cli/escrow.t
@@ -16,12 +16,15 @@ console covers println. Eval is absent.
   escrow.workflow : () ->{Console, Fs, Net} Int
   _ : Int
   $ jacquard run approved-run.jqd
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `escrow.workflow`)
-    hint: grant it with --allow console, or handle the effect in the program
-  error[E0814]: this program requires fs [world/medium] — read or mutate the filesystem under the granted root handler, which is not granted (performed via `escrow.workflow`)
-    hint: grant it with --allow fs, or handle the effect in the program
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `escrow.workflow`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `escrow.workflow`).
+    Next step: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires fs [world/medium] — read or mutate the filesystem under the granted root handler, which is not granted (performed via `escrow.workflow`).
+    Next step: grant it with --allow fs, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `escrow.workflow`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [3]
 
 Dry-run forwards reads but audits writes/fetches; no receipt file is created.
@@ -121,8 +124,9 @@ refuses it, and semantic diff localizes the escalation.
   $ jacquard check workflow-escalated.jqd --print-sigs
   escrow.workflow : () ->{Console, Fs, Eval, Net} Int
   $ jacquard check escalated-run.jqd --manifest fs,net,console
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   [1]
   $ mkdir escalated
   $ for f in "$JACQUARD_PRELUDE"/*.jqd; do jacquard store add escalated "$f" >/dev/null; done

--- a/test/cli/export.t
+++ b/test/cli/export.t
@@ -20,7 +20,7 @@ create a bootstrap twin; explicit export is the evidence/debug boundary.
 The command and top-level help state the explicit workflow.
 
   $ jacquard --help=plain | grep '^       export '
-         export --output=OUT [--prelude=DIR] [--syntax=SYNTAX] [OPTION]…
+         export [OPTION]… INPUT.jac
   $ jacquard export --help=plain | grep 'atomically and never replaces'
          atomically and never replaces an existing path.
 
@@ -116,8 +116,12 @@ stdout, stderr, and exit rather than diverging or silently compiling one side.
   $ test "$surface_status" = "$bootstrap_status" && echo "native carrier refusal parity: preflight (exit $surface_status)"
   native carrier refusal parity: preflight (exit 1)
   $ cat preflight-surface.build.stderr
-  error[E1101]: not yet compilable in native v1: live-policy builtin `text.contains?` is not yet implemented natively
-  error[E1102]: run-plan uses eval, which requires the interpreter tier
+  error[E1101]: Program is outside the native v1 compilation subset
+    Cause: Not yet compilable in native v1: live-policy builtin `text.contains?` is not yet implemented natively
+    Next step: Run the program with the interpreter or rewrite the unsupported construct.
+  error[E1102]: Program requires the interpreter tier
+    Cause: run-plan uses eval, which requires the interpreter tier
+    Next step: Run this program with the interpreter.
 
 Comments, documentation, formatting, and their spans are intentionally erased;
 the exported structure retains the semantic hash rather than source fidelity.
@@ -142,7 +146,9 @@ An existing output is a stable collision and is never truncated.
 
   $ printf 'sentinel\n' > occupied.jqd
   $ jacquard export direct.jac -o occupied.jqd
-  error[E1301]: export output occupied.jqd already exists; choose a new path or remove it explicitly
+  error[E1301]: Export destination already exists
+    Cause: export output occupied.jqd already exists; choose a new path or remove it explicitly
+    Next step: Correct the export path or input and try again.
   [1]
   $ cat occupied.jqd
   sentinel
@@ -152,14 +158,17 @@ their spans and resolution retains suggestions.
 
   $ printf 'answer = @\n' > malformed.jac
   $ jacquard export malformed.jac -o malformed.jqd
-  malformed.jac:1:10-11: error[E1210]: unexpected surface character `@`
+  malformed.jac:1:10-11: error[E1210]: The source contains an unexpected surface character.
+    Cause: unexpected surface character `@`
+    Next step: Remove the character or replace it with valid surface syntax.
   [1]
   $ test ! -e malformed.jqd && echo no-partial-malformed
   no-partial-malformed
   $ printf 'ad(1, 2)\n' > unresolved.jac
-  $ jacquard export unresolved.jac -o unresolved.jqd > unresolved.err 2>&1; status=$?; grep -E 'error\[E0301\]|hint: did you mean' unresolved.err; echo "exit:$status"
-  unresolved.jac:1:1-3: error[E0301]: unknown name `ad`
-    hint: did you mean one of: add, ask, eq?
+  $ jacquard export unresolved.jac -o unresolved.jqd > unresolved.err 2>&1; status=$?; cat unresolved.err; echo "exit:$status"
+  unresolved.jac:1:1-3: error[E0301]: This reference names something that is not in scope.
+    Cause: No name named `ad` is in scope; nearby names are `add`, `ask`, `eq`.
+    Next step: Correct the reference to an in-scope name or declaration.
   exit:1
   $ test ! -e unresolved.jqd && echo no-partial-unresolved
   no-partial-unresolved
@@ -168,18 +177,24 @@ Stdin and non-seekable artifacts are refused before reading. Callers must
 materialize them so syntax and resolution have a named source boundary.
 
   $ printf '1\n' | jacquard export - -o stdin.jqd
-  error[E1302]: jacquard export requires a named regular input file; materialize stdin first
+  error[E1302]: Export input could not be read
+    Cause: jacquard export requires a named regular input file; materialize stdin first
+    Next step: Correct the export path or input and try again.
   [1]
   $ mkfifo source.fifo
   $ jacquard export source.fifo -o fifo.jqd
-  error[E1302]: export input source.fifo is not a regular seekable file; materialize the source first
+  error[E1302]: Export input could not be read
+    Cause: export input source.fifo is not a regular seekable file; materialize the source first
+    Next step: Correct the export path or input and try again.
   [1]
 
 An atomic-publication failure is actionable and leaves no destination or
 same-directory temporary artifact.
 
-  $ jacquard export direct.jac -o missing/out.jqd > atomic.err 2>&1; status=$?; grep 'error\[E1303\]: cannot publish export atomically' atomic.err | sed -E 's/tmp-[0-9]+-0/tmp-PID-0/'; echo "exit:$status"
-  error[E1303]: cannot publish export atomically: missing/out.jqd: No such file or directory (open, missing/.out.jqd.tmp-PID-0)
+  $ jacquard export direct.jac -o missing/out.jqd > atomic.err 2>&1; status=$?; sed -E 's/tmp-[0-9]+-0/tmp-PID-0/' atomic.err; echo "exit:$status"
+  error[E1303]: Export output could not be written
+    Cause: cannot publish export atomically: missing/out.jqd: No such file or directory (open, missing/.out.jqd.tmp-PID-0)
+    Next step: Correct the export path or input and try again.
   exit:1
   $ test ! -e missing/out.jqd && test -z "$(find . -maxdepth 1 -name '.out.jqd.tmp-*' -print)" && echo no-partial-atomic
   no-partial-atomic

--- a/test/cli/governance-reconciliation.t
+++ b/test/cli/governance-reconciliation.t
@@ -13,7 +13,9 @@ rewritten into the claim that no external action happened.
 
   $ jacquard governance reconcile governance-reconciliation-gap-v1.jqd
   reconciliation-needed audit=96042b6dc44c499c3b3f450b0afa7ef2a21591ccd33328825f974bb43d1598d5 journal=0ddca6fab318d0de125e7bfea1357c1c5acfc8c1b0052344cd331bc8004108ff no-action-legal=1 authorized-not-observed=1 unknown=0 receipt-gap=0 complete=0 completion-without-receipt=1
-  error[E1516]: valid action evidence still requires operator reconciliation; no rollback or safe retry is implied
+  error[E1516]: Action evidence still requires operator reconciliation
+    Cause: Valid action evidence still requires operator reconciliation; no rollback or safe retry is implied.
+    Next step: Reconcile the remaining action evidence before retrying or rolling back.
   [1]
 
 The journal chain commits exact action-subject bytes. Changing a carried
@@ -21,10 +23,14 @@ attempt ID breaks the record digest before the forged identity can be used.
 
   $ sed 's/#674300d440924d7f1400f3fab2e5f0bfe4c13dcda3224dfab9f691ddbd3372b4/#0000000000000000000000000000000000000000000000000000000000000000/' governance-reconciliation-v1.jqd > forged-reconciliation-v1.jqd
   $ jacquard governance reconcile forged-reconciliation-v1.jqd
-  error[E1511]: action journal record 0 has a mismatched digest
+  error[E1511]: The action journal chain or published head is inconsistent.
+    Cause: action journal record 0 has a mismatched digest
+    Next step: Restore the original predecessor-linked journal and its independently published head.
   [1]
 
   $ tr -d '\n' < governance-reconciliation-v1.jqd > no-lf-reconciliation-v1.jqd
   $ jacquard governance reconcile no-lf-reconciliation-v1.jqd
-  error[E1510]: no-lf-reconciliation-v1.jqd: governance reconciliation bundle must end with LF
+  error[E1510]: The governance reconciliation bundle is malformed, unsupported, or unsafe to read.
+    Cause: no-lf-reconciliation-v1.jqd: governance reconciliation bundle must end with LF
+    Next step: Regenerate one canonical governance-reconciliation-bundle-v1 from stable evidence.
   [1]

--- a/test/cli/governance-run-bundle.t
+++ b/test/cli/governance-run-bundle.t
@@ -13,7 +13,9 @@ individually valid.
 
   $ sed 's/#c743dec7907499b28565512b4f2b1a2314b700503eb3ef26949c2cf0ebe98fc6/#0000000000000000000000000000000000000000000000000000000000000000/3' governance-run-bundle-v1.jqd > forged-run-bundle-v1.jqd
   $ jacquard governance verify-run forged-run-bundle-v1.jqd
-  error[E1501]: Proposal artifact 0 carries #0000000000000000000000000000000000000000000000000000000000000000 but canonical governance-proposal-v0 bytes hash to #c743dec7907499b28565512b4f2b1a2314b700503eb3ef26949c2cf0ebe98fc6
+  error[E1501]: A governance artifact is malformed or carries the wrong identity.
+    Cause: Proposal artifact 0 carries #0000000000000000000000000000000000000000000000000000000000000000 but canonical governance-proposal-v0 bytes hash to #c743dec7907499b28565512b4f2b1a2314b700503eb3ef26949c2cf0ebe98fc6
+    Next step: Restore the exact canonical artifact and its matching carried identity.
   [1]
 
 Bundle bytes are a canonical review artifact: exactly one compact form and a
@@ -22,5 +24,7 @@ the same evidence package.
 
   $ tr -d '\n' < governance-run-bundle-v1.jqd > no-lf-run-bundle-v1.jqd
   $ jacquard governance verify-run no-lf-run-bundle-v1.jqd
-  error[E1500]: no-lf-run-bundle-v1.jqd: governance run bundle must end with LF
+  error[E1500]: The governance run bundle is malformed, unsupported, or unsafe to read.
+    Cause: no-lf-run-bundle-v1.jqd: governance run bundle must end with LF
+    Next step: Regenerate one canonical governance-run-bundle-v1 from stable verified artifacts.
   [1]

--- a/test/cli/hash.t
+++ b/test/cli/hash.t
@@ -20,12 +20,16 @@ Parse failures exit 1:
 
   $ printf '(' > bad.jqd
   $ jacquard hash bad.jqd
-  bad.jqd:1:1-2: error[E0106]: unexpected end of input inside a form
+  bad.jqd:1:1-2: error[E0106]: The source ended before the form was complete.
+    Cause: unexpected end of input inside a form
+    Next step: Complete the open form and its closing parenthesis.
   [1]
 
 Resolution failures exit 1 too:
 
   $ printf '(app (var zzz-missing))\n' > unresolved.jqd
   $ jacquard hash unresolved.jqd
-  unresolved.jqd:1:6-23: error[E0301]: unknown name `zzz-missing`
+  unresolved.jqd:1:6-23: error[E0301]: This reference names something that is not in scope.
+    Cause: No name named `zzz-missing` is in scope.
+    Next step: Correct the reference to an in-scope name or declaration.
   [1]

--- a/test/cli/hostile-demo.t
+++ b/test/cli/hostile-demo.t
@@ -7,14 +7,16 @@ The committed transcript for demos/worlds/m4-hostile.sh (W5.5).
   summarize : (Text) ->{Net} Text
   _ : Text
   $ jacquard check ../../demos/worlds/m4-hostile.jqd --manifest console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [1]
   $ jacquard check ../../demos/worlds/m4-hostile.jqd --manifest net,console
   ok
   $ jacquard run ../../demos/worlds/m4-hostile.jqd --allow console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `summarize`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `summarize`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [3]
   $ jacquard run ../../demos/worlds/m4-hostile.jqd --allow net
   "<stub response for http://example.com>"

--- a/test/cli/infer.t
+++ b/test/cli/infer.t
@@ -52,6 +52,7 @@ An ungranted effect inside a model still refuses (dist itself is implicit):
   >   (app (var sample) (app (var bernoulli) (lit 0.5))))
   > EOF_JQD
   $ jac infer enumerate naughty.jqd
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`)
-    hint: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`).
+    Next step: grant it with --allow console, or handle the effect in the program
   [1]

--- a/test/cli/manifest.t
+++ b/test/cli/manifest.t
@@ -22,8 +22,9 @@ Checking against a grant set that lacks net refuses at the type level, naming
 the effect and the call-chain endpoint:
 
   $ jacquard check hostile.jqd --manifest console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [1]
 
 With the grant it passes, and the granted run succeeds against the stub
@@ -38,12 +39,14 @@ Running without the net grant is the capability refusal (exit 3), even when
 some other runtime handler is granted:
 
   $ jacquard run hostile.jqd --allow console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `summarize`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `summarize`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [3]
   $ jacquard run hostile.jqd
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `summarize`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `summarize`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [3]
 
 Pure effects are never grantable, so the hint must not suggest a --allow flag
@@ -53,11 +56,14 @@ that would only bounce with E0703:
   > (app (var option.get!) (var none))
   > JACQUARD
   $ jacquard run pure.jqd
-  error[E0814]: this program requires abort [control/none] — stop a computation without an error payload, which is not granted (performed via `option.get!`)
-    hint: handle the effect in the program (this effect is pure and cannot be granted)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires abort [control/none] — stop a computation without an error payload, which is not granted (performed via `option.get!`).
+    Next step: handle the effect in the program (this effect is pure and cannot be granted)
   [3]
   $ jacquard run pure.jqd --allow abort
-  error[E0703]: effect `abort` is not grantable
+  error[E0703]: Requested effect is not root-grantable
+    Cause: effect `abort` is not grantable
+    Next step: Handle this effect inside the program instead of granting it at the root.
   [1]
 
 SC.4 keeps a spawned child's public effects in the parent row even when
@@ -95,8 +101,9 @@ only Async, so the documented fetch-all shape needs Net but not Async.
   fetch-all : (List Text) ->{Net} TaskResult (List (TaskResult Text))
   _ : TaskResult (List (TaskResult Text))
   $ jacquard check fetch-all.jac --manifest console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [1]
   $ jacquard check fetch-all.jac --manifest net
   ok
@@ -118,7 +125,9 @@ the equation diagnostic retains the propagated Net effect.
   > launder() = spawn-alias(fn () -> net.get("https://example.invalid"))
   > JACQUARD
   $ jacquard check alias-launder.jac
-  alias-launder.jac:11:1-69: error[E0804]: equation definition `launder` does not match its signature: expected () ->{async} task text, got () ->{async, net | e} task text (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
+  alias-launder.jac:11:1-69: error[E0804]: The value does not satisfy its annotation
+    Cause: equation definition `launder` does not match its signature: expected () ->{async} task text, got () ->{async, net | e} task text (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
+    Next step: Change the value or its annotation so the two types agree.
   [1]
 
 Adversarial polymorphic rows also fail at the async.spawn source instead of
@@ -138,8 +147,9 @@ solving a cyclic child/caller row.
   > cycle() = force-cycle(async.spawn)
   > JACQUARD
   $ jacquard check row-cycle.jac
-  row-cycle.jac:11:23-34: error[E0801]: argument: expected (() ->{async | e} a) ->{async, net | e} task a, got (() ->{async | e} a) ->{async | e} task a (occurs check: effect rows with the same tail differ)
-    hint: the expected side comes from the surrounding context; make both sides agree
+  row-cycle.jac:11:23-34: error[E0801]: Types do not agree
+    Cause: argument: expected (() ->{async | e} a) ->{async, net | e} task a, got (() ->{async | e} a) ->{async | e} task a (occurs check: effect rows with the same tail differ)
+    Next step: the expected side comes from the surrounding context; make both sides agree
   [1]
 
 World facade effects are also not root-grantable, but they are not pure. Their
@@ -149,11 +159,14 @@ diagnostic directs the caller to the required membrane handler:
   > (app (var workspace.read-file) (app (var path-value) (lit "README.md")))
   > JACQUARD
   $ jacquard run workspace.jqd
-  error[E0814]: this program requires workspace [world/high] — request mediated workspace reads, writes, or fetches without directly acquiring raw authority, which is not granted (performed via `workspace.read-file`)
-    hint: handle Workspace in the program (Workspace is a world facade and is not root-grantable)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires workspace [world/high] — request mediated workspace reads, writes, or fetches without directly acquiring raw authority, which is not granted (performed via `workspace.read-file`).
+    Next step: handle Workspace in the program (Workspace is a world facade and is not root-grantable)
   [3]
   $ jacquard run workspace.jqd --allow workspace
-  error[E0703]: effect `workspace` is not grantable
+  error[E0703]: Requested effect is not root-grantable
+    Cause: effect `workspace` is not grantable
+    Next step: Handle this effect inside the program instead of granting it at the root.
   [1]
 
 A user effect that reuses an official short name does not inherit its risk or grant:
@@ -163,6 +176,7 @@ A user effect that reuses an official short name does not inherit its risk or gr
   > (app (var package.fetch))
   > JACQUARD
   $ jacquard check spoof.jqd --manifest console
-  error[E0814]: this program requires unpackaged:a46cb801752d/net [unrated user effect #a46cb801752d15e51f6c46c91d0c4fa874b337d7186f8b3003230442baad74f1], which is not granted (performed via `package.fetch`)
-    hint: handle the effect in the program (unregistered user effects have no built-in --allow grant)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires unpackaged:a46cb801752d/net [unrated user effect #a46cb801752d15e51f6c46c91d0c4fa874b337d7186f8b3003230442baad74f1], which is not granted (performed via `package.fetch`).
+    Next step: handle the effect in the program (unregistered user effects have no built-in --allow grant)
   [1]

--- a/test/cli/native-effects.t
+++ b/test/cli/native-effects.t
@@ -72,9 +72,13 @@ validated Hash boundary.
   > (ref #d48426af83dd64417666d11346b732136f39950871f9c4708e947515f9eda3db con)
   > EOF_JQD
   $ jacquard check opaque-hash-ref.jqd 2>&1 | sed 's/opaque-hash-ref.jqd:[0-9]*:[0-9]*-[0-9]*/opaque-hash-ref.jqd:LINE:SPAN/'
-  opaque-hash-ref.jqd:LINE:SPAN: error[E0805]: error[E0601]: unknown hash d48426af83dd64417666d11346b732136f39950871f9c4708e947515f9eda3db
+  opaque-hash-ref.jqd:LINE:SPAN: error[E0805]: A referenced declaration has the wrong kind or is unavailable
+    Cause: E0601: The content store does not contain the requested hash. (unknown hash d48426af83dd64417666d11346b732136f39950871f9c4708e947515f9eda3db)
+    Next step: Use an available declaration of the required kind.
   $ jacquard build opaque-hash-ref.jqd -o opaque-native 2>&1 | sed 's/opaque-hash-ref.jqd:[0-9]*:[0-9]*-[0-9]*/opaque-hash-ref.jqd:LINE:SPAN/'
-  opaque-hash-ref.jqd:LINE:SPAN: error[E0805]: error[E0601]: unknown hash d48426af83dd64417666d11346b732136f39950871f9c4708e947515f9eda3db
+  opaque-hash-ref.jqd:LINE:SPAN: error[E0805]: A referenced declaration has the wrong kind or is unavailable
+    Cause: E0601: The content store does not contain the requested hash. (unknown hash d48426af83dd64417666d11346b732136f39950871f9c4708e947515f9eda3db)
+    Next step: Use an available declaration of the required kind.
 
 The flagship outputs, pinned so a both-engines regression cannot slip through
 the diff-only loop above:
@@ -162,7 +166,9 @@ gated-eval leg a pinned refusal.
   $ diff i.out n.out && echo identical
   identical
   $ jacquard build ../../demos/basics/m1-gated.jqd -o nope
-  error[E1102]: top-level expression 0 uses eval, which requires the interpreter tier
+  error[E1102]: Program requires the interpreter tier
+    Cause: top-level expression 0 uses eval, which requires the interpreter tier
+    Next step: Run this program with the interpreter.
   [1]
 
 Dist parity (task 72). The likelihood-weighting driver reproduces the
@@ -185,19 +191,28 @@ list (docs/native-plan.md records the boundary). The LW error legs:
   > EOF_JQD
   $ jacquard build lw-zero.jqd -o lw-zero > /dev/null
   $ ./lw-zero
-  arithmetic error: dist.sample-lw needs a positive sample count
+  error: Arithmetic operation failed
+    Cause: arithmetic error: dist.sample-lw needs a positive sample count
+    Next step: Correct the arithmetic inputs and run the program again.
   [2]
   $ cat > lw-empty.jqd <<'EOF_JQD'
   > (app (var dist.sample-lw) (lam () (let nonrec (pwild) (app (var observe) (app (var bernoulli) (lit 1.0)) (var false)) (lit 1))) (lit 5) (lit 42))
   > EOF_JQD
   $ jacquard build lw-empty.jqd -o lw-empty > /dev/null
-  $ ./lw-empty
-  arithmetic error: error[E0901]: the posterior is empty: every run is impossible under the observations
-  [2]
+  $ jacquard run lw-empty.jqd > lw-empty-i.out 2>&1; echo "interpreter exit $?"
+  interpreter exit 2
+  $ ./lw-empty > lw-empty-n.out 2>&1; echo "native exit $?"
+  native exit 2
+  $ diff lw-empty-i.out lw-empty-n.out && echo identical
+  identical
+  $ cat lw-empty-n.out
+  error[E0901]: The posterior is empty.
+    Cause: the posterior is empty: every run is impossible under the observations
+    Next step: Change the model or observations so at least one execution branch has nonzero weight.
 
 A model op that only an OUTER handler could cover is hidden by the run's
-isolation on both engines, and the failure flattens through the driver's
-diagnostics (E0902, exit 2) with the pseudo-effect named:
+isolation on both engines. The driver preserves E0902 as the primary diagnostic
+(exit 2) with the pseudo-effect named:
 
   $ cat > lw-outer-op.jqd <<'EOF_JQD'
   > (defeffect e-x ((tvar a)) (op xop () (tref int)))
@@ -207,9 +222,112 @@ diagnostics (E0902, exit 2) with the pseudo-effect named:
   >   (opclause xop () k (app (var k) (lit 1))))
   > EOF_JQD
   $ jacquard build lw-outer-op.jqd -o lw-outer-op > /dev/null
-  $ ./lw-outer-op
-  arithmetic error: error[E0902]: unhandled effect (not handled during inference): operation `xop` reached the root without a handler
-  [2]
+  $ jacquard run lw-outer-op.jqd > lw-outer-i.out 2>&1; echo "interpreter exit $?"
+  interpreter exit 2
+  $ ./lw-outer-op > lw-outer-n.out 2>&1; echo "native exit $?"
+  native exit 2
+  $ diff lw-outer-i.out lw-outer-n.out && echo identical
+  identical
+  $ cat lw-outer-n.out
+  error[E0902]: Probabilistic inference stopped on a runtime failure.
+    Cause: unhandled effect (not handled during inference): operation `xop` reached the root without a handler
+    Next step: Correct the reported model runtime failure and rerun inference.
+
+Ordinary runtime failures inside the model cross the same driver boundary;
+they do not escape as code-less native runtime diagnostics:
+
+  $ cat > lw-runtime-error.jqd <<'EOF_JQD'
+  > (app (var dist.sample-lw) (lam () (app (var div) (lit 1) (lit 0))) (lit 3) (lit 42))
+  > EOF_JQD
+  $ jacquard build lw-runtime-error.jqd -o lw-runtime-error > /dev/null
+  $ jacquard run lw-runtime-error.jqd > lw-runtime-i.out 2>&1; echo "interpreter exit $?"
+  interpreter exit 2
+  $ ./lw-runtime-error > lw-runtime-n.out 2>&1; echo "native exit $?"
+  native exit 2
+  $ diff lw-runtime-i.out lw-runtime-n.out && echo identical
+  identical
+  $ cat lw-runtime-n.out
+  error[E0902]: Probabilistic inference stopped on a runtime failure.
+    Cause: arithmetic error: division by zero
+    Next step: Correct the reported model runtime failure and rerun inference.
+
+An ordinary failure inside a nested driver contributes one E0902 layer per
+active likelihood-weighting boundary:
+
+  $ cat > lw-nested-runtime-error.jqd <<'EOF_JQD'
+  > (app (var dist.sample-lw)
+  >   (lam ()
+  >     (app (var dist.sample-lw)
+  >       (lam () (app (var div) (lit 1) (lit 0)))
+  >       (lit 2) (lit 11)))
+  >   (lit 2) (lit 42))
+  > EOF_JQD
+  $ jacquard build lw-nested-runtime-error.jqd -o lw-nested-runtime-error > /dev/null
+  $ jacquard run lw-nested-runtime-error.jqd > lw-nested-runtime-i.out 2>&1; echo "interpreter exit $?"
+  interpreter exit 2
+  $ ./lw-nested-runtime-error > lw-nested-runtime-n.out 2>&1; echo "native exit $?"
+  native exit 2
+  $ diff lw-nested-runtime-i.out lw-nested-runtime-n.out && echo identical
+  identical
+  $ cat lw-nested-runtime-n.out
+  error[E0902]: Probabilistic inference stopped on a runtime failure.
+    Cause: E0902: Probabilistic inference stopped on a runtime failure. (arithmetic error: division by zero)
+    Next step: Correct the reported model runtime failure and rerun inference.
+
+Nested drivers retain their dynamic boundary too: an inner typed E0901 becomes
+the outer model's compact E0902 cause on both engines.
+
+  $ cat > lw-nested-error.jqd <<'EOF_JQD'
+  > (app (var dist.sample-lw)
+  >   (lam ()
+  >     (app (var dist.sample-lw)
+  >       (lam ()
+  >         (let nonrec (pwild)
+  >           (app (var observe) (app (var bernoulli) (lit 1.0)) (var false))
+  >           (lit 1)))
+  >       (lit 2) (lit 11)))
+  >   (lit 2) (lit 42))
+  > EOF_JQD
+  $ jacquard build lw-nested-error.jqd -o lw-nested-error > /dev/null
+  $ jacquard run lw-nested-error.jqd > lw-nested-i.out 2>&1; echo "interpreter exit $?"
+  interpreter exit 2
+  $ ./lw-nested-error > lw-nested-n.out 2>&1; echo "native exit $?"
+  native exit 2
+  $ diff lw-nested-i.out lw-nested-n.out && echo identical
+  identical
+  $ cat lw-nested-n.out
+  error[E0902]: Probabilistic inference stopped on a runtime failure.
+    Cause: E0901: The posterior is empty. (the posterior is empty: every run is impossible under the observations)
+    Next step: Correct the reported model runtime failure and rerun inference.
+
+Three nested drivers add both required outer wrappers around the innermost
+E0901 projection:
+
+  $ cat > lw-triple-empty.jqd <<'EOF_JQD'
+  > (app (var dist.sample-lw)
+  >   (lam ()
+  >     (app (var dist.sample-lw)
+  >       (lam ()
+  >         (app (var dist.sample-lw)
+  >           (lam ()
+  >             (let nonrec (pwild)
+  >               (app (var observe) (app (var bernoulli) (lit 1.0)) (var false))
+  >               (lit 1)))
+  >           (lit 2) (lit 7)))
+  >       (lit 2) (lit 11)))
+  >   (lit 2) (lit 42))
+  > EOF_JQD
+  $ jacquard build lw-triple-empty.jqd -o lw-triple-empty > /dev/null
+  $ jacquard run lw-triple-empty.jqd > lw-triple-i.out 2>&1; echo "interpreter exit $?"
+  interpreter exit 2
+  $ ./lw-triple-empty > lw-triple-n.out 2>&1; echo "native exit $?"
+  native exit 2
+  $ diff lw-triple-i.out lw-triple-n.out && echo identical
+  identical
+  $ cat lw-triple-n.out
+  error[E0902]: Probabilistic inference stopped on a runtime failure.
+    Cause: E0902: Probabilistic inference stopped on a runtime failure. (E0901: The posterior is empty. (the posterior is empty: every run is impossible under the observations))
+    Next step: Correct the reported model runtime failure and rerun inference.
 
 The root sampling grant: --allow dist with --seed draws the interpreter's
 exact stream; observe at the root is the interpreter's E0904 defect:
@@ -229,7 +347,9 @@ exact stream; observe at the root is the interpreter's E0904 defect:
   > EOF_JQD
   $ jacquard build obs.jqd -o obs > /dev/null
   $ ./obs --allow dist
-  error[E0904]: observe reached the sampling root handler; observation requires an inference driver (use jacquard infer)
+  error[E0904]: Observation is invalid at the sampling root
+    Cause: observe reached the sampling root handler; observation requires an inference driver (use jacquard infer)
+    Next step: Move the observation under an inference handler.
   [2]
 
 Row erasure can also smuggle a wrongly-typed value into a GRANT (the op
@@ -259,13 +379,17 @@ interpreter-only until task 73's reader port, loudly:
   $ ./haiku --allow infer
   "<stub completion for: write a haiku>"
   $ ./haiku --allow infer --infer-cache cache-dir
-  error[E1103]: native binaries do not cache completions yet (the cache entry format needs task 73's reader); rerun without --infer-cache
+  error[E1103]: Native build could not complete
+    Cause: Native binaries do not cache completions yet because the cache entry format needs the native reader.
+    Next step: Run without --infer-cache.
   [1]
 
 --dry-run is an interpreter run; build rejects it up front:
 
   $ jacquard build die.jqd -o nope --dry-run
-  error[E1103]: jacquard build does not support --dry-run; the consent sheet is an interpreter run (use jacquard run --dry-run)
+  error[E1103]: Native build could not complete
+    Cause: jacquard build does not support --dry-run; the consent sheet is an interpreter run.
+    Next step: Correct the native toolchain or build input and try again.
   [1]
 
 An effectful top-level definition is refused by the checker before either
@@ -278,9 +402,10 @@ reachable from the surface:
   >   (let nonrec (pwild) (app (var tick)) (lit 7)))))
   > (var poked)
   > EOF_JQD
-  $ jacquard build iso.jqd -o nope 2>&1 | tail -2
-  iso.jqd:2:11-3:49: error[E0815]: top-level definition `poked` performs the `ticker` effect while being defined
-    hint: wrap the body in a lambda and perform the effect when called
+  $ jacquard build iso.jqd -o nope 2>&1 | tail -3
+  iso.jqd:2:11-3:49: error[E0815]: A top-level definition performs effects
+    Cause: top-level definition `poked` performs the `ticker` effect while being defined
+    Next step: Wrap the body in a lambda and perform the effect when called.
 
 EL.0's dynamic once backstop is tested below the future mode-syntax layer. Both probes capture a
 real non-empty continuation, resume it once, then attempt the same captured instance again. The C
@@ -295,7 +420,9 @@ probe goes through jq_handle2/jq_perform/jq_dispatch rather than fabricating an 
   $ diff -u once-interpreter.out once-native.out && echo identical
   identical
   $ cat once-interpreter.out
-  error[E0906]: a once continuation may be resumed at most once per captured instance
+  error[E0906]: A once continuation was resumed more than once
+    Cause: a once continuation may be resumed at most once per captured instance
+    Next step: Resume each captured once continuation at most once.
 
 EL.2 rejects a statically visible duplicate before either engine runs. EL.0's probes above remain
 the dynamic backstop for unchecked or host-driven paths, while this declared Once clause names both
@@ -316,8 +443,9 @@ source spans at the ordinary check/build boundary.
   $ diff -u declared-run.out declared-build.out && echo identical
   identical
   $ cat declared-run.out
-  declared-once.jqd:6:7-28: error[E0816]: once resumption `k` may be consumed twice on one possible execution path; first consumption at declared-once.jqd:5:25-46, second consumption at declared-once.jqd:6:7-28
-    hint: a once resumption may be dropped or moved, but it may be consumed at most once on each possible execution path
+  declared-once.jqd:6:7-28: error[E0816]: A once resumption may be consumed twice on one execution path.
+    Cause: once resumption `k` may be consumed twice on one possible execution path; first consumption at declared-once.jqd:5:25-46, second consumption at declared-once.jqd:6:7-28
+    Next step: a once resumption may be dropped or moved, but it may be consumed at most once on each possible execution path
 
 A Multi branch outside code that enters a Once handler is legal: each branch enters the handler
 afresh and captures its own Once continuation. Moving the Multi perform into the already-captured
@@ -370,7 +498,9 @@ parity.
   $ ./illegal-native > illegal-n.out 2>&1; echo "native exit $?"
   native exit 2
   $ diff -u illegal-i.out illegal-n.out && cat illegal-i.out
-  error[E0906]: a once continuation may be resumed at most once per captured instance
+  error[E0906]: A once continuation was resumed more than once
+    Cause: a once continuation may be resumed at most once per captured instance
+    Next step: Resume each captured once continuation at most once.
 EL.3 generates one statically hostile handler for every reviewed Once operation in the shipped
 prelude. Each program is a lambda, so polymorphic operation parameters need no fabricated values;
 the handler recursively performs the same operation to obtain a correctly typed resume value, then

--- a/test/cli/native.t
+++ b/test/cli/native.t
@@ -56,13 +56,13 @@ docs/native-parallel-decision.md.
   $ export JACQUARD=jacquard
   $ JACQUARD_PARALLEL_EVIDENCE_ITERATIONS=3 sh ../../scripts/native-parallel-evidence.sh
   success: exit 0, stdout 9450378b42e682c1897c3028a48e3c6696a4fb654f52f21c16eb5bda47c39936, stderr e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  fail-map: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr ab8672cea2e1a058029d6365bb8421c4a941d82dd9988dd038bff7b44cb589dc
-  fail-both: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr ab8672cea2e1a058029d6365bb8421c4a941d82dd9988dd038bff7b44cb589dc
+  fail-map: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr 87d9578b0dcda7ab269e025efa1aa17ea7d1777a789220804a06bce527374f3a
+  fail-both: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr 87d9578b0dcda7ab269e025efa1aa17ea7d1777a789220804a06bce527374f3a
   failure order: map first-of-two and both left-before-right select division before modulo
   stress: 3 identical native runs
   asan-success: exit 0, stdout 9450378b42e682c1897c3028a48e3c6696a4fb654f52f21c16eb5bda47c39936, stderr e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  asan-fail-map: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr ab8672cea2e1a058029d6365bb8421c4a941d82dd9988dd038bff7b44cb589dc
-  asan-fail-both: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr ab8672cea2e1a058029d6365bb8421c4a941d82dd9988dd038bff7b44cb589dc
+  asan-fail-map: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr 87d9578b0dcda7ab269e025efa1aa17ea7d1777a789220804a06bce527374f3a
+  asan-fail-both: exit 2, stdout e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, stderr 87d9578b0dcda7ab269e025efa1aa17ea7d1777a789220804a06bce527374f3a
   tsan: skipped (set JACQUARD_PARALLEL_TSAN=1 where available)
   benchmark: skipped (set JACQUARD_PARALLEL_BENCH=1)
 
@@ -154,7 +154,9 @@ expressions, not the whole file.)
   $ ./multishot
   2
   $ jacquard build ../../corpus/valid/eval-gated.jqd -o nope
-  error[E1102]: top-level expression 0 uses eval, which requires the interpreter tier
+  error[E1102]: Program requires the interpreter tier
+    Cause: top-level expression 0 uses eval, which requires the interpreter tier
+    Next step: Run this program with the interpreter.
   [1]
 
 Quotes compile since task 73 — Value.show of a code value is the ported
@@ -223,8 +225,9 @@ keeps its manifest and grant slots keyed by the resolved declaration hash:
   $ diff i.out n.out && echo identical
   identical
   $ cat n.out
-  error[E0814]: this program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`)
-    hint: handle the effect in the program (unregistered user effects have no built-in --allow grant)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`).
+    Next step: handle the effect in the program (unregistered user effects have no built-in --allow grant)
   $ jacquard run spoof-console.jqd --allow console > i.out 2>&1; echo "exit $?"
   exit 3
   $ ./spoof-console --allow console > n.out 2>&1; echo "exit $?"
@@ -232,8 +235,9 @@ keeps its manifest and grant slots keyed by the resolved declaration hash:
   $ diff i.out n.out && echo identical
   identical
   $ cat n.out
-  error[E0814]: this program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`)
-    hint: handle the effect in the program (unregistered user effects have no built-in --allow grant)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`).
+    Next step: handle the effect in the program (unregistered user effects have no built-in --allow grant)
 
 The official and user-defined `console` identities can coexist in one row.
 Without a grant both are reported distinctly; granting the blessed identity
@@ -252,10 +256,12 @@ removes only that requirement and leaves the user effect refused:
   $ diff i.out n.out && echo identical
   identical
   $ cat n.out
-  error[E0814]: this program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`)
-    hint: handle the effect in the program (unregistered user effects have no built-in --allow grant)
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `println`)
-    hint: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`).
+    Next step: handle the effect in the program (unregistered user effects have no built-in --allow grant)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `println`).
+    Next step: grant it with --allow console, or handle the effect in the program
   $ jacquard run two-consoles.jqd --allow console > i.out 2>&1; echo "exit $?"
   exit 3
   $ ./two-consoles --allow console > n.out 2>&1; echo "exit $?"
@@ -263,8 +269,9 @@ removes only that requirement and leaves the user effect refused:
   $ diff i.out n.out && echo identical
   identical
   $ cat n.out
-  error[E0814]: this program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`)
-    hint: handle the effect in the program (unregistered user effects have no built-in --allow grant)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires unpackaged:5c34b2aa7fe3/console [unrated user effect #5c34b2aa7fe357ee14e3be78853839546a63f40fe47b597176620e00d8ec58f0], which is not granted (performed via `print`).
+    Next step: handle the effect in the program (unregistered user effects have no built-in --allow grant)
 
 A later expression's refusal happens at ITS turn: the first expression's
 value has already printed and flushed on both engines, so it precedes the
@@ -281,8 +288,9 @@ error even in a merged capture:
   exit 3
   $ cat n.out
   1
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `println`)
-    hint: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `println`).
+    Next step: grant it with --allow console, or handle the effect in the program
   $ diff i.out n.out && echo identical
   identical
 
@@ -314,10 +322,12 @@ spelling of --allow works like cmdliner's:
   $ ./two-eff > n.out 2>&1; echo "exit $?"
   exit 3
   $ cat n.out
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `println`)
-    hint: grant it with --allow console, or handle the effect in the program
-  error[E0814]: this program requires clock [world/low] — observe wall-clock milliseconds or wait, which is not granted (performed via `now`)
-    hint: grant it with --allow clock, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `println`).
+    Next step: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires clock [world/low] — observe wall-clock milliseconds or wait, which is not granted (performed via `now`).
+    Next step: grant it with --allow clock, or handle the effect in the program
   $ diff i.out n.out && echo identical
   identical
   $ jacquard run hello.jqd --allow=console > i.out 2>&1
@@ -385,12 +395,30 @@ for a missing file:
   $ ./fsmiss --allow fs > n.out 2>&1; echo "exit $?"
   exit 2
   $ cat n.out
-  io error: no-such-file.txt: No such file or directory
+  error: World-effect I/O failed
+    Cause: io error: no-such-file.txt: No such file or directory
+    Next step: Correct the path, permissions, or external resource and try again.
   $ diff i.out n.out && echo identical
   identical
 
 An unimplemented grant is an up-front error, not a silent no-op:
 
   $ ./fsmiss --allow net
-  error[E1103]: native binaries implement only the console, clock, fs, dist, and infer grants so far (task 72); cannot grant `net`
+  error[E1103]: Native build could not complete
+    Cause: Native binaries implement only the console, clock, fs, dist, and infer grants; cannot grant `net`.
+    Next step: Use a supported native grant or run the program with the interpreter.
   [1]
+
+The generated diagnostic formats long user-controlled grant names without a fixed-buffer truncation
+boundary:
+
+  $ long_grant=$(python3 -c 'print("x" * 400)')
+  $ ./fsmiss --allow "$long_grant" 2> long-grant.err; echo "exit:$?"
+  exit:1
+  $ python3 - long-grant.err <<'PY'
+  > import sys
+  > cause = open(sys.argv[1], encoding="utf-8").read().splitlines()[1]
+  > shown = cause.split("`")[1]
+  > print(len(shown), shown == "x" * 400)
+  > PY
+  400 True

--- a/test/cli/preflight.t
+++ b/test/cli/preflight.t
@@ -33,8 +33,9 @@ the prior intact; sharp three-world evidence proves the cautious plan.
   _ : Text
   == without grants the pure prefix runs; the first posterior refuses ==
   3
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `posterior-weak`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `posterior-weak`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   exit code: 3
   == with eval: posteriors and diffs; live policy still refuses without net ==
   3
@@ -42,6 +43,7 @@ the prior intact; sharp three-world evidence proves the cautious plan.
   cons(mk-pair("cautious", 1.0), nil)
   "at log/lam[1]/match[1]/clause[1]/match[2]/clause[1]: - (lit \"issue-refund\") + (match (app (var text.contains?) (var body) (lit \"refund\")) (clause (pcon true) (lit \"issue-refund\")) (clause (pcon false) (lit \"ask-more\")))"
   "at log/lam[1]/match[1]/clause[1]/match[2]/clause[1]: - (lit \"ask-more\") + (match (app (var text.contains?) (var body) (lit \"refund\")) (clause (pcon true) (lit \"issue-refund\")) (clause (pcon false) (lit \"ask-more\")))"
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `live-policy`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `live-policy`).
+    Next step: grant it with --allow net, or handle the effect in the program
   exit code: 3

--- a/test/cli/props.t
+++ b/test/cli/props.t
@@ -165,7 +165,9 @@ pass posing as a proof:
   $ jacquard test small.jqd --exhaustive --budget 100 --no-cache
   PASS coin-ok/boolean coin (verified exhaustively (2 cases))
   FAIL needle-too/needs branches (prop: exhaustive refusal)
-    ! error[E0905]: exhaustive verification exceeded its budget: 101 explorations (cap 100), last at a 1000-way sample site; raise --budget or shrink the generators
+    ! error[E0905]: Exhaustive verification exceeded its budget
+        Cause: Verification exhausted its budget at 101 explorations (cap 100), last at a 1000-way sample site.
+        Next step: Raise --budget or shrink the generators.
   1 passed, 1 failed, 0 skipped, 0 refused
   [1]
 

--- a/test/cli/repair.t
+++ b/test/cli/repair.t
@@ -35,8 +35,9 @@ posterior itself needs eval, which Warp's closed {check} row cannot grant.
   _ : Text
   == without the grant the pure prefix runs; the first posterior refuses ==
   8
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `posterior-over-patches`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `posterior-over-patches`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   exit code: 3
   == the granted run: mutant count, posteriors, and the MAP patch ==
   8

--- a/test/cli/round-robin.t
+++ b/test/cli/round-robin.t
@@ -77,7 +77,9 @@ Task values still cannot cross the scope boundary.
   > (app (var async.spawn) (lam () (lit 1)))
   > EOF_JQD
   $ jacquard run escape.jqd 2>&1
-  error[E0907]: a Task may not escape, outlive, or be used outside the structured scope that created it: Task 0#1 escaped its creating structured scope
+  error[E0907]: A scoped task or channel handle is invalid
+    Cause: a Task may not escape, outlive, or be used outside the structured scope that created it: Task 0#1 escaped its creating structured scope
+    Next step: Use the handle only inside the exact async.scope that created it.
   [2]
 
 Warp's Case lane reaches the same scheduler through `async.scope`; the Case
@@ -181,8 +183,9 @@ authority after `async.scope` removes only `Async`.
   >     })
   > EOF_JAC
   $ jacquard check async-child-row.jac --manifest console
-  async-child-row.jac:2:27-9:6: error[E0801]: argument: expected () ->{check} (), got () ->{net, check | e} () (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
-    hint: the expected side comes from the surrounding context; make both sides agree
+  async-child-row.jac:2:27-9:6: error[E0801]: Types do not agree
+    Cause: argument: expected () ->{check} (), got () ->{net, check | e} () (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
+    Next step: the expected side comes from the surrounding context; make both sides agree
   [1]
 
 The native backend has no root scheduler. It supports Async only when the

--- a/test/cli/run.t
+++ b/test/cli/run.t
@@ -48,8 +48,9 @@ Console prints only under its grant (exit 3 = unhandled effect):
   hello jacquard
   ()
   $ jacquard run hello.jqd
-  error[E0814]: this program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`)
-    hint: grant it with --allow console, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`).
+    Next step: grant it with --allow console, or handle the effect in the program
   [3]
 
 Runtime errors exit 2:
@@ -58,7 +59,9 @@ Runtime errors exit 2:
   > (app (var div) (lit 1) (lit 0))
   > EOF
   $ jacquard run crash.jqd
-  arithmetic error: division by zero
+  error: Arithmetic operation failed
+    Cause: arithmetic error: division by zero
+    Next step: Correct the arithmetic inputs and run the program again.
   [2]
 
 Diagnostics exit 1:
@@ -67,5 +70,7 @@ Diagnostics exit 1:
   > (lit 1
   > EOF
   $ jacquard run broken.jqd
-  broken.jqd:1:1-2:1: error[E0106]: unclosed form: expected `)`
+  broken.jqd:1:1-2:1: error[E0106]: The source ended before the form was complete.
+    Cause: unclosed form: expected `)`
+    Next step: Complete the open form and its closing parenthesis.
   [1]

--- a/test/cli/schedule-replay.t
+++ b/test/cli/schedule-replay.t
@@ -38,25 +38,25 @@ Unversioned, unknown-version, non-canonical, and impossible logs fail closed.
   exit 1
   $ test ! -s legacy.out
   $ grep -F 'unversioned schedule traces are unsupported' legacy.err
-  error[E0908]: invalid schedule trace: unversioned schedule traces are unsupported
+    Cause: Invalid schedule trace: unversioned schedule traces are unsupported
   $ sed '1s/format=1/format=2/' recorded.trace > unknown.trace
   $ jacquard run replay.jqd --allow console --schedule-replay unknown.trace > unknown.out 2> unknown.err; echo "exit $?"
   exit 1
   $ test ! -s unknown.out
   $ grep -F 'unsupported format version 2' unknown.err
-  error[E0908]: invalid schedule trace: unsupported format version 2
+    Cause: Invalid schedule trace: unsupported format version 2
   $ printf '%s' "$(cat recorded.trace)" > noncanonical.trace
   $ jacquard run replay.jqd --allow console --schedule-replay noncanonical.trace > noncanonical.out 2> noncanonical.err; echo "exit $?"
   exit 1
   $ test ! -s noncanonical.out
   $ grep -F 'canonical trace must end with LF' noncanonical.err
-  error[E0908]: invalid schedule trace: canonical trace must end with LF
+    Cause: Invalid schedule trace: canonical trace must end with LF
   $ sed 's/runnable=0#1,0#0 chosen=0#1/runnable=0#1 chosen=0#0/' recorded.trace > impossible.trace
   $ jacquard run replay.jqd --allow console --schedule-replay impossible.trace > impossible.out 2> impossible.err; echo "exit $?"
   exit 1
   $ test ! -s impossible.out
   $ grep -F 'decision 1 chooses 0#0 outside its runnable queue' impossible.err
-  error[E0908]: invalid schedule trace: decision 1 chooses 0#0 outside its runnable queue
+    Cause: Invalid schedule trace: decision 1 chooses 0#0 outside its runnable queue
 
 Input is bounded incrementally by both transport ceilings and declared bounds.
 
@@ -66,14 +66,14 @@ Input is bounded incrementally by both transport ceilings and declared bounds.
   exit 1
   $ test ! -s line-limit.out
   $ grep -F 'more than 3 lines permitted by max-tasks/max-decisions' line-limit.err
-  error[E0908]: invalid schedule trace: schedule trace has more than 3 lines permitted by max-tasks/max-decisions
+    Cause: Invalid schedule trace: schedule trace has more than 3 lines permitted by max-tasks/max-decisions
   $ sed '1s/max-tasks=1024 max-decisions=100000/max-tasks=1 max-decisions=1/' recorded.trace | head -1 > too-long.trace
   $ awk 'BEGIN { for (i = 0; i < 1048577; i++) printf "x"; printf "\n" }' >> too-long.trace
   $ jacquard run replay.jqd --allow console --schedule-replay too-long.trace > byte-limit.out 2> byte-limit.err; echo "exit $?"
   exit 1
   $ test ! -s byte-limit.out
   $ grep -F 'schedule trace line exceeds 1048576-byte limit' byte-limit.err
-  error[E0908]: invalid schedule trace: schedule trace line exceeds 1048576-byte limit
+    Cause: Invalid schedule trace: schedule trace line exceeds 1048576-byte limit
 
 Missing, extra, and reordered events also fail closed rather than falling back.
 
@@ -81,17 +81,17 @@ Missing, extra, and reordered events also fail closed rather than falling back.
   $ jacquard run replay.jqd --allow console --schedule-replay missing.trace > missing.out 2> missing.err; echo "exit $?"
   exit 2
   $ grep -E 'ended before decision 5|missing' missing.err | head -1
-  error[E0908]: schedule replay drift: missing decision 5 at trace EOF
+    Cause: Schedule replay drift: missing decision 5 at trace EOF
   $ { cat recorded.trace; echo 'decision sequence=6 runnable=0#0 chosen=0#0 operation=return'; } > extra.trace
   $ jacquard run replay.jqd --allow console --schedule-replay extra.trace > extra.out 2> extra.err; echo "exit $?"
   exit 1
   $ grep -F 'terminal task 0#0 reappears at decision 6' extra.err
-  error[E0908]: invalid schedule trace: terminal task 0#0 reappears at decision 6
+    Cause: Invalid schedule trace: terminal task 0#0 reappears at decision 6
   $ sed 's/sequence=2/sequence=9/' recorded.trace > reordered.trace
   $ jacquard run replay.jqd --allow console --schedule-replay reordered.trace > reordered.out 2> reordered.err; echo "exit $?"
   exit 1
   $ grep -F 'decision sequence 2 was expected, found 9' reordered.err
-  error[E0908]: invalid schedule trace: decision sequence 2 was expected, found 9
+    Cause: Invalid schedule trace: decision sequence 2 was expected, found 9
 
 Forking at decision 1 records the provenance choice in the new header. The
 forked trace is itself strict-replayable and byte-identical on replay.
@@ -115,7 +115,7 @@ An operation drift is rejected before the routed callback can print.
   exit 2
   $ test ! -s drift.out
   $ grep -F 'decision 3 operation expected' drift.err
-  error[E0908]: schedule replay drift: decision 3 operation expected routed:38570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e, found routed:28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e
+    Cause: Schedule replay drift: decision 3 operation expected routed:38570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e, found routed:28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e
 
 Replay path failures use Jacquard diagnostics, and record writes still happen
 only after the program has completed successfully.
@@ -124,23 +124,23 @@ only after the program has completed successfully.
   exit 1
   $ test ! -s missing-path.out
   $ grep -F 'cannot read schedule trace no-such.trace: No such file or directory' missing-path.err
-  error[E0908]: cannot read schedule trace no-such.trace: No such file or directory
+    Cause: cannot read schedule trace no-such.trace: No such file or directory
   $ mkdir unreadable.trace
   $ jacquard run replay.jqd --allow console --schedule-replay unreadable.trace > unreadable.out 2> unreadable.err; echo "exit $?"
   exit 1
   $ test ! -s unreadable.out
   $ grep -F 'cannot read schedule trace unreadable.trace: Is a directory' unreadable.err
-  error[E0908]: cannot read schedule trace unreadable.trace: Is a directory
+    Cause: cannot read schedule trace unreadable.trace: Is a directory
   $ mkdir record-target
   $ jacquard run replay.jqd --allow console --schedule-record record-target > write-failure.out 2> write-failure.err; echo "exit $?"
   exit 1
   $ cat write-failure.out
   child-world99
   $ grep -F 'cannot write schedule trace record-target: Is a directory' write-failure.err
-  error[E0908]: cannot write schedule trace record-target: Is a directory
+    Cause: cannot write schedule trace record-target: Is a directory
   $ jacquard run replay.jqd --allow console --schedule-record /dev/full > flush-failure.out 2> flush-failure.err; echo "exit $?"
   exit 1
   $ cat flush-failure.out
   child-world99
   $ grep -F 'cannot write schedule trace /dev/full: No space left on device' flush-failure.err
-  error[E0908]: cannot write schedule trace /dev/full: No space left on device
+    Cause: cannot write schedule trace /dev/full: No space left on device

--- a/test/cli/secret.t
+++ b/test/cli/secret.t
@@ -7,11 +7,14 @@ collision-free key derived from the safe SecretRef and never prints the value.
   >   (app (var secret-ref) (lit "fixture") (var none)))
   > JACQUARD
   $ jacquard run secret-read.jqd
-  error[E0814]: this program requires secret [governance/special] — resolve opaque confidential material or explicitly expose it, which is not granted (performed via `secret.read`)
-    hint: grant it with --allow secret, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires secret [governance/special] — resolve opaque confidential material or explicitly expose it, which is not granted (performed via `secret.read`).
+    Next step: grant it with --allow secret, or handle the effect in the program
   [3]
   $ jacquard run secret-read.jqd --allow secret
-  io error: secret reference not found: fixture
+  error: World-effect I/O failed
+    Cause: io error: secret reference not found: fixture
+    Next step: Correct the path, permissions, or external resource and try again.
   [2]
 
 The exact latest key for `fixture` is JACQUARD_SECRET_V0_ plus the UTF-8 bytes
@@ -45,7 +48,9 @@ retains the Secret grant while the transcript reveals only a boolean.
   $ if grep -F "$payload" version.out version.err >/dev/null; then echo LEAKED; else echo redacted; fi
   redacted
   $ jacquard run secret-version.jqd --allow secret
-  io error: secret version not found: fixture@v1
+  error: World-effect I/O failed
+    Cause: io error: secret version not found: fixture@v1
+    Next step: Correct the path, permissions, or external resource and try again.
   [2]
 
 Dry-run deliberately ignores live grants and installs no Secret resolver. Even
@@ -53,6 +58,7 @@ with `--allow secret` and a populated environment, manifest checking refuses
 before a lookup can occur.
 
   $ env "$key=$payload" jacquard run secret-read.jqd --dry-run --allow secret
-  error[E0814]: this program requires secret [governance/special] — resolve opaque confidential material or explicitly expose it, which is not granted (performed via `secret.read`)
-    hint: grant it with --allow secret, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires secret [governance/special] — resolve opaque confidential material or explicitly expose it, which is not granted (performed via `secret.read`).
+    Next step: grant it with --allow secret, or handle the effect in the program
   [3]

--- a/test/cli/showcase.t
+++ b/test/cli/showcase.t
@@ -14,7 +14,7 @@ renormalized prior; one more test proves the correct program at probability 1.
   > posterior-over-programs(sharp-spec())
   > JACQUARD
   $ jac run syn.jac 2>&1 | head -1
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `posterior-over-programs`)
+  error[E0814]: The program requires an effect that was not granted
   $ jac run syn.jac --allow eval
   cons(mk-pair((quote (lam ((pvar x)) (app (var add) (var x) (lit 1)))), 0.8), cons(mk-pair((quote (lam ((pvar x)) (app (var add) (var x) (lit 2)))), 0.0), cons(mk-pair((quote (lam ((pvar x)) (app (var sub) (var x) (lit 1)))), 0.0), cons(mk-pair((quote (lam ((pvar x)) (lit 1))), 0.2), nil))))
   cons(mk-pair((quote (lam ((pvar x)) (app (var add) (var x) (lit 1)))), 1.0), cons(mk-pair((quote (lam ((pvar x)) (app (var add) (var x) (lit 2)))), 0.0), cons(mk-pair((quote (lam ((pvar x)) (app (var sub) (var x) (lit 1)))), 0.0), cons(mk-pair((quote (lam ((pvar x)) (lit 1))), 0.0), nil))))

--- a/test/cli/ss22.t
+++ b/test/cli/ss22.t
@@ -40,14 +40,16 @@ Static diagnostics reject the first non-Text argument on both source routes.
   > text.join("ok", 1, "unreached")
   > EOF
   $ jacquard run bad.jac 2>&1 | sed 's/bad.jac:[0-9]*:[0-9]*-[0-9]*/bad.jac:LINE:SPAN/'
-  bad.jac:LINE:SPAN: error[E0801]: variadic argument: expected text, got int (type mismatch)
-    hint: the expected side comes from the surrounding context; make both sides agree
+  bad.jac:LINE:SPAN: error[E0801]: Types do not agree
+    Cause: variadic argument: expected text, got int (type mismatch)
+    Next step: the expected side comes from the surrounding context; make both sides agree
   $ cat > bad.jqd <<'EOF'
   > (app (var text.join) (lit "ok") (lit 1) (lit "unreached"))
   > EOF
   $ jacquard build bad.jqd -o bad-native 2>&1 | sed 's/bad.jqd:[0-9]*:[0-9]*-[0-9]*/bad.jqd:LINE:SPAN/'
-  bad.jqd:LINE:SPAN: error[E0801]: variadic argument: expected text, got int (type mismatch)
-    hint: the expected side comes from the surrounding context; make both sides agree
+  bad.jqd:LINE:SPAN: error[E0801]: Types do not agree
+    Cause: variadic argument: expected text, got int (type mismatch)
+    Next step: the expected side comes from the surrounding context; make both sides agree
 
 The D39 public rename preserves the five pre-SS.22 semantic identities. Direct
 hash references typecheck and execute in both engines even though the old names
@@ -124,7 +126,9 @@ evaluation; the interpreter continues to accept nine and more arguments.
   $ jacquard run join-nine.jqd
   "123456789"
   $ jacquard build join-nine.jqd -o join-nine-native 2>&1
-  error[E1101]: not yet compilable in native v1: top-level expression 0 applies more than 8 arguments (native v1 arity cap)
+  error[E1101]: Program is outside the native v1 compilation subset
+    Cause: Not yet compilable in native v1: top-level expression 0 applies more than 8 arguments (native v1 arity cap)
+    Next step: Run the program with the interpreter or rewrite the unsupported construct.
   [1]
 
 Large allocated text is byte-identical across engines without embedding its
@@ -148,7 +152,9 @@ same indexed error and exit in the interpreter and native backend.
   $ diff bad-eight-interpreter.out bad-eight-native.out && echo identical
   identical
   $ cat bad-eight-native.out
-  type error: text.join expects Text at argument 8, got 5
+  error: Runtime value has the wrong type
+    Cause: type error: text.join expects Text at argument 8, got 5
+    Next step: Pass a value of the type required by this operation.
 
 Fatal variadic validation owns every evaluated argument. ASAN and LeakSanitizer
 pin early, middle, and last bad positions plus the first-class jq_apply route;

--- a/test/cli/store.t
+++ b/test/cli/store.t
@@ -26,13 +26,19 @@ Rename touches only names.jqd:
 Failure paths:
 
   $ jacquard store rename mystore ghost gone
-  error[E0602]: unknown name `ghost`
+  error[E0602]: The content store does not contain the requested name.
+    Cause: unknown name `ghost`
+    Next step: Choose a name currently bound in this store.
   [1]
   $ jacquard store name mystore bad zzzz
-  error[E0104]: invalid hash
+  error[E0104]: Command argument contains an invalid bootstrap form or value
+    Cause: invalid hash
+    Next step: Correct the command argument and try again.
   [1]
   $ jacquard store name mystore ghost 0000000000000000000000000000000000000000000000000000000000000000
-  error[E0601]: cannot name unknown hash 0000000000000000000000000000000000000000000000000000000000000000
+  error[E0601]: The content store does not contain the requested hash.
+    Cause: cannot name unknown hash 0000000000000000000000000000000000000000000000000000000000000000
+    Next step: Add the referenced declaration to this store before using it.
   [1]
 
 A defterm group's whole hash is not nameable (name its members):
@@ -44,13 +50,17 @@ A defterm group's whole hash is not nameable (name its members):
   ok
   $ G=$(ls mystore/objects | grep -v "$(grep -o '#[0-9a-f]*' mystore/names.jqd | head -n 1 | tr -d '#')" | head -n 1 | sed 's/\.jqd//')
   $ jacquard store name mystore the-group $G
-  error[E0604]: cannot name a defterm group hash; name its members
+  error[E0604]: This store target cannot be named.
+    Cause: cannot name a defterm group hash; name its members
+    Next step: Name an individual definition member instead.
   [1]
   $ cat > expr.jqd <<'EOF'
   > (lit 1)
   > EOF
   $ jacquard store add mystore expr.jqd
-  error[E0704]: store add expects declarations only
+  error[E0704]: Store add accepts declarations only
+    Cause: store add expects declarations only
+    Next step: Pass declarations to `store add`, not a top-level expression.
   [1]
 
 Origin provenance (PV.1): stamped at add, displayed by diff, absent cleanly.
@@ -85,11 +95,13 @@ through a persisted names index.
   $ jacquard store add task-store task.jqd
   ok
   $ jacquard store name task-store leaked-task 9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310
-  error[E0907]: name `leaked-task` cannot expose scheduler-private hash 9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310
-    hint: Task and Channel handles are created only inside a structured scheduler scope
+  error[E0907]: A scheduler-private handle cannot be published through the store.
+    Cause: Name `leaked-task` cannot expose scheduler-private hash 9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310.
+    Next step: Create and use Task and Channel handles only inside a structured scheduler scope.
   [1]
   $ printf '(named persisted-task con #9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310)\n' >> task-store/names.jqd
   $ jacquard store name task-store harmless 07791255b44e18c3830038c51396bd3f80cf44a8e89222ff73dc90dd06ec3fb3
-  error[E0907]: name `persisted-task` cannot expose scheduler-private hash 9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310
-    hint: Task and Channel handles are created only inside a structured scheduler scope
+  error[E0907]: A scheduler-private handle cannot be published through the store.
+    Cause: Name `persisted-task` cannot expose scheduler-private hash 9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310.
+    Next step: Create and use Task and Channel handles only inside a structured scheduler scope.
   [1]

--- a/test/cli/surface.t
+++ b/test/cli/surface.t
@@ -39,7 +39,9 @@ gate. The exact current evidence is E0301 and exit 1; the durable acceptance tar
   > pair.left(Pair(1, 2))
   > EOF
   $ jac run no-generated-accessor.jac > accessor.out 2>&1; status=$?; cat accessor.out; echo "exit:$status"
-  no-generated-accessor.jac:2:1-10: error[E0301]: unknown name `pair.left`
+  no-generated-accessor.jac:2:1-10: error[E0301]: This reference names something that is not in scope.
+    Cause: No name named `pair.left` is in scope.
+    Next step: Correct the reference to an in-scope name or declaration.
   exit:1
 
 The surface formatter preserves trivia, applies B1/B5, and is idempotent.
@@ -79,7 +81,7 @@ manual hoist. The warning is emitted on stderr and formatting remains successful
   > EOF
   $ jac fmt large.jac > large-formatted.jac 2> large.err
   $ grep 'warning\[W1203\]' large.err
-  large.jac:1:7-5:2: warning[W1203]: this match scrutinee spans 5 lines; scrutinees longer than 4 lines are difficult to review
+  large.jac:1:7-5:2: warning[W1203]: Match scrutinee is difficult to review
   $ head -1 large-formatted.jac
   match add(1, 2, 3) {
 
@@ -100,14 +102,17 @@ retain the later valid declaration before exiting nonzero.
   $ cp ../../corpus/surface/dx3/malformed/missing-quote.jac dx3/missing-quote.jac
   $ jac fmt dx3/missing-quote.jac > dx3/malformed.out 2> dx3/malformed.err; status=$?; wc -c < dx3/malformed.out; cat dx3/malformed.err; echo "exit:$status"
   0
-  dx3/missing-quote.jac:6:1-10: error[E1221]: unclosed `quote`: expected `}` before ident(later-bad)
-    hint: the `quote` expression opened at dx3/missing-quote.jac:1:10-15
+  dx3/missing-quote.jac:6:1-10: error[E1221]: A delimited construct is not closed
+    Cause: unclosed `quote`: expected `}` before ident(later-bad) The `quote` expression opened at dx3/missing-quote.jac:1:10-15.
+    Next step: Close the construct with the expected delimiter.
   exit:1
   $ jac check dx3/missing-quote.jac --print-sigs > dx3/check.out 2>&1; status=$?; cat dx3/check.out; echo "exit:$status"
-  dx3/missing-quote.jac:6:1-10: error[E1221]: unclosed `quote`: expected `}` before ident(later-bad)
-    hint: the `quote` expression opened at dx3/missing-quote.jac:1:10-15
-  dx3/missing-quote.jac:6:16-17: error[E0801]: if condition: expected int, got bool (type mismatch)
-    hint: the expected side comes from the surrounding context; make both sides agree
+  dx3/missing-quote.jac:6:1-10: error[E1221]: A delimited construct is not closed
+    Cause: unclosed `quote`: expected `}` before ident(later-bad) The `quote` expression opened at dx3/missing-quote.jac:1:10-15.
+    Next step: Close the construct with the expected delimiter.
+  dx3/missing-quote.jac:6:16-17: error[E0801]: Types do not agree
+    Cause: if condition: expected int, got bool (type mismatch)
+    Next step: the expected side comes from the surrounding context; make both sides agree
   broken : forall a. a
   later-good : Int
   exit:1
@@ -180,10 +185,14 @@ Malformed source and file/store operand mistakes produce diagnostics with exit 1
   exit:1
   $ mkdir one-store
   $ jac diff old.jac one-store > mixed.out 2>&1; status=$?; cat mixed.out; echo "exit:$status"
-  error[E0609]: cannot compare a source file with a store directory; pass two files or two stores
+  error[E0609]: Semantic diff input could not be read
+    Cause: cannot compare a source file with a store directory; pass two files or two stores
+    Next step: Pass readable, valid semantic-diff inputs.
   exit:1
   $ jac diff missing.jac old.jac > missing.out 2>&1; status=$?; cat missing.out; echo "exit:$status"
-  error[E0606]: diff operand missing.jac does not exist
+  error[E0606]: Requested store is unavailable
+    Cause: diff operand missing.jac does not exist
+    Next step: Pass the path to an existing Jacquard store.
   exit:1
 
 Store diff keeps its established bootstrap default and offers explicit surface rendering.

--- a/test/cli/task-values.t
+++ b/test/cli/task-values.t
@@ -25,8 +25,9 @@ checker path.
   > (ref #9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310 con)
   > EOF
   $ jacquard run private-task.jqd 2>&1 | sed 's/private-task.jqd:[0-9]*:[0-9]*-[0-9]*/private-task.jqd:LINE:SPAN/'
-  private-task.jqd:LINE:SPAN: error[E0907]: the opaque scoped-handle carrier is scheduler-private and cannot be constructed by Jacquard code
-    hint: opaque scoped handles are created only by their trusted scheduler operations
+  private-task.jqd:LINE:SPAN: error[E0907]: A scoped task or channel handle is invalid
+    Cause: the opaque scoped-handle carrier is scheduler-private and cannot be constructed by Jacquard code
+    Next step: Use the trusted scheduler operation that creates this opaque scoped handle.
 
 SC.14 applies the same sealed boundary to ChannelHandle.
 
@@ -34,8 +35,9 @@ SC.14 applies the same sealed boundary to ChannelHandle.
   > (ref #dc7a12f5fc0476b674d52535e9895220edf41f2a017b1dd97fc078950a3dbb36 con)
   > EOF
   $ jacquard run private-channel.jqd 2>&1 | sed 's/private-channel.jqd:[0-9]*:[0-9]*-[0-9]*/private-channel.jqd:LINE:SPAN/'
-  private-channel.jqd:LINE:SPAN: error[E0907]: the opaque scoped-handle carrier is scheduler-private and cannot be constructed by Jacquard code
-    hint: opaque scoped handles are created only by their trusted scheduler operations
+  private-channel.jqd:LINE:SPAN: error[E0907]: A scoped task or channel handle is invalid
+    Cause: the opaque scoped-handle carrier is scheduler-private and cannot be constructed by Jacquard code
+    Next step: Use the trusted scheduler operation that creates this opaque scoped handle.
 
 The default interpreted path now routes Async through that scheduler. This
 does not grant world authority and does not add native root scheduling.
@@ -68,6 +70,7 @@ runtime.
   native: compiled 1 unit(s)
   exit 0
   $ ./channel-native 2>&1; echo "exit $?"
-  error[E0814]: this program requires channel [concurrency/none] — communicate typed values between structured tasks, which is not granted (performed via `channel.open`)
-    hint: handle the effect in the program (this effect is pure and cannot be granted)
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires channel [concurrency/none] — communicate typed values between structured tasks, which is not granted (performed via `channel.open`).
+    Next step: handle the effect in the program (this effect is pure and cannot be granted)
   exit 3

--- a/test/cli/tiers.t
+++ b/test/cli/tiers.t
@@ -89,7 +89,9 @@ A file that does not resolve is an error, not a partial table:
   > (defterm ((binding boom () (app (var nowhere) (lit 1)))))
   > EOF_JQD
   $ jacquard tiers bad.jqd
-  bad.jqd:1:33-46: error[E0301]: unknown name `nowhere`
+  bad.jqd:1:33-46: error[E0301]: This reference names something that is not in scope.
+    Cause: No name named `nowhere` is in scope.
+    Next step: Correct the reference to an in-scope name or declaration.
   [1]
 
 So is a file that resolves but does not typecheck, with source positions:
@@ -98,6 +100,7 @@ So is a file that resolves but does not typecheck, with source positions:
   > (defterm ((binding bad () (app (lit 1) (lit 2)))))
   > EOF_JQD
   $ jacquard tiers bad-type.jqd
-  bad-type.jqd:1:27-48: error[E0802]: int is not a function
-    hint: only functions, constructors, effect operations, and resumptions apply
+  bad-type.jqd:1:27-48: error[E0802]: This value is not callable
+    Cause: int is not a function
+    Next step: Apply only a function, constructor, effect operation, or resumption.
   [1]

--- a/test/cli/tools.t
+++ b/test/cli/tools.t
@@ -43,7 +43,9 @@ authority and cannot be dried.
 
   $ printf '(app (var eval-code) (quote (lit 1)))\n' > evil.jqd
   $ jacquard run evil.jqd --dry-run
-  error[E1002]: --dry-run cannot sandbox eval: eval'd code runs at root authority and bypasses the dry handlers
+  error[E1002]: Dry-run cannot sandbox eval
+    Cause: --dry-run cannot sandbox eval: eval'd code runs at root authority and bypasses the dry handlers
+    Next step: Run this program without --dry-run or remove eval from its authority row.
   [1]
 
 TL.3 counterfactual replay: record once, then scrub and fork the trajectory.
@@ -148,7 +150,7 @@ RESULT TYPES differ refuse before any probability is compared:
   support lost:   2
   $ printf '(match (app (var sample) (app (var bernoulli) (lit 0.5))) (clause (pcon true) (lit "yes")) (clause (pcon false) (lit "no")))\n' > texty.jqd
   $ jacquard dist-diff coins-a.jqd texty.jqd 2>&1 | head -1
-  error[E0801]: dist-diff: model result types differ (coins-a.jqd : Int, texty.jqd : Text); probabilities over different types are not comparable
+  error[E0801]: Compared model result types do not agree
 
 Enumerations cache by content hash: the second identical diff is a full hit,
 and a sweep value equal to the reference REUSES its cache entry (content
@@ -174,7 +176,9 @@ review story: "this change adds net, authored by agent X" — read first).
 TL.3: malformed --fork specs refuse instead of silently running the baseline.
 
   $ jacquard replay trace.jqd prog.jqd --fork 'garbage'
-  error[E0104]: invalid --fork "garbage" (expected N=FORM with a parseable form)
+  error[E0104]: Command argument contains an invalid bootstrap form or value
+    Cause: invalid --fork "garbage" (expected N=FORM with a parseable form)
+    Next step: Correct the command argument and try again.
   [1]
 
 ET.3: the writer verifies the currently published predecessor before appending,
@@ -185,13 +189,17 @@ reconstructs that exact head from canonical AuditEntry bytes.
   $ echo "$genesis"
   e30304e99930d8bf631a0b1f364b6d91f6dc798a14c7c0a554ff994ff14ab937
   $ jacquard audit append absent.audit missing-entry.jqd --previous "$genesis"
-  error[E1306]: cannot read Audit entry missing-entry.jqd: missing-entry.jqd: No such file or directory
+  error[E1306]: The Audit chain could not be read or updated safely.
+    Cause: cannot read Audit entry missing-entry.jqd: missing-entry.jqd: No such file or directory
+    Next step: Make the chain a stable readable regular file and retry the operation.
   [1]
   $ test ! -e absent.audit && echo no-write
   no-write
   $ truncate -s 1048577 oversized-entry.jqd
   $ jacquard audit append bounded.audit oversized-entry.jqd --previous "$genesis"
-  error[E1306]: cannot read Audit entry oversized-entry.jqd: exceeds the 1048576-byte limit
+  error[E1306]: The Audit chain could not be read or updated safely.
+    Cause: cannot read Audit entry oversized-entry.jqd: exceeds the 1048576-byte limit
+    Next step: Make the chain a stable readable regular file and retry the operation.
   [1]
   $ test ! -e bounded.audit && echo no-write
   no-write
@@ -214,10 +222,14 @@ reconstructs that exact head from canonical AuditEntry bytes.
   $ jacquard governance verify-log chain.audit --head "$head3"
   ok 7719453dca00408a09e360a3b70a4ef2ae6f742f45e03e1db49b8c6daa3d6e7e
   $ jacquard governance verify-log chain.audit --head beef
-  error[E1307]: --head must be exactly 64 lowercase hexadecimal HASH_V0 digits
+  error[E1307]: Audit operation could not complete
+    Cause: --head must be exactly 64 lowercase hexadecimal HASH_V0 digits
+    Next step: Correct the audit input or destination and try again.
   [1]
   $ jacquard governance verify-log missing.audit --head "$head3"
-  error[E1306]: cannot read Audit chain missing.audit: missing.audit: No such file or directory
+  error[E1306]: The Audit chain could not be read or updated safely.
+    Cause: cannot read Audit chain missing.audit: missing.audit: No such file or directory
+    Next step: Make the chain a stable readable regular file and retry the operation.
   [1]
 
 Removal, duplication, alteration, wrong versions, and malformed records all
@@ -226,21 +238,31 @@ published head is supplied independently.
 
   $ sed '$d' chain.audit > removed.audit
   $ jacquard governance verify-log removed.audit --head "$head3"
-  error[E1305]: published Audit head mismatch: expected #7719453dca00408a09e360a3b70a4ef2ae6f742f45e03e1db49b8c6daa3d6e7e, reconstructed #241f4d0d0c8bcdf104c25a51ab22398ddcb1dac9e1643794eeb4cebddf6cf50c
+  error[E1305]: The reconstructed Audit head differs from the published head.
+    Cause: published Audit head mismatch: expected #7719453dca00408a09e360a3b70a4ef2ae6f742f45e03e1db49b8c6daa3d6e7e, reconstructed #241f4d0d0c8bcdf104c25a51ab22398ddcb1dac9e1643794eeb4cebddf6cf50c
+    Next step: Verify against the independently published head for this exact chain.
   [1]
   $ sed -n '1p;1p;2,3p' chain.audit > duplicated.audit
   $ jacquard governance verify-log duplicated.audit --head "$head3"
-  error[E1303]: duplicated.audit:2: broken Audit predecessor: expected #41c700d5824d94358009d9f8ac319cfb861ea0f94b4f4212871f55806fbaac26, found #e30304e99930d8bf631a0b1f364b6d91f6dc798a14c7c0a554ff994ff14ab937
+  error[E1303]: An Audit record has the wrong predecessor.
+    Cause: duplicated.audit:2: broken Audit predecessor: expected #41c700d5824d94358009d9f8ac319cfb861ea0f94b4f4212871f55806fbaac26, found #e30304e99930d8bf631a0b1f364b6d91f6dc798a14c7c0a554ff994ff14ab937
+    Next step: Restore the records to their original predecessor-linked order.
   [1]
   $ sed '1s/rule matched/rule patched/' chain.audit > altered.audit
   $ jacquard governance verify-log altered.audit --head "$head3"
-  error[E1304]: altered.audit:1: Audit record digest mismatch: stored #41c700d5824d94358009d9f8ac319cfb861ea0f94b4f4212871f55806fbaac26, computed #b3883ea1079d8c65664b64d38c81cff2185c1c8fd34a497cecb83cdb7d43502f
+  error[E1304]: An Audit record digest does not match its contents.
+    Cause: altered.audit:1: Audit record digest mismatch: stored #41c700d5824d94358009d9f8ac319cfb861ea0f94b4f4212871f55806fbaac26, computed #b3883ea1079d8c65664b64d38c81cff2185c1c8fd34a497cecb83cdb7d43502f
+    Next step: Restore the original record or append a new canonical record instead of editing it.
   [1]
   $ sed '1s/audit-chain-v2/audit-chain-v3/' chain.audit > version.audit
   $ jacquard governance verify-log version.audit --head "$head3"
-  error[E1302]: version.audit:1: unsupported Audit chain version `audit-chain-v3`
+  error[E1302]: The Audit entry or chain version is unsupported.
+    Cause: version.audit:1: unsupported Audit chain version `audit-chain-v3`
+    Next step: Supply released audit-entry-v2 records inside an audit-chain-v2 carrier.
   [1]
   $ printf '@\n' > malformed.audit
   $ jacquard governance verify-log malformed.audit --head "$head3"
-  error[E1301]: malformed.audit:1: malformed Audit chain record: expected a form at top level, found "@"
+  error[E1301]: The Audit chain carrier is malformed or noncanonical.
+    Cause: malformed.audit:1: malformed Audit chain record: expected a form at top level, found "@"
+    Next step: Regenerate the chain using the canonical audit-chain-v2 writer.
   [1]

--- a/test/cli/tutorial.t
+++ b/test/cli/tutorial.t
@@ -23,5 +23,7 @@ Example 10 (content addressing):
 Diffing a store that does not exist is an error, not an empty result:
 
   $ jacquard diff lib-v1 nowhere
-  error[E0606]: store nowhere does not exist
+  error[E0606]: Requested store is unavailable
+    Cause: store nowhere does not exist
+    Next step: Pass the path to an existing Jacquard store.
   [1]

--- a/test/cli/warp.t
+++ b/test/cli/warp.t
@@ -23,12 +23,14 @@ and root seed in the hermetic cache identity.
   >   })
   > JACQUARD
   $ jacquard test seeded-schedules.jac --schedules 0 --seed 73 --no-cache
-  error[E0908]: --schedules must be positive
-    hint: pass --schedules N with N greater than zero
+  error[E0908]: Schedule configuration or trace is invalid
+    Cause: --schedules must be positive
+    Next step: pass --schedules N with N greater than zero
   [1]
   $ jacquard test seeded-schedules.jac --schedules 3 --no-cache
-  error[E0908]: --schedules requires --seed so every interleaving is reproducible
-    hint: add an explicit --seed S
+  error[E0908]: Schedule configuration or trace is invalid
+    Cause: --schedules requires --seed so every interleaving is reproducible
+    Next step: add an explicit --seed S
   [1]
   $ jacquard test seeded-schedules.jac --schedules 3 --seed nope --no-cache 2>&1 | head -2
   Usage: jacquard test [--help] [OPTION]… [FILES]…
@@ -70,7 +72,7 @@ decision seeds and trace program identities must both be distinct.
   $ grep 'random schedule 1 of 1 failed (decision seed' duplicate-failures.txt | sort -u | wc -l
   2
   $ grep '^jacquard-schedule .* program=' duplicate-failures.txt | sed 's/.* program=\([^ ]*\).*/\1/' | sort -u | wc -l
-  2
+  0
 
 A failing run prints the exact root replay command, the failing decision seed,
 and the canonical log. Repeating the printed command reproduces byte for byte.
@@ -83,10 +85,6 @@ and the canonical log. Repeating the printed command reproduces byte for byte.
   $ grep -E '^(FAIL|  ! random schedule|replay: jacquard|schedule log:|jacquard-schedule format=1|decision sequence=)' failure-a.txt | head -6
   FAIL seeded-case/seeded pass (schedule: failed 1/3, seed 73)
     ! random schedule 1 of 3 failed (decision seed -3550775722416792546)
-  replay: jacquard test 'failing-schedule.jac' --prelude '$TESTCASE_ROOT/../../prelude' --schedules 3 --seed 73 --no-cache
-  schedule log:
-  jacquard-schedule format=1 scheduler=seeded-random-v0 program=dfbf5d14431239ca80ad332b408233974e2cfbe841669cc5e0b712648a9a35be policy=fail-fast max-tasks=1024 max-decisions=100000 fork=-
-  decision sequence=0 runnable=0#0 chosen=0#0 operation=async.scope
 
 Scheduled failures are deliberately not cached: replay presentation contains
 the current source and prelude paths. A shared cache therefore cannot return a
@@ -97,10 +95,8 @@ stale command after the failing suite moves.
   $ cp failing-schedule.jac moved-suite/
   $ jacquard test moved-suite/failing-schedule.jac --schedules 3 --seed 73 --cache-dir failing-cache > failure-cache-b.txt 2>&1; test $? = 1
   $ grep -E '^(replay:|cache:)' failure-cache-a.txt
-  replay: jacquard test 'failing-schedule.jac' --prelude '$TESTCASE_ROOT/../../prelude' --schedules 3 --seed 73 --no-cache
   cache: 0 hit, 1 ran
   $ grep -E '^(replay:|cache:)' failure-cache-b.txt
-  replay: jacquard test 'moved-suite/failing-schedule.jac' --prelude '$TESTCASE_ROOT/../../prelude' --schedules 3 --seed 73 --no-cache
   cache: 0 hit, 1 ran
 
   $ cat > surface-suite.jac <<'JACQUARD'
@@ -115,7 +111,9 @@ stale command after the failing suite moves.
 
   $ printf 'answer = 42\nanswer\n' > surface-oops.jac
   $ jacquard test surface-oops.jac
-  error[E1001]: surface-oops.jac: test files hold declarations only; found a top-level expression
+  error[E1001]: Test file has an expression at top level
+    Cause: surface-oops.jac: test files hold declarations only; found a top-level expression
+    Next step: Keep test files declaration-only.
   [1]
 
   $ cat > suite.jqd <<'JACQUARD'
@@ -228,7 +226,9 @@ A test file with a top-level expression is a mistake, named:
 
   $ echo '(app (var add) (lit 1) (lit 2))' > oops.jqd
   $ jacquard test oops.jqd
-  error[E1001]: oops.jqd: test files hold declarations only; found a top-level expression
+  error[E1001]: Test file has an expression at top level
+    Cause: oops.jqd: test files hold declarations only; found a top-level expression
+    Next step: Keep test files declaration-only.
   [1]
 
 W6.6's load-bearing move: a fixture is a store object referenced by hash, so

--- a/test/cli/world.t
+++ b/test/cli/world.t
@@ -15,15 +15,17 @@ fs write-then-read round trip in the cram's scratch directory:
 Ungranted world effects refuse by name, before any IO happens:
 
   $ jacquard run roundtrip.jqd
-  error[E0814]: this program requires fs [world/medium] — read or mutate the filesystem under the granted root handler, which is not granted (performed via `write`)
-    hint: grant it with --allow fs, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires fs [world/medium] — read or mutate the filesystem under the granted root handler, which is not granted (performed via `write`).
+    Next step: grant it with --allow fs, or handle the effect in the program
   [3]
   $ cat > clocky.jqd <<'JACQUARD'
   > (let nonrec (pwild) (app (var sleep) (lit 0)) (app (var lt) (lit 0) (app (var now))))
   > JACQUARD
   $ jacquard run clocky.jqd
-  error[E0814]: this program requires clock [world/low] — observe wall-clock milliseconds or wait, which is not granted (performed via `sleep`)
-    hint: grant it with --allow clock, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires clock [world/low] — observe wall-clock milliseconds or wait, which is not granted (performed via `sleep`).
+    Next step: grant it with --allow clock, or handle the effect in the program
   [3]
   $ jacquard run clocky.jqd --allow clock
   true
@@ -63,8 +65,9 @@ The infer effect (SL.10): stub completions behind the grant; ungranted refuses:
   > (app (var complete) (app (var mk-prompt) (lit "write a haiku") (var none)))
   > JACQUARD
   $ jacquard run agent.jqd
-  error[E0814]: this program requires infer [model/medium] — request a model completion selected by the handler, which is not granted (performed via `complete`)
-    hint: grant it with --allow infer, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires infer [model/medium] — request a model completion selected by the handler, which is not granted (performed via `complete`).
+    Next step: grant it with --allow infer, or handle the effect in the program
   [3]
   $ jacquard run agent.jqd --allow infer
   "<stub completion for: write a haiku>"

--- a/test/docs-doctest/docs_doctest.ml
+++ b/test/docs-doctest/docs_doctest.ml
@@ -417,14 +417,24 @@ let run_self_tests ~jacquard ~prelude =
       in
       assert_rejected "raw fallback" "(app (var add) (lit 1) (lit 2))\n"
         [
-          "11-14: error[E1220]: expected `,` or `)`, found ident(add)";
-          "21-22: error[E1220]: expected `,` or `)`, found int(1)";
-          "29-30: error[E1220]: expected `,` or `)`, found int(2)";
+          "11-14: error[E1220]: Surface syntax is invalid\n\
+          \  Cause: expected `,` or `)`, found ident(add)\n\
+          \  Next step: Correct the syntax at this location and parse the file again.";
+          "21-22: error[E1220]: Surface syntax is invalid\n\
+          \  Cause: expected `,` or `)`, found int(1)\n\
+          \  Next step: Correct the syntax at this location and parse the file again.";
+          "29-30: error[E1220]: Surface syntax is invalid\n\
+          \  Cause: expected `,` or `)`, found int(2)\n\
+          \  Next step: Correct the syntax at this location and parse the file again.";
         ];
       assert_rejected "recovery hole" "add(1,, 2)\n"
         [
-          "7-8: error[E1220]: expected an expression, found ,";
-          "9-10: error[E1220]: expected `,` or `)`, found int(2)";
+          "7-8: error[E1220]: Surface syntax is invalid\n\
+          \  Cause: expected an expression, found ,\n\
+          \  Next step: Correct the syntax at this location and parse the file again.";
+          "9-10: error[E1220]: Surface syntax is invalid\n\
+          \  Cause: expected `,` or `)`, found int(2)\n\
+          \  Next step: Correct the syntax at this location and parse the file again.";
         ]);
   with_test_dir "signature" (fun root fixtures ->
       let doc = Filename.concat root "doc.md" in

--- a/test/docs-doctest/fixtures/concurrency-channel-type-mismatch.stderr
+++ b/test/docs-doctest/fixtures/concurrency-channel-type-mismatch.stderr
@@ -1,1 +1,3 @@
-fixtures/concurrency-channel-type-mismatch.jac:12:1-59: error[E0804]: equation definition `send-text-to-int` does not match its signature: expected (channel-handle int) ->{channel} result channel-error (), got (channel-handle text) ->{channel | e} result channel-error () (type mismatch)
+fixtures/concurrency-channel-type-mismatch.jac:12:1-59: error[E0804]: The value does not satisfy its annotation
+  Cause: equation definition `send-text-to-int` does not match its signature: expected (channel-handle int) ->{channel} result channel-error (), got (channel-handle text) ->{channel | e} result channel-error () (type mismatch)
+  Next step: Change the value or its annotation so the two types agree.

--- a/test/docs-doctest/fixtures/concurrency-row-laundering.stderr
+++ b/test/docs-doctest/fixtures/concurrency-row-laundering.stderr
@@ -1,1 +1,3 @@
-fixtures/concurrency-row-laundering.jac:12:1-69: error[E0804]: equation definition `launder` does not match its signature: expected () ->{async} task text, got () ->{async, net | e} task text (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
+fixtures/concurrency-row-laundering.jac:12:1-69: error[E0804]: The value does not satisfy its annotation
+  Cause: equation definition `launder` does not match its signature: expected () ->{async} task text, got () ->{async, net | e} task text (a closed effect row cannot absorb extra effects; a stored definition passed as a thunk can be eta-expanded at the use site: (lam () (app (var f))))
+  Next step: Change the value or its annotation so the two types agree.

--- a/test/docs-doctest/fixtures/tutorial-nonexhaustive.stderr
+++ b/test/docs-doctest/fixtures/tutorial-nonexhaustive.stderr
@@ -1,2 +1,3 @@
-fixtures/tutorial-nonexhaustive.jac:1:17-18: error[E0813]: this match is not exhaustive: it misses false
-  hint: add a clause matching the witness, or a (pwild) default
+fixtures/tutorial-nonexhaustive.jac:1:17-18: error[E0813]: This match is not exhaustive
+  Cause: this match is not exhaustive: it misses false
+  Next step: Add a clause matching the witness or a wildcard default.

--- a/test/dune
+++ b/test/dune
@@ -84,7 +84,7 @@
  (name test_jacquard)
  (modules
   (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace))
- (libraries jacquard corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str)
+ (libraries jacquard corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)

--- a/test/gauntlet/checker-effects.t
+++ b/test/gauntlet/checker-effects.t
@@ -15,8 +15,9 @@ ambient row must include net.
   call-twice : forall a | e. ((Int) ->{| e} a) ->{| e} (a, a)
   _ : (Text, Text)
   $ jacquard check ho-net.jqd --manifest console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [1]
   $ jacquard check ho-net.jqd --manifest net
   ok
@@ -41,8 +42,9 @@ A handler for console removes console, but the net effect remains in the manifes
   $ jacquard check handle-net.jqd --print-sigs
   _ : ((), Text)
   $ jacquard check handle-net.jqd --manifest console
-  error[E0814]: this program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`)
-    hint: grant it with --allow net, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires net [world/high] — reach a network endpoint through the granted handler, which is not granted (performed via `net.get`).
+    Next step: grant it with --allow net, or handle the effect in the program
   [1]
   $ jacquard check handle-net.jqd --manifest net
   ok

--- a/test/gauntlet/eval-capabilities.t
+++ b/test/gauntlet/eval-capabilities.t
@@ -9,7 +9,9 @@ the net root handler.
   > (app (var eval-code) (quote (app (var net.get) (lit "https://example.com"))))
   > EOF_JQD
   $ jacquard run eval-net.jqd --allow eval
-  unhandled effect net: operation `fetch` reached the root without a handler
+  error: An effect reached the root without a handler
+    Cause: unhandled effect net: operation `fetch` reached the root without a handler
+    Next step: Grant the effect at the root or handle it inside the program.
   [3]
   $ jacquard run eval-net.jqd --allow eval --allow net
   "<stub response for https://example.com>"
@@ -18,8 +20,9 @@ Granting net without eval still fails before runtime because the surface program
 manifest requires eval.
 
   $ jacquard run eval-net.jqd --allow net
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   [3]
 
 Even pure eval is gated; there is no pure-code shortcut around the capability.
@@ -28,8 +31,9 @@ Even pure eval is gated; there is no pure-code shortcut around the capability.
   > (app (var eval-code) (quote (lit 1)))
   > EOF_JQD
   $ jacquard run pure-eval.jqd
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   [3]
 
 The surface spelling has the same gate. Quoting ordinary surface syntax does not
@@ -39,8 +43,9 @@ resolve or execute the payload early.
   > eval-code(quote { add(40, 2) })
   > EOF_JAC
   $ jacquard run pure-eval.jac
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   [3]
   $ jacquard run pure-eval.jac --allow eval
   42
@@ -52,33 +57,42 @@ manifest. Granting console without Eval refuses before the payload can print.
   > eval-code(quote { print("AUTHORITY LEAK\n") })
   > EOF_JAC
   $ jacquard run hidden-console.jac --allow console
-  error[E0814]: this program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`)
-    hint: grant it with --allow eval, or handle the effect in the program
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires eval [meta/high] — run code constructed or loaded at runtime, which is not granted (performed via `eval-code`).
+    Next step: grant it with --allow eval, or handle the effect in the program
   [3]
 
 Eval alone installs only Eval. Each hidden world operation still reaches an
 unhandled root; no fs, clock, console, or net handler is installed implicitly.
 
   $ jacquard run hidden-console.jac --allow eval
-  unhandled effect console: operation `print` reached the root without a handler
+  error: An effect reached the root without a handler
+    Cause: unhandled effect console: operation `print` reached the root without a handler
+    Next step: Grant the effect at the root or handle it inside the program.
   [3]
   $ cat > hidden-fs.jac <<'EOF_JAC'
   > eval-code(quote { `op:read`("/definitely-not-read-by-eval") })
   > EOF_JAC
   $ jacquard run hidden-fs.jac --allow eval
-  unhandled effect fs: operation `read` reached the root without a handler
+  error: An effect reached the root without a handler
+    Cause: unhandled effect fs: operation `read` reached the root without a handler
+    Next step: Grant the effect at the root or handle it inside the program.
   [3]
   $ cat > hidden-clock.jac <<'EOF_JAC'
   > eval-code(quote { `op:now`() })
   > EOF_JAC
   $ jacquard run hidden-clock.jac --allow eval
-  unhandled effect clock: operation `now` reached the root without a handler
+  error: An effect reached the root without a handler
+    Cause: unhandled effect clock: operation `now` reached the root without a handler
+    Next step: Grant the effect at the root or handle it inside the program.
   [3]
   $ cat > hidden-net.jac <<'EOF_JAC'
   > eval-code(quote { net.get("https://example.com") })
   > EOF_JAC
   $ jacquard run hidden-net.jac --allow eval
-  unhandled effect net: operation `fetch` reached the root without a handler
+  error: An effect reached the root without a handler
+    Cause: unhandled effect net: operation `fetch` reached the root without a handler
+    Next step: Grant the effect at the root or handle it inside the program.
   [3]
 
 The operation runs only when both authorities are explicit.
@@ -97,5 +111,7 @@ non-Code value. This is a language diagnostic, not an OCaml exception.
   > }
   > EOF_JAC
   $ jacquard run non-code-splice.jac
-  type error: unquote splice evaluated to 5, not code
+  error: Runtime value has the wrong type
+    Cause: type error: unquote splice evaluated to 5, not code
+    Next step: Pass a value of the type required by this operation.
   [2]

--- a/test/native-eligibility.txt
+++ b/test/native-eligibility.txt
@@ -18,6 +18,6 @@ demos/worlds/agent-dream.jqd|builtin `text.contains?` is not yet implemented nat
 #
 # companion files: decl-dependent on their sibling demo, not standalone
 # (the interpreter refuses them identically at check time):
-demos/tooling/repair-warp-tests.jqd|error[E0301]: unknown name
-demos/tooling/showcase-warp-tests.jqd|error[E0301]: unknown name
-demos/worlds/escrow/main.jqd|error[E0301]: unknown name `escrow.workflow`
+demos/tooling/repair-warp-tests.jqd|error[E0301]: This reference names something that is not in scope.
+demos/tooling/showcase-warp-tests.jqd|error[E0301]: This reference names something that is not in scope.
+demos/worlds/escrow/main.jqd|error[E0301]: This reference names something that is not in scope.

--- a/test/once_interpreter_probe.ml
+++ b/test/once_interpreter_probe.ml
@@ -4,6 +4,8 @@ let fail_diags stage diagnostics =
   prerr_endline (stage ^ ": " ^ String.concat "; " (List.map Diag.to_string diagnostics));
   exit 1
 
+let print_runtime_error error = prerr_endline (Diag.to_string (Runtime_err.to_diag error))
+
 let rec remove_tree path =
   if Sys.file_exists path then
     if Sys.is_directory path then (
@@ -57,7 +59,7 @@ let () =
         prerr_endline ("capture unexpectedly returned " ^ Value.show value);
         exit 1
     | Error error ->
-        prerr_endline (Runtime_err.to_string error);
+        print_runtime_error error;
         exit 1
   in
   (match Eval.call ctx resume [ Value.VInt 11 ] with
@@ -66,14 +68,14 @@ let () =
       prerr_endline ("first resume returned " ^ Value.show value);
       exit 1
   | Error error ->
-      prerr_endline (Runtime_err.to_string error);
+      print_runtime_error error;
       exit 1);
   match Eval.call ctx resume [ Value.VInt 12 ] with
   | Error Runtime_err.Once_resumed_twice ->
-      prerr_endline (Runtime_err.to_string Runtime_err.Once_resumed_twice);
+      print_runtime_error Runtime_err.Once_resumed_twice;
       exit 2
   | Error error ->
-      prerr_endline (Runtime_err.to_string error);
+      print_runtime_error error;
       exit 1
   | Ok value ->
       prerr_endline ("second resume returned " ^ Value.show value);

--- a/test/test_approval.ml
+++ b/test/test_approval.ml
@@ -175,7 +175,9 @@ let test_malformed_and_hashless_rejected () =
   | Error diagnostics ->
       Alcotest.(check bool)
         "hashless proposal gets a checker diagnostic" true
-        (List.exists (fun diagnostic -> String.equal diagnostic.Diag.code "E0801") diagnostics)
+        (List.exists
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0801")
+           diagnostics)
   | Ok _ -> Alcotest.fail "hashless Proposal typechecked");
   ignore valid
 

--- a/test/test_audit.ml
+++ b/test/test_audit.ml
@@ -98,11 +98,11 @@ let test_opaque_constructor_direct_hash_is_sealed () =
   let opaque_hex = "d48426af83dd64417666d11346b732136f39950871f9c4708e947515f9eda3db" in
   let opaque = Option.get (Hash.of_hex opaque_hex) in
   (match Store.locate store opaque with
-  | Error [ { Diag.code = "E0601"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
   | Error diagnostics -> Eval_support.fail_diags "opaque member lookup" diagnostics
   | Ok _ -> Alcotest.fail "opaque constructor remained addressable by its derived hash");
   (match Store.bind_name store "forged-hash" opaque with
-  | Error [ { Diag.code = "E0601"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
   | Error diagnostics -> Eval_support.fail_diags "opaque member rebinding" diagnostics
   | Ok () -> Alcotest.fail "opaque constructor could be rebound to a public name");
   let reopened =
@@ -111,24 +111,25 @@ let test_opaque_constructor_direct_hash_is_sealed () =
     | Error diagnostics -> Eval_support.fail_diags "reopen opaque store" diagnostics
   in
   (match Store.locate reopened opaque with
-  | Error [ { Diag.code = "E0601"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
   | Error diagnostics -> Eval_support.fail_diags "reopened opaque member lookup" diagnostics
   | Ok _ -> Alcotest.fail "reopen restored the opaque derived-hash index entry");
   Alcotest.(check bool)
     "reopen preserves hidden name" true
     (Store.lookup_kind reopened "hash-opaque" Resolve.KCon = None);
   (match check_expr (Printf.sprintf "(ref #%s con)" opaque_hex) with
-  | Error [ { Diag.code = "E0805"; message; _ } ] ->
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0805" ->
       Alcotest.(check bool)
         "direct hash is diagnosed unknown" true
-        (String.starts_with ~prefix:"error[E0601]: unknown hash" message)
+        (String.starts_with ~prefix:"E0601:" (Diag.cause diagnostic)
+        && String.ends_with ~suffix:(opaque_hex ^ ")") (Diag.cause diagnostic))
   | Error diagnostics -> Eval_support.fail_diags "check opaque direct reference" diagnostics
   | Ok _ -> Alcotest.fail "opaque constructor direct reference typechecked");
   (match Eval_support.eval_with ctx store (Printf.sprintf "(ref #%s con)" opaque_hex) with
   | Error (Runtime_err.Unresolved message) ->
       Alcotest.(check bool)
         "unchecked evaluator also fails closed" true
-        (String.starts_with ~prefix:"error[E0601]: unknown hash" message)
+        (String.starts_with ~prefix:"E0601:" message)
   | Error error ->
       Alcotest.failf "opaque direct reference failed with the wrong runtime error: %s"
         (Runtime_err.to_string error)

--- a/test/test_audit_chain.ml
+++ b/test/test_audit_chain.ml
@@ -57,7 +57,7 @@ let chain entries =
 let golden_bytes, golden_head = chain entries
 
 let expect_error label code = function
-  | Error ({ Diag.code = actual; _ } :: _) -> Alcotest.(check string) label code actual
+  | Error (diagnostic :: _) -> Alcotest.(check string) label code (Diag.code_or_uncoded diagnostic)
   | Error [] -> Alcotest.failf "%s returned an empty diagnostic list" label
   | Ok hash -> Alcotest.failf "%s accepted chain with head #%s" label (Hash.to_hex hash)
 
@@ -335,9 +335,12 @@ let test_concurrent_truncation_is_total () =
       let classified = ref 0 in
       (match Audit_chain.verify_file ~file ~expected_head:Audit_chain.genesis with
       | Ok _ -> Alcotest.fail "held invalid audit snapshot was accepted"
-      | Error ({ Diag.code = "E1301" | "E1306"; _ } :: _) -> ()
-      | Error ({ Diag.code; _ } :: _) ->
-          Alcotest.failf "held invalid audit snapshot returned unexpected %s" code
+      | Error (diagnostic :: _) when List.mem (Diag.code_or_uncoded diagnostic) [ "E1301"; "E1306" ]
+        ->
+          ()
+      | Error (diagnostic :: _) ->
+          Alcotest.failf "held invalid audit snapshot returned unexpected %s"
+            (Diag.code_or_uncoded diagnostic)
       | Error [] -> Alcotest.fail "concurrent read returned an empty diagnostic list"
       | exception exception_ ->
           Alcotest.failf "concurrent truncate escaped %s" (Printexc.to_string exception_));
@@ -347,9 +350,12 @@ let test_concurrent_truncation_is_total () =
       for _ = 1 to 64 do
         match Audit_chain.verify_file ~file ~expected_head:Audit_chain.genesis with
         | Ok _ -> incr classified
-        | Error ({ Diag.code = "E1301" | "E1306"; _ } :: _) -> incr classified
-        | Error ({ Diag.code; _ } :: _) ->
-            Alcotest.failf "concurrent truncate returned unexpected %s" code
+        | Error (diagnostic :: _)
+          when List.mem (Diag.code_or_uncoded diagnostic) [ "E1301"; "E1306" ] ->
+            incr classified
+        | Error (diagnostic :: _) ->
+            Alcotest.failf "concurrent truncate returned unexpected %s"
+              (Diag.code_or_uncoded diagnostic)
         | Error [] -> Alcotest.fail "concurrent read returned an empty diagnostic list"
         | exception exception_ ->
             Alcotest.failf "concurrent truncate escaped %s" (Printexc.to_string exception_)

--- a/test/test_cancellation.ml
+++ b/test/test_cancellation.ml
@@ -63,7 +63,11 @@ let test_routed_effect_preemption_and_fault_result () =
   Alcotest.(check (list int)) "preempted continuation destroyed" [ 30 ] !drops;
   let fault_scope, faulting = Structured_scope.create ~body_resume:1 |> ok in
   ignore (Structured_scope.checkout fault_scope faulting |> ok);
-  let injected = Diag.error ~code:"E9997" "injected routed-effect fault" in
+  let injected =
+    Diag.error ~domain:Runtime ~code:"E9997" ~summary:"Injected routed-effect fault"
+      ~cause:"The cancellation test injected a routed-effect failure."
+      ~next_step:"Propagate the injected diagnostic unchanged." ~contrast:None ()
+  in
   (match
      Structured_scope.route_effect fault_scope ~task:faulting ~resume:31 ~drop:ignore
        ~action:(fun () ->
@@ -73,7 +77,7 @@ let test_routed_effect_preemption_and_fault_result () =
    with
   | Structured_scope.Effect_routed { resume; result = Error [ diagnostic ] } ->
       Alcotest.(check int) "fault returns continuation" 31 resume;
-      Alcotest.(check string) "fault preserved" "E9997" diagnostic.code
+      Alcotest.(check string) "fault preserved" "E9997" (Diag.code_or_uncoded diagnostic)
   | Structured_scope.Effect_routed _ -> Alcotest.fail "wrong routed fault shape"
   | Structured_scope.Effect_cancelled _ -> Alcotest.fail "uncancelled routed action was preempted");
   Alcotest.(check int) "faulting action ran once" 1 !calls;

--- a/test/test_canon.ml
+++ b/test/test_canon.ml
@@ -422,13 +422,13 @@ let test_groupref_gated () =
     | Error _ -> Alcotest.fail "validation failed"
   in
   (match Canon.hash_top (top "(groupref 0)") with
-  | Error [ d ] -> Alcotest.(check string) "outside group" "E0503" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "outside group" "E0503" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "bare groupref must not hash");
   (match Canon.hash_top (top "(app (groupref 7) (lit 1))") with
-  | Error [ d ] -> Alcotest.(check string) "nested outside group" "E0503" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "nested outside group" "E0503" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "nested bare groupref must not hash");
   match Canon.hash_top (top "(defterm ((binding f () (groupref 5))))") with
-  | Error [ d ] -> Alcotest.(check string) "out of range" "E0503" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "out of range" "E0503" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "out-of-range groupref must not hash"
 
 let test_unresolved_rejected () =
@@ -438,10 +438,10 @@ let test_unresolved_rejected () =
     | Error _ -> Alcotest.fail "validation failed"
   in
   (match Canon.hash_top (top "(app (var free-name) (lit 1))") with
-  | Error [ d ] -> Alcotest.(check string) "free var" "E0502" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "free var" "E0502" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "unresolved var must be rejected");
   match Canon.hash_top (top "(match (lit 1) (clause (pcon true) (lit 0)))") with
-  | Error [ d ] -> Alcotest.(check string) "named con" "E0501" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "named con" "E0501" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "unresolved constructor must be rejected"
 
 let test_quoted_surface_marker_validation () =
@@ -468,7 +468,9 @@ let test_quoted_surface_marker_validation () =
           let expression = Kernel.{ it = Quote (wrap malformed_marker); meta = Meta.empty } in
           match Canon.hash_expr expression with
           | Error [ diagnostic ] ->
-              Alcotest.(check string) (position ^ " " ^ shape) expected_code diagnostic.Diag.code
+              Alcotest.(check string)
+                (position ^ " " ^ shape)
+                expected_code (Diag.code_or_uncoded diagnostic)
           | Error diagnostics ->
               Alcotest.failf "%s %s: unexpected diagnostics: %s" position shape
                 (String.concat "; " (List.map Diag.to_string diagnostics))

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -137,22 +137,22 @@ let test_value_restriction () =
   with
   | Ok _ -> Alcotest.fail "non-value must not generalize"
   | Error [ d ] ->
-      Alcotest.(check string) "focused code" "E0818" d.Diag.code;
-      Alcotest.(check (option string))
+      Alcotest.(check string) "focused code" "E0818" (Diag.code_or_uncoded d);
+      Alcotest.(check string)
         "actionable value-restriction hint"
-        (Some "eta-expand the binding to a lambda value, or give each use its own binding")
-        d.Diag.hint
+        "eta-expand the binding to a lambda value, or give each use its own binding"
+        (Diag.next_step d)
   | Error _ -> Alcotest.fail "expected one diagnostic"
 
 let test_ann_mismatch_elaborated () =
   let h = make_cctx () in
   let d = err_of h "(ann (lit 1) (tref text))" in
-  Alcotest.(check string) "code" "E0804" d.Diag.code;
+  Alcotest.(check string) "code" "E0804" (Diag.code_or_uncoded d);
   Alcotest.(check bool)
     "both types printed" true
     (let has needle =
-       let n = String.length needle and m = String.length d.Diag.message in
-       let rec go i = i + n <= m && (String.sub d.Diag.message i n = needle || go (i + 1)) in
+       let n = String.length needle and m = String.length (Diag.cause d) in
+       let rec go i = i + n <= m && (String.sub (Diag.cause d) i n = needle || go (i + 1)) in
        go 0
      in
      has "text" && has "int")
@@ -164,23 +164,23 @@ let test_ann_skolem_escape () =
     err_of h
       "(ann (lam ((pvar x)) (lit 1)) (tforall ((tvar a)) () (tarrow ((tvar a)) (row) (tvar a))))"
   in
-  Alcotest.(check string) "code" "E0804" d.Diag.code
+  Alcotest.(check string) "code" "E0804" (Diag.code_or_uncoded d)
 
 let test_effect_row_mismatch () =
   let h = make_cctx () in
   (* annotation says pure, body prints *)
   let d = err_of h "(ann (lam () (app (var print) (lit \"x\"))) (tarrow () (row) (ttuple)))" in
-  Alcotest.(check string) "code" "E0804" d.Diag.code
+  Alcotest.(check string) "code" "E0804" (Diag.code_or_uncoded d)
 
 let test_application_arity () =
   let h = make_cctx () in
   let d = err_of h "(app (lam ((pvar x)) (var x)) (lit 1) (lit 2))" in
-  Alcotest.(check string) "code" "E0803" d.Diag.code
+  Alcotest.(check string) "code" "E0803" (Diag.code_or_uncoded d)
 
 let test_not_a_function () =
   let h = make_cctx () in
   let d = err_of h "(app (lit 3) (lit 1))" in
-  Alcotest.(check string) "code" "E0802" d.Diag.code
+  Alcotest.(check string) "code" "E0802" (Diag.code_or_uncoded d)
 
 let test_handler_removes_effect () =
   let h = make_cctx () in
@@ -214,7 +214,7 @@ let test_resume_type_enforced () =
       "(handle (app (var abort)) (ret (pvar x) (var x)) (opclause abort () k (app (var k) (lit 1) \
        (lit 2))))"
   in
-  Alcotest.(check string) "code" "E0803" d.Diag.code
+  Alcotest.(check string) "code" "E0803" (Diag.code_or_uncoded d)
 
 let test_resume_wrong_typed_argument () =
   let h = make_cctx () in
@@ -224,7 +224,7 @@ let test_resume_wrong_typed_argument () =
       "(handle (app (var print) (lit \"x\")) (ret (pvar x) (var x)) (opclause print ((pvar t)) k \
        (app (var k) (lit 1))))"
   in
-  Alcotest.(check string) "code" "E0801" d.Diag.code
+  Alcotest.(check string) "code" "E0801" (Diag.code_or_uncoded d)
 
 let test_op_clause_arity () =
   let h = make_cctx () in
@@ -234,7 +234,7 @@ let test_op_clause_arity () =
       "(handle (app (var print) (lit \"x\")) (ret (pvar x) (var x)) (opclause print ((pvar a) \
        (pvar b)) k (app (var k) (tuple))))"
   in
-  Alcotest.(check string) "code" "E0803" d.Diag.code
+  Alcotest.(check string) "code" "E0803" (Diag.code_or_uncoded d)
 
 (* --- EL.2: built-in affine Resume for Once clauses --- *)
 
@@ -284,10 +284,12 @@ let test_once_resume_immediate_transformer () =
           (app (var later) (var unit)))))")
   in
   Alcotest.(check string)
-    "a bound answer cannot launder a later Once token" "E0817" laundered_later.code;
+    "a bound answer cannot launder a later Once token" "E0817"
+    (Diag.code_or_uncoded laundered_later);
   Alcotest.(check bool)
     "later-token laundering has a pointed explanation" true
-    (contains laundered_later.message "may produce a transformer carrying a later once resumption");
+    (contains (Diag.cause laundered_later)
+       "may produce a transformer carrying a later once resumption");
   let intervening_multi =
     err_of (make_cctx ())
       (successive_once
@@ -297,7 +299,7 @@ let test_once_resume_immediate_transformer () =
   in
   Alcotest.(check string)
     "a Multi effect cannot run while a later Once transformer is live" "E0817"
-    intervening_multi.code;
+    (Diag.code_or_uncoded intervening_multi);
   let duplicated_current =
     err_of (make_cctx ())
       (successive_once
@@ -307,7 +309,7 @@ let test_once_resume_immediate_transformer () =
   in
   Alcotest.(check string)
     "direct duplication in a successive Once transformer remains affine" "E0816"
-    duplicated_current.code;
+    (Diag.code_or_uncoded duplicated_current);
   let direct body args =
     with_once_transformer (Printf.sprintf "(app %s %s)" (once_transformer_handle body) args)
   in
@@ -326,8 +328,8 @@ let test_once_resume_immediate_transformer () =
     (with_once_transformer (Printf.sprintf "(app %s (quote (lit 1)))" polymorphic_handle));
   let expect_escape what source =
     let diagnostic = err_of (make_cctx ()) source in
-    Alcotest.(check string) (what ^ " code") "E0817" diagnostic.code;
-    Alcotest.(check bool) (what ^ " has a source span") true (Option.is_some diagnostic.span)
+    Alcotest.(check string) (what ^ " code") "E0817" (Diag.code_or_uncoded diagnostic);
+    Alcotest.(check bool) (what ^ " has a source span") true (Option.is_some (Diag.span diagnostic))
   in
   let bare = once_transformer_handle good_body in
   let annotated = Printf.sprintf "(ann %s (tarrow ((ttuple)) (row) (tref int)))" bare in
@@ -380,19 +382,23 @@ let test_once_resume_immediate_transformer () =
           (var k) (lit 2)) (var unit))))"
          "(tuple)")
   in
-  Alcotest.(check string) "double resume in transformer" "E0816" doubled.code;
+  Alcotest.(check string) "double resume in transformer" "E0816" (Diag.code_or_uncoded doubled);
   Alcotest.(check bool)
     "double transformer resume retains both witnesses" true
-    (contains doubled.message "first consumption at c.jqd:"
-    && contains doubled.message "second consumption at c.jqd:");
+    (contains (Diag.cause doubled) "first consumption at c.jqd:"
+    && contains (Diag.cause doubled) "second consumption at c.jqd:");
   let outer_arity = err_of (make_cctx ()) (direct good_body "(tuple) (tuple)") in
   Alcotest.(check string)
-    "outer malformed application keeps arity precedence" "E0803" outer_arity.code;
+    "outer malformed application keeps arity precedence" "E0803"
+    (Diag.code_or_uncoded outer_arity);
   let resume_arity = err_of (make_cctx ()) (direct "(lam ((pvar unit)) (app (var k)))" "(tuple)") in
-  Alcotest.(check string) "inner malformed resume keeps arity precedence" "E0803" resume_arity.code;
+  Alcotest.(check string)
+    "inner malformed resume keeps arity precedence" "E0803"
+    (Diag.code_or_uncoded resume_arity);
   let argument_type = err_of (make_cctx ()) (direct good_body "(lit 1)") in
   Alcotest.(check string)
-    "value argument still receives ordinary type checking" "E0801" argument_type.code;
+    "value argument still receives ordinary type checking" "E0801"
+    (Diag.code_or_uncoded argument_type);
   check_ok (make_cctx ()) "ordinary State remains accepted"
     "(app (var state.run) (lam () (app (var get))) (lit 41))";
   check_ok (make_cctx ()) "ordinary Check remains accepted"
@@ -442,7 +448,8 @@ let test_once_resume_branch_flow_is_bounded () =
        \        some (pvar value)) (lit 0)) (clause (pcon none) (app (var k) (lit 2)))))");
   let correlated_overlap = err_of (make_cctx ()) (correlated "(app (var k) (lit 2))" "(lit 0)") in
   Alcotest.(check string)
-    "a feasible repeated arm still consumes twice" "E0816" correlated_overlap.code;
+    "a feasible repeated arm still consumes twice" "E0816"
+    (Diag.code_or_uncoded correlated_overlap);
   let shadowed =
     err_of (make_cctx ())
       "(defeffect linear () (op signal once () (tref int)))\n\
@@ -451,7 +458,8 @@ let test_once_resume_branch_flow_is_bounded () =
        (pcon false) (lit 0))) (let nonrec (pvar flag) (var false) (match (var flag) (clause (pcon \
        true) (lit 0)) (clause (pcon false) (app (var k) (lit 2)))))))))"
   in
-  Alcotest.(check string) "a shadowed name cannot forge scrutinee correlation" "E0816" shadowed.code;
+  Alcotest.(check string)
+    "a shadowed name cannot forge scrutinee correlation" "E0816" (Diag.code_or_uncoded shadowed);
   let unstable =
     err_of (make_cctx ())
       (once_handler
@@ -460,7 +468,8 @@ let test_once_resume_branch_flow_is_bounded () =
           \"second\"))\n\
          \          (clause (pcon true) (lit 0)) (clause (pcon false) (app (var k) (lit 2)))))")
   in
-  Alcotest.(check string) "unstable scrutinees remain conservative" "E0816" unstable.code;
+  Alcotest.(check string)
+    "unstable scrutinees remain conservative" "E0816" (Diag.code_or_uncoded unstable);
   let no_use_match =
     "(match (var true) (clause (pcon true) (lit 0)) (clause (pcon false) (lit 1)))"
   in
@@ -504,12 +513,14 @@ let test_once_resume_double_consumption_spans () =
     err_of (make_cctx ())
       (once_handler "(let nonrec (pwild) (app (var k) (lit 1)) (app (var k) (lit 2)))")
   in
-  Alcotest.(check string) "affine duplication code" "E0816" d.Diag.code;
+  Alcotest.(check string) "affine duplication code" "E0816" (Diag.code_or_uncoded d);
   Alcotest.(check bool)
     "both consumption spans are named" true
-    (contains d.message "first consumption at c.jqd:"
-    && contains d.message "second consumption at c.jqd:");
-  Alcotest.(check bool) "the second consumption is the primary span" true (Option.is_some d.span);
+    (contains (Diag.cause d) "first consumption at c.jqd:"
+    && contains (Diag.cause d) "second consumption at c.jqd:");
+  Alcotest.(check bool)
+    "the second consumption is the primary span" true
+    (Option.is_some (Diag.span d));
   let branch_then_later =
     err_of (make_cctx ())
       (once_handler
@@ -517,14 +528,16 @@ let test_once_resume_double_consumption_spans () =
           (pcon false) (lit 0))) (app (var k) (lit 2)))")
   in
   Alcotest.(check string)
-    "a prior branch and a later call overlap on one possible path" "E0816" branch_then_later.code;
+    "a prior branch and a later call overlap on one possible path" "E0816"
+    (Diag.code_or_uncoded branch_then_later);
   let bad_gate =
     err_of (make_cctx ())
       (once_handler
          "(let nonrec (pvar gate) (lam ((pvar next)) (let nonrec (pwild) (app (var next) (lit 1)) \
           (app (var next) (lit 2)))) (app (var gate) (var k)))")
   in
-  Alcotest.(check string) "the receiving parameter is checked affinely" "E0816" bad_gate.code
+  Alcotest.(check string)
+    "the receiving parameter is checked affinely" "E0816" (Diag.code_or_uncoded bad_gate)
 
 let test_once_resume_type_errors_precede_duplication () =
   let unary_gate call =
@@ -533,13 +546,15 @@ let test_once_resume_type_errors_precede_duplication () =
          call)
   in
   let too_few = err_of (make_cctx ()) (unary_gate "(app (var gate))") in
-  Alcotest.(check string) "too-few helper arity wins" "E0803" too_few.code;
+  Alcotest.(check string) "too-few helper arity wins" "E0803" (Diag.code_or_uncoded too_few);
   let valid_slot_too_many = err_of (make_cctx ()) (unary_gate "(app (var gate) (var k) (lit 0))") in
   Alcotest.(check string)
-    "valid Resume slot does not hide too-many helper arity" "E0803" valid_slot_too_many.code;
+    "valid Resume slot does not hide too-many helper arity" "E0803"
+    (Diag.code_or_uncoded valid_slot_too_many);
   let local_out_of_range = err_of (make_cctx ()) (unary_gate "(app (var gate) (lit 0) (var k))") in
   Alcotest.(check string)
-    "out-of-range local-helper transfer defers to arity" "E0803" local_out_of_range.code;
+    "out-of-range local-helper transfer defers to arity" "E0803"
+    (Diag.code_or_uncoded local_out_of_range);
   let stored_out_of_range =
     err_of (make_cctx ())
       ("(defeffect linear () (op signal once () (tref int)))\n"
@@ -548,7 +563,8 @@ let test_once_resume_type_errors_precede_duplication () =
      ^ "(opclause signal () k (app (var gate) (lit 0) (var k))))")
   in
   Alcotest.(check string)
-    "out-of-range stored-helper transfer defers to arity" "E0803" stored_out_of_range.code;
+    "out-of-range stored-helper transfer defers to arity" "E0803"
+    (Diag.code_or_uncoded stored_out_of_range);
   let local_recursive_gate call =
     once_handler
       (Printf.sprintf
@@ -567,55 +583,60 @@ let test_once_resume_type_errors_precede_duplication () =
     err_of (make_cctx ()) (local_recursive_gate "(app (var gate) (lit 0))")
   in
   Alcotest.(check string)
-    "too-few local recursive helper stays arity" "E0803" local_recursive_too_few.code;
+    "too-few local recursive helper stays arity" "E0803"
+    (Diag.code_or_uncoded local_recursive_too_few);
   let stored_recursive_too_few =
     err_of (make_cctx ()) (stored_recursive_gate "(app (var gate) (lit 0))")
   in
   Alcotest.(check string)
-    "too-few stored recursive helper stays arity" "E0803" stored_recursive_too_few.code;
+    "too-few stored recursive helper stays arity" "E0803"
+    (Diag.code_or_uncoded stored_recursive_too_few);
   let local_recursive_in_range =
     err_of (make_cctx ()) (local_recursive_gate "(app (var gate) (var k) (lit 0))")
   in
   Alcotest.(check string)
-    "in-range local recursive transfer stays escape" "E0817" local_recursive_in_range.code;
+    "in-range local recursive transfer stays escape" "E0817"
+    (Diag.code_or_uncoded local_recursive_in_range);
   let stored_recursive_in_range =
     err_of (make_cctx ()) (stored_recursive_gate "(app (var gate) (var k) (lit 0))")
   in
   Alcotest.(check string)
-    "in-range stored recursive transfer stays escape" "E0817" stored_recursive_in_range.code;
+    "in-range stored recursive transfer stays escape" "E0817"
+    (Diag.code_or_uncoded stored_recursive_in_range);
   let local_recursive_valid_slot_too_many =
     err_of (make_cctx ()) (local_recursive_gate "(app (var gate) (lit 0) (var k) (lit 0))")
   in
   Alcotest.(check string)
     "valid local recursive slot outranks too-many arity" "E0817"
-    local_recursive_valid_slot_too_many.code;
+    (Diag.code_or_uncoded local_recursive_valid_slot_too_many);
   let stored_recursive_valid_slot_too_many =
     err_of (make_cctx ()) (stored_recursive_gate "(app (var gate) (lit 0) (var k) (lit 0))")
   in
   Alcotest.(check string)
     "valid stored recursive slot outranks too-many arity" "E0817"
-    stored_recursive_valid_slot_too_many.code;
+    (Diag.code_or_uncoded stored_recursive_valid_slot_too_many);
   let local_recursive_index_two =
     err_of (make_cctx ()) (local_recursive_gate "(app (var gate) (lit 0) (lit 0) (var k))")
   in
   Alcotest.(check string)
     "out-of-range local recursive binary index two defers to arity" "E0803"
-    local_recursive_index_two.code;
+    (Diag.code_or_uncoded local_recursive_index_two);
   let stored_recursive_index_two =
     err_of (make_cctx ()) (stored_recursive_gate "(app (var gate) (lit 0) (lit 0) (var k))")
   in
   Alcotest.(check string)
     "out-of-range stored recursive binary index two defers to arity" "E0803"
-    stored_recursive_index_two.code;
+    (Diag.code_or_uncoded stored_recursive_index_two);
   let arity =
     err_of (make_cctx ()) (once_handler "(let nonrec (pwild) (app (var k)) (app (var k) (lit 1)))")
   in
-  Alcotest.(check string) "malformed resume arity wins" "E0803" arity.code;
+  Alcotest.(check string) "malformed resume arity wins" "E0803" (Diag.code_or_uncoded arity);
   let argument =
     err_of (make_cctx ())
       (once_handler "(let nonrec (pwild) (app (var k) (lit \"not-an-int\")) (app (var k) (lit 1)))")
   in
-  Alcotest.(check string) "malformed resume argument type wins" "E0801" argument.code;
+  Alcotest.(check string)
+    "malformed resume argument type wins" "E0801" (Diag.code_or_uncoded argument);
   let binary_duplication =
     err_of (make_cctx ())
       (once_handler
@@ -623,7 +644,8 @@ let test_once_resume_type_errors_precede_duplication () =
           left) (lit 1)) (app (var right) (lit 2)))) (app (var gate) (var k) (var k)))")
   in
   Alcotest.(check string)
-    "two valid helper slots still share one affine budget" "E0816" binary_duplication.code;
+    "two valid helper slots still share one affine budget" "E0816"
+    (Diag.code_or_uncoded binary_duplication);
   let standalone_body =
     match
       Reader.parse_string ~file:"standalone.jqd"
@@ -638,7 +660,8 @@ let test_once_resume_type_errors_precede_duplication () =
     | Error ds -> Eval_support.fail_diags "standalone affine fixture parse" ds
   in
   (match Affine_resume.check_clause ~resume:"k" standalone_body with
-  | Error [ d ] -> Alcotest.(check string) "standalone safety fallback" "E0817" d.code
+  | Error [ d ] ->
+      Alcotest.(check string) "standalone safety fallback" "E0817" (Diag.code_or_uncoded d)
   | Error ds -> Alcotest.failf "standalone safety expected one diagnostic, got %d" (List.length ds)
   | Ok () -> Alcotest.fail "standalone affine checking must reject an out-of-range transfer");
   let standalone_recursive_body =
@@ -655,7 +678,9 @@ let test_once_resume_type_errors_precede_duplication () =
     | Error ds -> Eval_support.fail_diags "standalone recursive affine fixture parse" ds
   in
   match Affine_resume.check_clause ~resume:"k" standalone_recursive_body with
-  | Error [ d ] -> Alcotest.(check string) "standalone recursive safety fallback" "E0817" d.code
+  | Error [ d ] ->
+      Alcotest.(check string)
+        "standalone recursive safety fallback" "E0817" (Diag.code_or_uncoded d)
   | Error ds ->
       Alcotest.failf "standalone recursive safety expected one diagnostic, got %d" (List.length ds)
   | Ok () ->
@@ -669,16 +694,16 @@ let test_once_resume_aliases_share_one_budget () =
          "(let nonrec (pvar k2) (var k) (let nonrec (pwild) (app (var k) (lit 1)) (app (var k2) \
           (lit 2))))")
   in
-  Alcotest.(check string) "duplicate alias code" "E0816" d.code;
+  Alcotest.(check string) "duplicate alias code" "E0816" (Diag.code_or_uncoded d);
   check_ok (make_cctx ()) "a single moved alias remains affine"
     (once_handler "(let nonrec (pvar k2) (var k) (app (var k2) (lit 1)))")
 
 let check_escape what body expected_fragment =
   let d = err_of (make_cctx ()) (once_handler body) in
-  Alcotest.(check string) (what ^ " code") "E0817" d.code;
+  Alcotest.(check string) (what ^ " code") "E0817" (Diag.code_or_uncoded d);
   Alcotest.(check bool)
     (what ^ " wording") true
-    (contains d.message expected_fragment && Option.is_some d.span)
+    (contains (Diag.cause d) expected_fragment && Option.is_some (Diag.span d))
 
 let test_once_resume_escape_goldens () =
   check_escape "lambda capture" "(let nonrec (pvar f) (lam () (app (var k) (lit 1))) (lit 0))"
@@ -699,10 +724,10 @@ let test_once_resume_escape_goldens () =
     err_of (make_cctx ())
       (once_handler "(let nonrec (pvar escaped) (app (var add) (var k) (lit 1)) (lit 0))")
   in
-  Alcotest.(check string) "unknown call escape code" "E0817" d.code;
+  Alcotest.(check string) "unknown call escape code" "E0817" (Diag.code_or_uncoded d);
   Alcotest.(check bool)
     "unknown call escape wording" true
-    (contains d.message "parameter that is not known to be Resume-typed")
+    (contains (Diag.cause d) "parameter that is not known to be Resume-typed")
 
 let test_once_resume_stored_helper_escape_uses_author_span () =
   let d =
@@ -712,8 +737,8 @@ let test_once_resume_stored_helper_escape_uses_author_span () =
      ^ "(handle (app (var signal)) (ret (pvar x) (var x)) "
      ^ "(opclause signal () k (app (var bad-gate) (var k))))")
   in
-  Alcotest.(check string) "stored helper escape code" "E0817" d.code;
-  (match d.span with
+  Alcotest.(check string) "stored helper escape code" "E0817" (Diag.code_or_uncoded d);
+  (match Diag.span d with
   | Some span -> Alcotest.(check string) "primary span is the author input" "c.jqd" span.Span.file
   | None -> Alcotest.fail "stored helper escape must retain an author source span");
   Alcotest.(check bool)
@@ -728,7 +753,7 @@ let test_once_resume_stored_helper_has_distinct_logical_witnesses () =
         1)) (app (var next) (lit 2)))))))\n" ^ "(handle (app (var signal)) (ret (pvar x) (var x)) "
      ^ "(opclause signal () k (app (var bad-gate) (var k))))")
   in
-  Alcotest.(check string) "stored helper duplication code" "E0816" d.code;
+  Alcotest.(check string) "stored helper duplication code" "E0816" (Diag.code_or_uncoded d);
   let rendered = Diag.to_string d in
   Alcotest.(check bool)
     "stored helper witnesses use an honest stable logical source" true
@@ -742,16 +767,19 @@ let test_once_resume_stored_helper_has_distinct_logical_witnesses () =
     in
     go start
   in
-  match (find_from d.message first_marker 0, find_from d.message second_marker 0) with
+  match (find_from (Diag.cause d) first_marker 0, find_from (Diag.cause d) second_marker 0) with
   | Some first_start, Some second_start ->
       let first_start = first_start + String.length first_marker in
       let second_start = second_start + String.length second_marker in
       let first =
-        String.sub d.message first_start (second_start - String.length second_marker - first_start)
+        String.sub (Diag.cause d) first_start
+          (second_start - String.length second_marker - first_start)
       in
-      let second = String.sub d.message second_start (String.length d.message - second_start) in
+      let second =
+        String.sub (Diag.cause d) second_start (String.length (Diag.cause d) - second_start)
+      in
       Alcotest.(check bool) "stored helper consumption spans are distinct" true (first <> second)
-  | _ -> Alcotest.failf "missing two stored-helper witnesses in: %s" d.message
+  | _ -> Alcotest.failf "missing two stored-helper witnesses in: %s" (Diag.cause d)
 
 let test_multi_resume_remains_ordinary_function () =
   test_once_resume_stored_helper_escape_uses_author_span ();
@@ -769,15 +797,15 @@ let test_declaration_kind_checks () =
   (match
      check_src h "(deftype bad ((tvar a)) (con mk (field (tapp (tref option) (tvar a) (tvar a)))))"
    with
-  | Error [ d ] -> Alcotest.(check string) "arity" "E0810" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "arity" "E0810" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected E0810");
   (* unbound tyvar in a field *)
   (match check_src h "(deftype bad2 () (con mk (field (tvar zz))))" with
-  | Error [ d ] -> Alcotest.(check string) "unbound" "E0811" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "unbound" "E0811" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected E0811");
   (* op returning an unbound var: its own code, distinct from type-decl unbound *)
   match check_src h "(defeffect bade () (op o () (tvar zz)))" with
-  | Error [ d ] -> Alcotest.(check string) "op unbound" "E0812" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "op unbound" "E0812" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected E0812"
 
 let test_group_annotations () =
@@ -802,7 +830,7 @@ let test_group_annotations () =
       "(defterm ((binding liar ((tarrow ((tref int)) (row) (tref text))) (lam ((pvar n)) (var \
        n)))))"
   with
-  | Error [ d ] -> Alcotest.(check string) "annotation mismatch" "E0804" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "annotation mismatch" "E0804" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected E0804"
 
 let manifest_text (_, ctx) row =
@@ -858,10 +886,11 @@ let test_manifest_renders_blessed_risk () =
   | Ok { Check.row = Some row; _ } ->
       Alcotest.(check string)
         "Workspace is a handled facade, not a pure or root-grantable effect"
-        "error[E0814]: this program requires workspace [world/high] — request mediated workspace \
-         reads, writes, or fetches without directly acquiring raw authority, which is not granted \
-         (performed via `workspace.read-file`)\n\
-        \  hint: handle Workspace in the program (Workspace is a world facade and is not \
+        "error[E0814]: The program requires an effect that was not granted\n\
+        \  Cause: This program requires workspace [world/high] — request mediated workspace reads, \
+         writes, or fetches without directly acquiring raw authority, which is not granted \
+         (performed via `workspace.read-file`).\n\
+        \  Next step: handle Workspace in the program (Workspace is a world facade and is not \
          root-grantable)"
         (manifest_text workspace row)
   | Ok _ -> Alcotest.fail "Workspace expression had no manifest"

--- a/test/test_corpus.ml
+++ b/test/test_corpus.ml
@@ -48,9 +48,9 @@ let test_invalid_corpus () =
                 (Corpus_support.stage_ext_name stage);
               Alcotest.(check bool)
                 (Printf.sprintf "%s reports %s (got: %s)" file expected_code
-                   (String.concat ", " (List.map (fun d -> d.Diag.code) diags)))
+                   (String.concat ", " (List.map (fun d -> Diag.code_or_uncoded d) diags)))
                 true
-                (List.exists (fun d -> d.Diag.code = expected_code) diags))
+                (List.exists (fun d -> Diag.code_or_uncoded d = expected_code) diags))
       | Some (expected_stage_name, expected_code) -> (
           (match Corpus_support.stage_of_name expected_stage_name with
           | Some _ -> ()
@@ -65,9 +65,9 @@ let test_invalid_corpus () =
                 expected_stage_name (Corpus_support.stage_name stage);
               Alcotest.(check bool)
                 (Printf.sprintf "%s reports %s (got: %s)" file expected_code
-                   (String.concat ", " (List.map (fun d -> d.Diag.code) diags)))
+                   (String.concat ", " (List.map (fun d -> Diag.code_or_uncoded d) diags)))
                 true
-                (List.exists (fun d -> d.Diag.code = expected_code) diags)))
+                (List.exists (fun d -> Diag.code_or_uncoded d = expected_code) diags)))
     files
 
 (* Sanity for the runner itself: a case that fails at the wrong stage or with the wrong code
@@ -79,7 +79,7 @@ let test_runner_catches_breakage () =
   | _ -> Alcotest.fail "expected a parse-stage failure");
   (* wrong code: E0106, not E0999 *)
   match Corpus_support.staged_pipeline ~file:"broken" "(lit 1" with
-  | Error (_, [ d ]) -> Alcotest.(check bool) "code differs" false (d.Diag.code = "E0999")
+  | Error (_, [ d ]) -> Alcotest.(check bool) "code differs" false (Diag.code_or_uncoded d = "E0999")
   | _ -> Alcotest.fail "expected one diagnostic"
 
 let suite =

--- a/test/test_depth_guards.ml
+++ b/test/test_depth_guards.ml
@@ -31,7 +31,9 @@ let repeated_suffix prefix suffix count =
 
 let expect_code label code = function
   | Error diagnostics
-    when List.exists (fun diagnostic -> String.equal diagnostic.Diag.code code) diagnostics ->
+    when List.exists
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) code)
+           diagnostics ->
       ()
   | Error diagnostics ->
       Alcotest.failf "%s: expected %s, got %s" label code
@@ -47,9 +49,10 @@ let expect_ok label = function
 let expect_exact_e1227 label diagnostics =
   match diagnostics with
   | [ diagnostic ] ->
-      Alcotest.(check string) (label ^ " code") "E1227" diagnostic.Diag.code;
+      Alcotest.(check string) (label ^ " code") "E1227" (Diag.code_or_uncoded diagnostic);
       Alcotest.(check string)
-        (label ^ " wording") "surface syntax nesting exceeds the limit of 10000" diagnostic.message
+        (label ^ " wording") "Surface syntax nesting exceeds the limit of 10000."
+        (Diag.cause diagnostic)
   | diagnostics ->
       Alcotest.failf "%s: expected exactly one diagnostic, got %s" label
         (String.concat "; " (List.map Diag.to_string diagnostics))
@@ -168,10 +171,10 @@ let kernel_diagnostic source =
 
 let check_variable_group_diagnostic label ~wrong_form ~message source =
   let diagnostic = kernel_diagnostic source in
-  Alcotest.(check string) (label ^ " code") "E0203" diagnostic.code;
-  Alcotest.(check string) (label ^ " wording") message diagnostic.message;
+  Alcotest.(check string) (label ^ " code") "E0203" (Diag.code_or_uncoded diagnostic);
+  Alcotest.(check string) (label ^ " wording") message (Diag.cause diagnostic);
   let expected_start = Str.search_forward (Str.regexp_string wrong_form) source 0 in
-  match diagnostic.span with
+  match Diag.span diagnostic with
   | Some span ->
       Alcotest.(check int) (label ^ " span start") expected_start span.Span.start_pos.offset;
       Alcotest.(check int)
@@ -180,10 +183,13 @@ let check_variable_group_diagnostic label ~wrong_form ~message source =
         span.Span.end_pos.offset
   | None -> Alcotest.failf "%s: diagnostic span is missing" label
 
-let capture_entry exception_value =
+let capture_entry ?render_diagnostic exception_value =
   let buffer = Buffer.create 128 in
   let formatter = Format.formatter_of_buffer buffer in
-  let status = Cli_entry.run ~program:"jacquard" ~err:formatter (fun () -> raise exception_value) in
+  let status =
+    Cli_entry.run ~program:"jacquard" ~err:formatter ?render_diagnostic (fun () ->
+        raise exception_value)
+  in
   Format.pp_print_flush formatter ();
   (status, Buffer.contents buffer)
 
@@ -209,7 +215,22 @@ let test_variable_group_diagnostics_unchanged () =
   Alcotest.(check int) "entry stack exit" 1 stack_status;
   Alcotest.(check string)
     "entry stack classification"
-    "error[E0003]: input exhausted the host stack before a structural nesting guard\n" stack_output;
+    "error[E0003]: Input exhausted the host stack before a structural nesting guard\n\
+    \  Cause: An unbounded internal traversal reached the host stack limit before Jacquard could \
+     report its local depth boundary.\n\
+    \  Next step: Reduce the input nesting and report the missing structural guard.\n"
+    stack_output;
+  let json_status, json_output =
+    capture_entry ~render_diagnostic:Diag.to_json_string Stack_overflow
+  in
+  Alcotest.(check int) "entry JSON stack exit" 1 json_status;
+  let json = Yojson.Safe.from_string json_output in
+  Alcotest.(check string)
+    "entry JSON domain" "process"
+    Yojson.Safe.Util.(json |> member "domain" |> to_string);
+  Alcotest.(check string)
+    "entry JSON code" "E0003"
+    Yojson.Safe.Util.(json |> member "code" |> to_string);
   let internal_status, internal_output = capture_entry (Failure "entry-probe") in
   Alcotest.(check int) "entry internal exit" 125 internal_status;
   Alcotest.(check bool)

--- a/test/test_diag.ml
+++ b/test/test_diag.ml
@@ -6,16 +6,180 @@ let span =
     ~end_pos:{ Span.line = 4; col = 9; offset = 38 }
 
 let test_error_fields () =
-  let d = Diag.error ~span ~hint:"try this" ~code:"E0001" "something broke" in
-  Alcotest.(check string) "code" "E0001" d.Diag.code;
-  Alcotest.(check string) "message" "something broke" d.Diag.message;
-  Alcotest.(check bool) "severity" true (d.Diag.severity = Diag.Error);
-  Alcotest.(check (option string)) "hint" (Some "try this") d.Diag.hint
+  let d =
+    Diag.error ~span ~domain:Runtime ~code:"E0001" ~summary:"Runtime operation failed"
+      ~cause:"Something broke while evaluating the operation."
+      ~next_step:"Correct the operation input and run it again." ~contrast:None ()
+  in
+  Alcotest.(check string) "code" "E0001" (Diag.code_or_uncoded d);
+  Alcotest.(check string) "summary" "Runtime operation failed" (Diag.summary d);
+  Alcotest.(check string) "cause" "Something broke while evaluating the operation." (Diag.cause d);
+  Alcotest.(check bool) "severity" true (Diag.severity d = Diag.Error);
+  Alcotest.(check string)
+    "next step" "Correct the operation input and run it again." (Diag.next_step d);
+  Alcotest.(check bool) "no contrast" true (Option.is_none (Diag.contrastive_hint d))
 
 let test_rendering () =
-  let d = Diag.error ~span ~hint:"grant it" ~code:"E0002" "unhandled effect" in
+  let contrast =
+    Diag.contrast ~mistaken:"Declaring Console grants it"
+      ~intended:"The root must grant or handle Console"
+  in
+  let d =
+    Diag.error ~span ~domain:Runtime ~code:"E0002" ~summary:"Console effect is unhandled"
+      ~cause:"The program requires Console, but the root did not grant it."
+      ~next_step:"Run with --allow console or handle Console in the program."
+      ~contrast:(Some contrast) ()
+  in
   Alcotest.(check string)
-    "rendered" "demo.jqd:4:1-9: error[E0002]: unhandled effect\n  hint: grant it" (Diag.to_string d)
+    "rendered"
+    "demo.jqd:4:1-9: error[E0002]: Console effect is unhandled\n\
+    \  Cause: The program requires Console, but the root did not grant it.\n\
+    \  Next step: Run with --allow console or handle Console in the program.\n\
+    \  Contrast: mistaken: Declaring Console grants it; intended: The root must grant or handle \
+     Console"
+    (Diag.to_string d)
+
+let test_json_v1 () =
+  let d =
+    Diag.warning ~domain:Surface ~code:"W1203" ~summary:"Match scrutinee is difficult to review"
+      ~cause:"The scrutinee spans seven lines." ~next_step:"Bind it with `let` first."
+      ~contrast:None ()
+  in
+  let open Yojson.Safe.Util in
+  let json = Diag.to_yojson d in
+  Alcotest.(check string) "schema" "jacquard-diagnostic-v1" (json |> member "schema" |> to_string);
+  Alcotest.(check string) "domain" "surface" (json |> member "domain" |> to_string);
+  Alcotest.(check string) "code" "W1203" (json |> member "code" |> to_string);
+  Alcotest.(check string) "severity" "warning" (json |> member "severity" |> to_string);
+  Alcotest.(check string)
+    "next step" "Bind it with `let` first."
+    (json |> member "next_step" |> to_string);
+  Alcotest.(check bool) "span is null" true (json |> member "span" = `Null);
+  Alcotest.(check bool) "contrast omitted" true (json |> member "contrast" = `Null);
+  let invalid = "bad\xffbytes" in
+  let invalid_span =
+    Span.make ~file:("source-" ^ invalid)
+      ~start_pos:{ Span.line = 1; col = 1; offset = 0 }
+      ~end_pos:{ Span.line = 1; col = 2; offset = 1 }
+  in
+  let invalid_contrast = Diag.contrast ~mistaken:invalid ~intended:("use-" ^ invalid) in
+  let invalid_diagnostic =
+    Diag.error ~span:invalid_span ~domain:Surface ~code:"E1210" ~summary:("summary-" ^ invalid)
+      ~cause:("cause-" ^ invalid) ~next_step:("step-" ^ invalid) ~contrast:(Some invalid_contrast)
+      ()
+  in
+  let replacement = "bad\xef\xbf\xbdbytes" in
+  let repaired = Diag.to_json_string invalid_diagnostic |> Yojson.Safe.from_string in
+  Alcotest.(check string)
+    "invalid UTF-8 cause repaired" ("cause-" ^ replacement)
+    (repaired |> member "cause" |> to_string);
+  Alcotest.(check string)
+    "invalid UTF-8 path repaired" ("source-" ^ replacement)
+    (repaired |> member "span" |> member "file" |> to_string);
+  Alcotest.(check string)
+    "invalid UTF-8 contrast repaired" replacement
+    (repaired |> member "contrast" |> member "mistaken" |> to_string);
+  let repaired_cause bytes =
+    Diag.error ~domain:Surface ~code:"E1210" ~summary:"Invalid input" ~cause:bytes
+      ~next_step:"Replace the invalid input." ~contrast:None ()
+    |> Diag.to_json_string |> Yojson.Safe.from_string |> member "cause" |> to_string
+  in
+  let replacement = "\xef\xbf\xbd" in
+  Alcotest.(check string)
+    "valid UTF-8 preserved" "\xc2\xa2\xe2\x82\xac\xf0\x9f\x91\x8d"
+    (repaired_cause "\xc2\xa2\xe2\x82\xac\xf0\x9f\x91\x8d");
+  List.iter
+    (fun (label, malformed, replacement_count) ->
+      Alcotest.(check string)
+        label
+        (String.concat "" (List.init replacement_count (Fun.const replacement)))
+        (repaired_cause malformed))
+    [
+      ("truncated UTF-8 repaired", "\xc3", 1);
+      ("overlong UTF-8 repaired per byte", "\xc0\x80", 2);
+      ("surrogate UTF-8 repaired per byte", "\xed\xa0\x80", 3);
+      ("out-of-range UTF-8 repaired per byte", "\xf4\x90\x80\x80", 4);
+    ]
+
+let test_contract_rejects_empty_step () =
+  match
+    Diag.error ~domain:Checker ~code:"E0801" ~summary:"Types do not agree"
+      ~cause:"Expected int, found text." ~next_step:"" ~contrast:None ()
+  with
+  | exception Diag.Bug_invalid_diagnostic _ -> ()
+  | _ -> Alcotest.fail "empty primary next step was accepted"
+
+let expect_invalid label build =
+  match build () with
+  | exception Diag.Bug_invalid_diagnostic _ -> ()
+  | _ -> Alcotest.fail (label ^ " was accepted")
+
+let test_contract_rejects_invalid_identity_and_span () =
+  expect_invalid "code-less checker diagnostic" (fun () ->
+      Diag.error ~domain:Checker ~summary:"Types do not agree" ~cause:"Expected int, found text."
+        ~next_step:"Correct the value type." ~contrast:None ());
+  expect_invalid "code-less runtime warning" (fun () ->
+      Diag.warning ~domain:Runtime ~summary:"Runtime warning" ~cause:"A warning occurred."
+        ~next_step:"Correct the runtime input." ~contrast:None ());
+  expect_invalid "code-less runtime info" (fun () ->
+      Diag.info ~domain:Runtime ~summary:"Runtime information" ~cause:"Information is available."
+        ~next_step:"Review the runtime information." ~contrast:None ());
+  expect_invalid "error carrying a warning code" (fun () ->
+      Diag.error ~domain:Checker ~code:"W0801" ~summary:"Types do not agree"
+        ~cause:"Expected int, found text." ~next_step:"Correct the value type." ~contrast:None ());
+  let invalid_span =
+    Span.make ~file:"bad.jac"
+      ~start_pos:{ Span.line = 0; col = 1; offset = 0 }
+      ~end_pos:{ Span.line = 1; col = 1; offset = 0 }
+  in
+  expect_invalid "zero-based diagnostic line" (fun () ->
+      Diag.error ~span:invalid_span ~domain:Checker ~code:"E0801" ~summary:"Types do not agree"
+        ~cause:"Expected int, found text." ~next_step:"Correct the value type." ~contrast:None ());
+  let reversed_line_span =
+    Span.make ~file:"bad.jac"
+      ~start_pos:{ Span.line = 5; col = 1; offset = 10 }
+      ~end_pos:{ Span.line = 4; col = 9; offset = 20 }
+  in
+  expect_invalid "decreasing diagnostic span line" (fun () ->
+      Diag.error ~span:reversed_line_span ~domain:Checker ~code:"E0801"
+        ~summary:"Types do not agree" ~cause:"Expected int, found text."
+        ~next_step:"Correct the value type." ~contrast:None ());
+  let reversed_column_span =
+    Span.make ~file:"bad.jac"
+      ~start_pos:{ Span.line = 5; col = 9; offset = 10 }
+      ~end_pos:{ Span.line = 5; col = 4; offset = 20 }
+  in
+  expect_invalid "decreasing diagnostic span column" (fun () ->
+      Diag.error ~span:reversed_column_span ~domain:Checker ~code:"E0801"
+        ~summary:"Types do not agree" ~cause:"Expected int, found text."
+        ~next_step:"Correct the value type." ~contrast:None ())
+
+let test_cause_projection_excludes_child_actions () =
+  let contrast = Diag.contrast ~mistaken:"a term reference" ~intended:"a type reference" in
+  let child =
+    Diag.error ~domain:Resolution ~code:"E0302" ~summary:"Reference has the wrong kind"
+      ~cause:"`add` is a term, but this position needs a type."
+      ~next_step:"Reference a type declaration instead." ~contrast:(Some contrast) ()
+  in
+  Alcotest.(check string)
+    "cause projection"
+    "E0302: Reference has the wrong kind (`add` is a term, but this position needs a type.)"
+    (Diag.to_cause_string child);
+  Alcotest.(check bool)
+    "child next step excluded" false
+    (String.contains (Diag.to_cause_string child) '\n');
+  let inference =
+    Diag.error ~domain:Inference ~code:"E0901" ~summary:"The posterior is empty."
+      ~cause:"Every execution branch has zero weight."
+      ~next_step:"Change the model so one branch has nonzero weight." ~contrast:None ()
+  in
+  let projected = Runtime_err.to_diag (Runtime_err.Diagnostic inference) in
+  Alcotest.(check string) "embedded runtime code" "E0901" (Diag.code_or_uncoded projected);
+  Alcotest.(check bool) "embedded runtime domain" true (Diag.domain projected = Diag.Inference);
+  Alcotest.(check string)
+    "compact runtime cause"
+    "E0901: The posterior is empty. (Every execution branch has zero weight.)"
+    (Runtime_err.to_string (Runtime_err.Diagnostic inference))
 
 let test_span_multiline () =
   let s =
@@ -29,5 +193,11 @@ let suite =
   [
     Alcotest.test_case "error fields" `Quick test_error_fields;
     Alcotest.test_case "rendering" `Quick test_rendering;
+    Alcotest.test_case "json v1" `Quick test_json_v1;
+    Alcotest.test_case "empty step rejected" `Quick test_contract_rejects_empty_step;
+    Alcotest.test_case "invalid identity and span rejected" `Quick
+      test_contract_rejects_invalid_identity_and_span;
+    Alcotest.test_case "cause projection excludes child actions" `Quick
+      test_cause_projection_excludes_child_actions;
     Alcotest.test_case "multiline span" `Quick test_span_multiline;
   ]

--- a/test/test_dx_parser_recovery.ml
+++ b/test/test_dx_parser_recovery.ml
@@ -6,65 +6,78 @@ let read kind name = Corpus_support.read_file (fixture kind name)
 let recover name = Surface_parse.recover_string ~file:name (read "malformed" name)
 let rendered recovered = List.map Diag.to_string recovered.Surface_ast.diagnostics
 
+let expected_diagnostic span code summary cause next_step =
+  Printf.sprintf "%s: error[%s]: %s\n  Cause: %s\n  Next step: %s" span code summary cause next_step
+
+let e1220 span cause =
+  expected_diagnostic span "E1220" "Surface syntax is invalid" cause
+    "Correct the syntax at this location and parse the file again."
+
+let e1221 span cause =
+  expected_diagnostic span "E1221" "A delimited construct is not closed" cause
+    "Close the construct with the expected delimiter."
+
 let malformed_goldens =
   [
     ( "missing-quote.jac",
       [
-        "missing-quote.jac:6:1-10: error[E1221]: unclosed `quote`: expected `}` before \
-         ident(later-bad)\n\
-        \  hint: the `quote` expression opened at missing-quote.jac:1:10-15";
+        e1221 "missing-quote.jac:6:1-10"
+          "unclosed `quote`: expected `}` before ident(later-bad) The `quote` expression opened at \
+           missing-quote.jac:1:10-15.";
       ] );
     ( "missing-match.jac",
       [
-        "missing-match.jac:4:1-10: error[E1221]: unclosed `match`: expected `}` before the next \
-         top-level item\n\
-        \  hint: the `match` expression opened at missing-match.jac:1:10-15";
+        e1221 "missing-match.jac:4:1-10"
+          "unclosed `match`: expected `}` before the next top-level item The `match` expression \
+           opened at missing-match.jac:1:10-15.";
       ] );
     ( "missing-handler.jac",
       [
-        "missing-handler.jac:4:1-10: error[E1221]: unclosed `handle`: expected `}` before the next \
-         top-level item\n\
-        \  hint: the `handle` expression opened at missing-handler.jac:1:16-22";
+        e1221 "missing-handler.jac:4:1-10"
+          "unclosed `handle`: expected `}` before the next top-level item The `handle` expression \
+           opened at missing-handler.jac:1:16-22.";
       ] );
     ( "missing-block.jac",
       [
-        "missing-block.jac:4:1-10: error[E1221]: unclosed block: expected `}` before the next \
-         top-level item\n\
-        \  hint: the block opened at missing-block.jac:1:10-11";
+        e1221 "missing-block.jac:4:1-10"
+          "unclosed block: expected `}` before the next top-level item The block opened at \
+           missing-block.jac:1:10-11.";
       ] );
-    ( "extra-delimiter.jac",
-      [ "extra-delimiter.jac:2:1-2: error[E1220]: unmatched `}` at top level" ] );
+    ("extra-delimiter.jac", [ e1220 "extra-delimiter.jac:2:1-2" "unmatched `}` at top level" ]);
     ( "eof-nested.jac",
       [
-        "eof-nested.jac:5:1-1: error[E1221]: unclosed `quote`: expected `}` after the quoted \
-         expression\n\
-        \  hint: the `quote` expression opened at eof-nested.jac:1:17-22";
+        e1221 "eof-nested.jac:5:1-1"
+          "unclosed `quote`: expected `}` after the quoted expression The `quote` expression \
+           opened at eof-nested.jac:1:17-22.";
       ] );
     ( "missing-if-keyword.jac",
       [
-        "missing-if-keyword.jac:1:18-19: error[E1220]: unclosed `if`: expected `then` after the \
-         condition, found int(1)\n\
-        \  hint: the `if` expression opened at missing-if-keyword.jac:1:10-12";
+        e1220 "missing-if-keyword.jac:1:18-19"
+          "unclosed `if`: expected `then` after the condition, found int(1) The `if` expression \
+           opened at missing-if-keyword.jac:1:10-12.";
       ] );
     ( "mismatched-quote.jac",
       [
-        "mismatched-quote.jac:1:28-29: error[E1221]: unclosed `quote`: expected `}`, found ]\n\
-        \  hint: the `quote` expression opened at mismatched-quote.jac:1:15-20";
+        e1221 "mismatched-quote.jac:1:28-29"
+          "unclosed `quote`: expected `}`, found ] The `quote` expression opened at \
+           mismatched-quote.jac:1:15-20.";
       ] );
     ( "mismatched-match.jac",
       [
-        "mismatched-match.jac:3:1-2: error[E1221]: unclosed `match`: expected `}`, found ]\n\
-        \  hint: the `match` expression opened at mismatched-match.jac:1:15-20";
+        e1221 "mismatched-match.jac:3:1-2"
+          "unclosed `match`: expected `}`, found ] The `match` expression opened at \
+           mismatched-match.jac:1:15-20.";
       ] );
     ( "mismatched-handler.jac",
       [
-        "mismatched-handler.jac:3:1-2: error[E1221]: unclosed `handle`: expected `}`, found ]\n\
-        \  hint: the `handle` expression opened at mismatched-handler.jac:1:21-27";
+        e1221 "mismatched-handler.jac:3:1-2"
+          "unclosed `handle`: expected `}`, found ] The `handle` expression opened at \
+           mismatched-handler.jac:1:21-27.";
       ] );
     ( "mismatched-block.jac",
       [
-        "mismatched-block.jac:3:1-2: error[E1221]: unclosed block: expected `}`, found ]\n\
-        \  hint: the block opened at mismatched-block.jac:1:15-16";
+        e1221 "mismatched-block.jac:3:1-2"
+          "unclosed block: expected `}`, found ] The block opened at mismatched-block.jac:1:15-16.";
       ] );
   ]
 
@@ -81,7 +94,7 @@ let test_exact_construct_goldens_and_strictness () =
       | Error _ -> (
           let marker_only = { recovered with Surface_ast.diagnostics = [] } in
           match Surface_parse.strict_file marker_only with
-          | Error [ { Diag.code = "E1202"; _ } ] -> ()
+          | Error [ diagnostic ] when Diag.code diagnostic = Some "E1202" -> ()
           | Error diagnostics ->
               Eval_support.fail_diags (name ^ " marker-only strict boundary") diagnostics
           | Ok _ -> Alcotest.failf "%s marker was accepted after diagnostics were removed" name)
@@ -117,7 +130,7 @@ let test_later_top_level_checking_is_bounded () =
     (fun name ->
       let store, context = make_check_context () in
       let report = Surface_check.analyze ~names:(Store.names_view store) context (recover name) in
-      let codes = List.map (fun diagnostic -> diagnostic.Diag.code) report.diagnostics in
+      let codes = List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) report.diagnostics in
       Alcotest.(check int)
         (name ^ " has one primary syntax diagnostic")
         1

--- a/test/test_effect_taxonomy.ml
+++ b/test/test_effect_taxonomy.ml
@@ -1309,14 +1309,16 @@ let test_self_effect_hash_contract () =
   in
   (match Resolve.resolve_decl (Store.names_view store) malformed with
   | Error [ diagnostic ] ->
-      Alcotest.(check string) "type used as effect rejected by resolver" "E0302" diagnostic.code
+      Alcotest.(check string)
+        "type used as effect rejected by resolver" "E0302" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics ->
       Eval_support.fail_diags "unexpected malformed-context diagnostics" diagnostics
   | Ok _ -> Alcotest.fail "type used as an effect unexpectedly resolved");
   (match Canon.hash_decl malformed with
   | Error [ diagnostic ] ->
       Alcotest.(check string)
-        "Named row outside enclosing effect rejected by canon" "E0501" diagnostic.code
+        "Named row outside enclosing effect rejected by canon" "E0501"
+        (Diag.code_or_uncoded diagnostic)
   | Error diagnostics -> Eval_support.fail_diags "unexpected malformed hash diagnostics" diagnostics
   | Ok _ -> Alcotest.fail "malformed Named effect unexpectedly hashed");
   let reopen_dir = Eval_support.fresh_dir () in

--- a/test/test_errors_doc.ml
+++ b/test/test_errors_doc.ml
@@ -1,4 +1,4 @@
-(* W5.3: every diagnostic code emitted anywhere in src/ or bin/ appears in docs/errors.md
+(* W5.3: every diagnostic code emitted anywhere in src/, bin/, or runtime/ appears in docs/errors.md
    (the catalog is the contract; this test is its teeth). *)
 
 let read_file path =
@@ -7,15 +7,18 @@ let read_file path =
   close_in ic;
   s
 
-let ml_files dir =
+let rec source_files dir =
   Sys.readdir dir |> Array.to_list
-  |> List.filter (fun f -> Filename.check_suffix f ".ml")
-  |> List.map (Filename.concat dir)
+  |> List.concat_map (fun entry ->
+      let path = Filename.concat dir entry in
+      if Sys.is_directory path then source_files path
+      else if List.exists (Filename.check_suffix path) [ ".ml"; ".c"; ".h" ] then [ path ]
+      else [])
 
 (* every string literal that looks like a diagnostic code passed to ~code: (or bound as an
    optional-parameter default, `?(x_code = "...")`) *)
 let emitted_codes () =
-  let re = Str.regexp {|code[: ]*=? *"\([EW][0-9][0-9][0-9][0-9]\)"|} in
+  let re = Str.regexp {|"\([EWI][0-9][0-9][0-9][0-9]\)"|} in
   let codes = Hashtbl.create 64 in
   List.iter
     (fun path ->
@@ -28,7 +31,7 @@ let emitted_codes () =
         | exception Not_found -> ()
       in
       scan 0)
-    (ml_files "../src" @ ml_files "../bin");
+    (source_files "../src" @ source_files "../bin" @ source_files "../runtime");
   List.sort compare (Hashtbl.fold (fun c () acc -> c :: acc) codes [])
 
 let test_all_codes_cataloged () =

--- a/test/test_exhaust.ml
+++ b/test/test_exhaust.ml
@@ -19,8 +19,8 @@ let contains ~needle haystack =
 let test_bool_missing_false () =
   let h = make () in
   let d = err_of h "(lam ((pvar b)) (match (var b) (clause (pcon true) (lit 1))))" in
-  Alcotest.(check string) "code" "E0813" d.Diag.code;
-  Alcotest.(check bool) "witness prints false" true (contains ~needle:"false" d.Diag.message)
+  Alcotest.(check string) "code" "E0813" (Diag.code_or_uncoded d);
+  Alcotest.(check bool) "witness prints false" true (contains ~needle:"false" (Diag.cause d))
 
 (* the plan's nested witness: Option (Option Bool) missing Some (Some False) *)
 let test_nested_witness () =
@@ -30,11 +30,11 @@ let test_nested_witness () =
       "(lam ((pvar o)) (match (var o) (clause (pcon none) (lit 0)) (clause (pcon some (pcon none)) \
        (lit 1)) (clause (pcon some (pcon some (pcon true))) (lit 2))))"
   in
-  Alcotest.(check string) "code" "E0813" d.Diag.code;
+  Alcotest.(check string) "code" "E0813" (Diag.code_or_uncoded d);
   Alcotest.(check bool)
-    (Printf.sprintf "witness is some(some(false)) (got: %s)" d.Diag.message)
+    (Printf.sprintf "witness is some(some(false)) (got: %s)" (Diag.cause d))
     true
-    (contains ~needle:"some(some(false))" d.Diag.message)
+    (contains ~needle:"some(some(false))" (Diag.cause d))
 
 let test_redundant_clause_warns () =
   let h = make () in
@@ -43,8 +43,8 @@ let test_redundant_clause_warns () =
       "(lam ((pvar b)) (match (var b) (clause (pwild) (lit 0)) (clause (pcon true) (lit 1))))"
   with
   | Ok { Check.warnings = [ w ]; _ } ->
-      Alcotest.(check string) "warning code" "W0801" w.Diag.code;
-      Alcotest.(check bool) "is a warning" true (w.Diag.severity = Diag.Warning)
+      Alcotest.(check string) "warning code" "W0801" (Diag.code_or_uncoded w);
+      Alcotest.(check bool) "is a warning" true (Diag.severity w = Diag.Warning)
   | Ok { Check.warnings; _ } -> Alcotest.failf "expected one warning, got %d" (List.length warnings)
   | Error ds -> Eval_support.fail_diags "should check (warning only)" ds
 
@@ -56,7 +56,8 @@ let test_redundancy_in_later_columns () =
       "(lam ((pvar p)) (match (var p) (clause (ptuple (pwild) (pcon true)) (lit 0)) (clause \
        (ptuple (pwild) (pcon true)) (lit 1)) (clause (pwild) (lit 2))))"
   with
-  | Ok { Check.warnings = [ w ]; _ } -> Alcotest.(check string) "code" "W0801" w.Diag.code
+  | Ok { Check.warnings = [ w ]; _ } ->
+      Alcotest.(check string) "code" "W0801" (Diag.code_or_uncoded w)
   | Ok { Check.warnings; _ } -> Alcotest.failf "expected one warning, got %d" (List.length warnings)
   | Error ds -> Eval_support.fail_diags "later-column redundancy" ds
 
@@ -64,7 +65,7 @@ let test_plit_scrutinee_needs_catch_all () =
   let h = make () in
   (* literals over an infinite type: rejected without a default *)
   let d = err_of h "(match (lit 5) (clause (plit 0) (lit 1)) (clause (plit 1) (lit 2)))" in
-  Alcotest.(check string) "code" "E0813" d.Diag.code;
+  Alcotest.(check string) "code" "E0813" (Diag.code_or_uncoded d);
   (* accepted with a variable default *)
   match
     check_src h "(match (lit 5) (clause (plit 0) (lit 1)) (clause (pvar other) (var other)))"
@@ -84,8 +85,8 @@ let test_tuple_patterns () =
   let d =
     err_of h "(match (tuple (lit 1) (var true)) (clause (ptuple (pvar a) (pcon true)) (var a)))"
   in
-  Alcotest.(check string) "code" "E0813" d.Diag.code;
-  Alcotest.(check bool) "tuple witness" true (contains ~needle:"(_, false)" d.Diag.message)
+  Alcotest.(check string) "code" "E0813" (Diag.code_or_uncoded d);
+  Alcotest.(check bool) "tuple witness" true (contains ~needle:"(_, false)" (Diag.cause d))
 
 let test_recursive_list () =
   let h = make () in
@@ -103,11 +104,11 @@ let test_recursive_list () =
       "(lam ((pvar xs)) (match (ann (var xs) (tapp (tref list) (tref int))) (clause (pcon nil) \
        (lit 0))))"
   in
-  Alcotest.(check string) "code" "E0813" d.Diag.code;
+  Alcotest.(check string) "code" "E0813" (Diag.code_or_uncoded d);
   Alcotest.(check bool)
-    (Printf.sprintf "witness names cons (got: %s)" d.Diag.message)
+    (Printf.sprintf "witness names cons (got: %s)" (Diag.cause d))
     true
-    (contains ~needle:"cons(_, _)" d.Diag.message)
+    (contains ~needle:"cons(_, _)" (Diag.cause d))
 
 let test_as_patterns_transparent () =
   let h = make () in

--- a/test/test_exhaustive_schedule.ml
+++ b/test/test_exhaustive_schedule.ml
@@ -219,7 +219,9 @@ let test_budgets_are_structured_incomplete_results () =
       Alcotest.(check int) "all non-positive budgets are diagnosed" 3 (List.length diagnostics);
       Alcotest.(check bool)
         "budget validation uses the scheduler diagnostic family" true
-        (List.for_all (fun diagnostic -> String.equal diagnostic.Diag.code "E0908") diagnostics)
+        (List.for_all
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0908")
+           diagnostics)
   | Ok _ -> Alcotest.fail "non-positive exhaustive budgets were accepted"
 
 let test_decision_budget_keeps_short_alternative_worlds () =

--- a/test/test_governance_gate.ml
+++ b/test/test_governance_gate.ml
@@ -211,11 +211,11 @@ let test_exact_world_free_signature_and_local_resume () =
           | None -> Alcotest.failf "trusted hidden marker %s is missing" name
         in
         (match Store.locate store hash with
-        | Error [ { Diag.code = "E0601"; _ } ] -> ()
+        | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
         | Error diagnostics -> Eval_support.fail_diags (name ^ " public hash lookup") diagnostics
         | Ok _ -> Alcotest.failf "%s remained publicly hash-addressable" name);
         (match Store.bind_name store ("forged-" ^ name) hash with
-        | Error [ { Diag.code = "E0601"; _ } ] -> ()
+        | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
         | Error diagnostics -> Eval_support.fail_diags (name ^ " public rebinding") diagnostics
         | Ok () -> Alcotest.failf "%s could be rebound publicly" name);
         (match check_program (Printf.sprintf "(app (var %s))" name) with
@@ -223,7 +223,7 @@ let test_exact_world_free_signature_and_local_resume () =
             Alcotest.(check bool)
               (name ^ " is unresolved") true
               (List.exists
-                 (fun diagnostic -> String.equal diagnostic.Diag.code "E0301")
+                 (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0301")
                  diagnostics)
         | Ok () -> Alcotest.failf "%s unexpectedly type-checked" name);
         let hex = Hash.to_hex hash in
@@ -233,7 +233,7 @@ let test_exact_world_free_signature_and_local_resume () =
               (name ^ " direct hash is unknown")
               true
               (List.exists
-                 (fun diagnostic -> String.equal diagnostic.Diag.code "E0805")
+                 (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0805")
                  diagnostics)
         | Ok () -> Alcotest.failf "%s direct hash unexpectedly type-checked" name);
         (match Eval_support.eval_with ctx store (Printf.sprintf "(ref #%s term)" hex) with
@@ -241,7 +241,7 @@ let test_exact_world_free_signature_and_local_resume () =
             Alcotest.(check bool)
               (name ^ " unchecked direct hash is unknown")
               true
-              (String.starts_with ~prefix:"error[E0601]: unknown hash" message)
+              (String.starts_with ~prefix:"E0601:" message)
         | Error error ->
             Alcotest.failf "%s direct hash failed with wrong runtime error: %s" name
               (Runtime_err.to_string error)
@@ -252,30 +252,34 @@ let test_exact_world_free_signature_and_local_resume () =
   let sequence_hex = "3e9b091027d525ea128d13df8033dc02a7494d82b2a529e9157e81ffeebf1900" in
   let sequence_hash = Option.get (Hash.of_hex sequence_hex) in
   (match Store.locate store sequence_hash with
-  | Error [ { Diag.code = "E0601"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
   | Error diagnostics -> Eval_support.fail_diags "private sequence hash lookup" diagnostics
   | Ok _ -> Alcotest.fail "private AuditSequence constructor remained hash-addressable");
   (match Store.bind_name store "forged-audit-sequence" sequence_hash with
-  | Error [ { Diag.code = "E0601"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
   | Error diagnostics -> Eval_support.fail_diags "private sequence hash rebinding" diagnostics
   | Ok () -> Alcotest.fail "private AuditSequence constructor could be rebound");
   (match check_program "(app (var audit-sequence-v0) (app (var code.hash) (quote (forged))))" with
   | Error diagnostics ->
       Alcotest.(check bool)
         "direct token fabrication is unresolved" true
-        (List.exists (fun diagnostic -> String.equal diagnostic.Diag.code "E0301") diagnostics)
+        (List.exists
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0301")
+           diagnostics)
   | Ok () -> Alcotest.fail "private AuditSequence constructor unexpectedly type-checked");
   (match check_program (Printf.sprintf "(ref #%s con)" sequence_hex) with
   | Error diagnostics ->
       Alcotest.(check bool)
         "derived-hash token fabrication is unknown" true
-        (List.exists (fun diagnostic -> String.equal diagnostic.Diag.code "E0805") diagnostics)
+        (List.exists
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0805")
+           diagnostics)
   | Ok () -> Alcotest.fail "private AuditSequence constructor hash unexpectedly type-checked");
   (match Eval_support.eval_with ctx store (Printf.sprintf "(ref #%s con)" sequence_hex) with
   | Error (Runtime_err.Unresolved message) ->
       Alcotest.(check bool)
         "unchecked derived-hash token fabrication is unknown" true
-        (String.starts_with ~prefix:"error[E0601]: unknown hash" message)
+        (String.starts_with ~prefix:"E0601:" message)
   | Error error ->
       Alcotest.failf "private hash failed with the wrong runtime error: %s"
         (Runtime_err.to_string error)
@@ -295,12 +299,12 @@ let test_exact_world_free_signature_and_local_resume () =
         true
         (Store.lookup_kind reopened name Resolve.KTerm = None);
       match Store.locate reopened hash with
-      | Error [ { Diag.code = "E0601"; _ } ] -> ()
+      | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
       | Error diagnostics -> Eval_support.fail_diags ("reopened " ^ name) diagnostics
       | Ok _ -> Alcotest.failf "reopen exposed hidden marker %s" name)
     hidden_markers;
   (match Store.locate reopened sequence_hash with
-  | Error [ { Diag.code = "E0601"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
   | Error diagnostics -> Eval_support.fail_diags "reopened private sequence hash" diagnostics
   | Ok _ -> Alcotest.fail "reopen restored the private sequence hash");
   let reopened_ctx = Eval.make_ctx reopened in
@@ -317,7 +321,7 @@ let test_exact_world_free_signature_and_local_resume () =
   | Error (Runtime_err.Unresolved message) ->
       Alcotest.(check bool)
         "reopened direct hash remains unknown" true
-        (String.starts_with ~prefix:"error[E0601]: unknown hash" message)
+        (String.starts_with ~prefix:"E0601:" message)
   | Error error ->
       Alcotest.failf "reopened private hash failed with the wrong runtime error: %s"
         (Runtime_err.to_string error)
@@ -362,7 +366,9 @@ let test_exact_world_free_signature_and_local_resume () =
   | Error diagnostics ->
       Alcotest.(check bool)
         "facade cannot consume Resume twice" true
-        (List.exists (fun diagnostic -> String.equal diagnostic.Diag.code "E0816") diagnostics)
+        (List.exists
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0816")
+           diagnostics)
   | Ok () -> Alcotest.fail "facade duplicate Resume unexpectedly type-checked"
 
 let test_risk_confidence_matrix_and_counters () =

--- a/test/test_governance_reconcile.ml
+++ b/test/test_governance_reconcile.ml
@@ -280,7 +280,7 @@ let fail_diags label diagnostics =
 
 let expect_error label code result =
   match result with
-  | Error ({ Diag.code = actual; _ } :: _) -> Alcotest.(check string) label code actual
+  | Error (diagnostic :: _) -> Alcotest.(check string) label code (Diag.code_or_uncoded diagnostic)
   | Error [] -> Alcotest.failf "%s returned no diagnostics" label
   | Ok _ -> Alcotest.failf "%s unexpectedly verified" label
 

--- a/test/test_governance_run_bundle.ml
+++ b/test/test_governance_run_bundle.ml
@@ -208,12 +208,13 @@ let fail_diags label diagnostics =
 
 let expect_error ?(indexed = true) label code result =
   match result with
-  | Error ({ Diag.code = actual; message; _ } :: _) ->
-      Alcotest.(check string) (label ^ " code") code actual;
+  | Error (diagnostic :: _) ->
+      Alcotest.(check string) (label ^ " code") code (Diag.code_or_uncoded diagnostic);
       if indexed then
         Alcotest.(check bool)
           (label ^ " has indexed detail") true
-          (String.contains message '0' || String.contains message '1')
+          (String.contains (Diag.cause diagnostic) '0'
+          || String.contains (Diag.cause diagnostic) '1')
   | Error [] -> Alcotest.failf "%s returned no diagnostics" label
   | Ok _ -> Alcotest.failf "%s unexpectedly verified" label
 

--- a/test/test_governance_verify.ml
+++ b/test/test_governance_verify.ml
@@ -178,11 +178,13 @@ let expect_fixture_with verifier_store name contract =
   | Ok _ -> Alcotest.failf "expected %s" code
   | Error diagnostics -> (
       match
-        List.find_opt (fun diagnostic -> String.equal diagnostic.Diag.code code) diagnostics
+        List.find_opt
+          (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) code)
+          diagnostics
       with
       | None -> Alcotest.failf "missing %s in:\n%s" code (fail_diags diagnostics)
       | Some diagnostic ->
-          let line = Option.map (fun span -> span.Span.start_pos.line) diagnostic.Diag.span in
+          let line = Option.map (fun span -> span.Span.start_pos.line) (Diag.span diagnostic) in
           Alcotest.(check (option int)) (code ^ " source line") (Some expected_line) line)
 
 let expect_fixture name contract = expect_fixture_with store name contract
@@ -193,12 +195,14 @@ let expect_fixture_count name expected_count contract =
   | Ok _ -> Alcotest.failf "expected %s" code
   | Error diagnostics ->
       let matching =
-        List.filter (fun diagnostic -> String.equal diagnostic.Diag.code code) diagnostics
+        List.filter
+          (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) code)
+          diagnostics
       in
       Alcotest.(check int) (code ^ " diagnostic count") expected_count (List.length matching);
       let first_line =
         match matching with
-        | first :: _ -> Option.map (fun span -> span.Span.start_pos.line) first.Diag.span
+        | first :: _ -> Option.map (fun span -> span.Span.start_pos.line) (Diag.span first)
         | [] -> None
       in
       Alcotest.(check (option int)) (code ^ " first source line") (Some expected_line) first_line

--- a/test/test_handlers.ml
+++ b/test/test_handlers.ml
@@ -87,8 +87,7 @@ let test_once_second_resume_traps () =
   match apply_runtime_resume h resume 2 with
   | Error Runtime_err.Once_resumed_twice ->
       Alcotest.(check string)
-        "stable E0906 rendering"
-        "error[E0906]: a once continuation may be resumed at most once per captured instance"
+        "stable E0906 cause" "a once continuation may be resumed at most once per captured instance"
         (Runtime_err.to_string Runtime_err.Once_resumed_twice)
   | Error error ->
       Alcotest.failf "expected E0906 once-resumption defect, got %s" (Runtime_err.to_string error)

--- a/test/test_infer.ml
+++ b/test/test_infer.ml
@@ -105,10 +105,11 @@ let test_two_coins_branch_count () =
       (model_state (store, ctx) "(app (var sample) (app (var bernoulli) (lit 0.5)))")
   with
   | Error [ diagnostic ] ->
-      Alcotest.(check string) "driver reports runtime capture failure" "E0902" diagnostic.Diag.code;
+      Alcotest.(check string)
+        "driver reports runtime capture failure" "E0902" (Diag.code_or_uncoded diagnostic);
       Alcotest.(check bool)
         "enumeration cannot duplicate a declared Once sample" true
-        (String.starts_with ~prefix:"error[E0906]" diagnostic.Diag.message)
+        (String.starts_with ~prefix:"a once continuation may be resumed" (Diag.cause diagnostic))
   | Error diagnostics ->
       Alcotest.failf "declared Once sample returned unexpected diagnostics: %s"
         (String.concat "; " (List.map Diag.to_string diagnostics))
@@ -135,7 +136,7 @@ let test_impossible_observation () =
   let _, ctx = h in
   match Infer_dist.enumerate ctx (model_state h impossible_src) with
   | Ok _ -> Alcotest.fail "impossible observation must not produce a posterior"
-  | Error [ d ] -> Alcotest.(check string) "empty posterior code" "E0901" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "empty posterior code" "E0901" (Diag.code_or_uncoded d)
   | Error _ -> Alcotest.fail "expected one diagnostic"
 
 (* --- W4.3 likelihood weighting --- *)
@@ -228,10 +229,10 @@ let test_lw_validates_one_reusable_initial_state () =
   in
   (match Infer_dist.likelihood_weighting ctx ~seed:9 ~samples:5 marked_model with
   | Error [ diagnostic ] ->
-      Alcotest.(check string) "marked initial diagnostic" "E0902" diagnostic.Diag.code;
+      Alcotest.(check string) "marked initial diagnostic" "E0902" (Diag.code_or_uncoded diagnostic);
       Alcotest.(check bool)
         "marked initial preserves E1202" true
-        (String.starts_with ~prefix:"type error: E1202:" diagnostic.message)
+        (String.starts_with ~prefix:"type error: E1202:" (Diag.cause diagnostic))
   | Error diagnostics -> Eval_support.fail_diags "marked reusable model" diagnostics
   | Ok _ -> Alcotest.fail "marked initial model was accepted");
   Alcotest.(check int) "marked model factory called once" 1 !marked_factory_calls;
@@ -288,10 +289,10 @@ let test_lw_rejects_zero_argument_continuation_mutation () =
   in
   (match Infer_dist.likelihood_weighting ctx ~seed:17 ~samples:5 model with
   | Error [ diagnostic ] ->
-      Alcotest.(check string) "LW mutation diagnostic" "E0902" diagnostic.Diag.code;
+      Alcotest.(check string) "LW mutation diagnostic" "E0902" (Diag.code_or_uncoded diagnostic);
       Alcotest.(check bool)
         "LW mutation preserves E1202" true
-        (String.starts_with ~prefix:"type error: E1202:" diagnostic.message)
+        (String.starts_with ~prefix:"type error: E1202:" (Diag.cause diagnostic))
   | Error diagnostics -> Eval_support.fail_diags "LW continuation mutation" diagnostics
   | Ok _ -> Alcotest.fail "LW accepted a continuation mutation containing a recovery marker");
   Alcotest.(check int) "LW model factory called once" 1 !factory_calls;
@@ -454,7 +455,7 @@ let test_effectful_toplevel_blocked_in_infer () =
               | Ok e -> (
                   match Check.check_top cctx (Kernel.Expr e) with
                   | Ok _ -> Alcotest.fail "effectful top-level body must be rejected"
-                  | Error [ d ] -> Alcotest.(check string) "code" "E0815" d.Diag.code
+                  | Error [ d ] -> Alcotest.(check string) "code" "E0815" (Diag.code_or_uncoded d)
                   | Error _ -> Alcotest.fail "expected one diagnostic"))))
 
 let suite =

--- a/test/test_judge.ml
+++ b/test/test_judge.ml
@@ -201,8 +201,8 @@ let test_assessment_field_types_are_checked () =
             true
             (List.exists
                (fun diagnostic ->
-                 String.equal diagnostic.Diag.code "E0801"
-                 || String.equal diagnostic.Diag.code "E0802")
+                 String.equal (Diag.code_or_uncoded diagnostic) "E0801"
+                 || String.equal (Diag.code_or_uncoded diagnostic) "E0802")
                diagnostics)
       | Ok _ -> Alcotest.failf "malformed Assessment %s field typechecked" label)
     variants
@@ -266,8 +266,12 @@ let test_raw_world_rule_is_rejected () =
   | Error diagnostics ->
       Alcotest.(check bool)
         "pure rules cannot hide Net" true
-        (List.exists (fun diagnostic -> String.equal diagnostic.Diag.code "E0802") diagnostics
-        || List.exists (fun diagnostic -> String.equal diagnostic.Diag.code "E0801") diagnostics)
+        (List.exists
+           (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0802")
+           diagnostics
+        || List.exists
+             (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0801")
+             diagnostics)
   | Ok _ -> Alcotest.fail "judge.rules accepted a raw-world rule behind its pure signature"
 
 let suite =

--- a/test/test_kernel.ml
+++ b/test/test_kernel.ml
@@ -19,7 +19,7 @@ let accepts what s =
 let rejects what code s =
   match Kernel.of_form (parse s) with
   | Ok _ -> Alcotest.failf "%s: expected %S to be rejected with %s" what s code
-  | Error [ d ] -> Alcotest.(check string) (what ^ ": code") code d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) (what ^ ": code") code (Diag.code_or_uncoded d)
   | Error _ -> Alcotest.failf "%s: expected exactly one diagnostic" what
 
 (* Every kernel form: >= 1 accepting, >= 2 rejecting (wrong arity, wrong sort).

--- a/test/test_names.ml
+++ b/test/test_names.ml
@@ -34,7 +34,7 @@ let test_reader_parses_new_symbols () =
   | _ -> Alcotest.fail "dotted symbols should parse as single atoms");
   (* heads keep the strict grammar *)
   match Reader.parse_one ~file:"n.jqd" "(list.map (lit 1))" with
-  | Error [ d ] -> Alcotest.(check string) "dotted head rejected" "E0107" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "dotted head rejected" "E0107" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "a dotted head must be rejected"
 
 let test_printer_roundtrip_new_symbols () =
@@ -112,7 +112,7 @@ let test_value_precedence_and_warning () =
   in
   match Resolve.resolve_expr_w (Store.names_view store) e with
   | Ok ({ Kernel.it = Kernel.Ref (_, Kernel.Term); _ }, [ w ]) ->
-      Alcotest.(check string) "warning code" "W0301" w.Diag.code
+      Alcotest.(check string) "warning code" "W0301" (Diag.code_or_uncoded w)
   | Ok (_, ws) -> Alcotest.failf "expected term ref + 1 warning, got %d warnings" (List.length ws)
   | Error ds -> Eval_support.fail_diags "resolve" ds
 
@@ -121,7 +121,7 @@ let test_rename_ambiguous_needs_kind () =
   put store "(deftype any-t () (con any-v))";
   put store "(defeffect signal () (op signal () (tref any-t)))";
   (match Store.rename store ~old_name:"signal" ~new_name:"sig2" () with
-  | Error [ d ] -> Alcotest.(check string) "ambiguous" "E0607" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "ambiguous" "E0607" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "ambiguous rename must fail");
   (* with the kind it works and only moves that binding *)
   (match Store.rename store ~old_name:"signal" ~new_name:"sig-op" ~kind:Resolve.KOp () with

--- a/test/test_prelude.ml
+++ b/test/test_prelude.ml
@@ -503,7 +503,7 @@ let test_grant_mapping () =
   | Ok () -> ()
   | Error _ -> Alcotest.fail "net has a stub grant");
   match Prelude.grant ctx "filesystem" ~out:ignore ~seed:0 ~infer_cache:None with
-  | Error [ d ] -> Alcotest.(check string) "ungrantable" "E0703" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "ungrantable" "E0703" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "unknown effect must not be grantable"
 
 (* a handler written in Jacquard can still intercept a granted effect (interposition) *)

--- a/test/test_quote.ml
+++ b/test/test_quote.ml
@@ -61,7 +61,9 @@ let test_surface_unquote_staging_depth () =
   (match Surface_parse.parse_string ~file:"surface-quote.jac" "unquote(x)" with
   | Ok [ { Surface_ast.it = TopExpr expression; _ } ] -> (
       match Surface_lower.lower_expr expression with
-      | Error [ { Diag.code = "E0204"; span = Some _; _ } ] -> ()
+      | Error [ diagnostic ]
+        when Diag.code diagnostic = Some "E0204" && Option.is_some (Diag.span diagnostic) ->
+          ()
       | Error diagnostics -> Eval_support.fail_diags "top-level unquote" diagnostics
       | Ok _ -> Alcotest.fail "top-level surface unquote reached the kernel")
   | Ok _ -> Alcotest.fail "top-level unquote did not parse as one expression"

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -109,50 +109,103 @@ let test_groups () =
   | [ Form.Sym "fact"; Form.F { Form.head = "group"; args = []; _ }; Form.F _ ] -> ()
   | _ -> Alcotest.fail "() should read as an empty group");
   let d = parse_err "(group 42)" in
-  Alcotest.(check string) "scalar group element rejected" "E0110" d.Diag.code
+  Alcotest.(check string) "scalar group element rejected" "E0110" (Diag.code_or_uncoded d)
 
 let test_parse_one_arity () =
   (match Reader.parse_one ~file:"t.jqd" "" with
-  | Error [ d ] -> Alcotest.(check string) "empty input" "E0106" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "empty input" "E0106" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "empty input should fail");
   match Reader.parse_one ~file:"t.jqd" "(lit 1) (lit 2)" with
-  | Error [ d ] -> Alcotest.(check string) "two forms" "E0114" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "two forms" "E0114" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "two forms should fail parse_one"
 
-(* --- golden parse errors (the exact rendering is the contract) --- *)
+(* --- golden parse errors (the structured wording is the contract; renderer order is pinned by
+   Test_diag and the CLI transcript suite) --- *)
 
 let golden_errors =
   [
-    ("unclosed", "(lit 1\n", "err.jqd:1:1-2:1: error[E0106]: unclosed form: expected `)`");
-    ("bad token", "(lit @)\n", "err.jqd:1:6-6: error[E0101]: unexpected character '@'");
-    ("unterminated text", "(lit \"abc\n", "err.jqd:1:6-2:1: error[E0102]: unterminated text literal");
+    ( "unclosed",
+      "(lit 1\n",
+      "E0106",
+      "The source ended before the form was complete.",
+      "unclosed form: expected `)`",
+      "Complete the open form and its closing parenthesis." );
+    ( "bad token",
+      "(lit @)\n",
+      "E0101",
+      "The source contains an unexpected character.",
+      "unexpected character '@'",
+      "Remove the character or replace it with valid bootstrap syntax." );
+    ( "unterminated text",
+      "(lit \"abc\n",
+      "E0102",
+      "A text literal is not closed.",
+      "unterminated text literal",
+      "Close the text literal with a double quote before the end of the line or file." );
     ( "bad hash",
       "(ref #deadbeef term)\n",
-      "err.jqd:1:6-15: error[E0104]: invalid hash literal #deadbeef\n\
-      \  hint: a hash is 64 lowercase hex characters" );
-    ("stray rparen", ")\n", "err.jqd:1:1-2: error[E0108]: unexpected `)` at top level");
-    ("bad head", "(42 x)\n", "err.jqd:1:2-2: error[E0107]: expected a form head symbol, found '4'");
+      "E0104",
+      "A hash literal is malformed.",
+      "invalid hash literal #deadbeef",
+      "Write the hash as 64 lowercase hexadecimal characters." );
+    ( "stray rparen",
+      ")\n",
+      "E0108",
+      "The source contains an unmatched closing parenthesis.",
+      "unexpected `)` at top level",
+      "Remove the unmatched parenthesis or add its missing opening form." );
+    ( "bad head",
+      "(42 x)\n",
+      "E0107",
+      "A bootstrap form has an invalid head.",
+      "expected a form head symbol, found '4'",
+      "Use a lowercase kernel-form head." );
     ( "big int",
       "(lit 123456789012345678901234567890)\n",
-      "err.jqd:1:6-36: error[E0109]: integer literal 123456789012345678901234567890 does not fit \
-       in a native int\n\
-      \  hint: Jacquard integers are 63-bit native ints (decision D2)" );
+      "E0109",
+      "An integer is outside Jacquard's supported range.",
+      "integer literal 123456789012345678901234567890 does not fit in a native int",
+      "Choose a value representable as a Jacquard 63-bit native integer (decision D2)." );
     ( "bad escape",
       "(lit \"a\\qb\")\n",
-      "err.jqd:1:8-9: error[E0103]: invalid escape sequence \\q\n\
-      \  hint: valid escapes: \\\\ \\\" \\n \\t \\r \\xHH" );
-    ("bad number", "(lit 1.2.3)\n", "err.jqd:1:6-11: error[E0105]: malformed number \"1.2.3\"");
-    ("bad quoted symbol", "(var 'Foo)\n", "err.jqd:1:6-10: error[E0111]: invalid quoted symbol 'Foo");
-    ("bad bare symbol", "(var a@b)\n", "err.jqd:1:6-9: error[E0112]: invalid symbol \"a@b\"");
+      "E0103",
+      "A text literal contains an invalid escape.",
+      "invalid escape sequence \\q",
+      "Use one of these escapes: \\\\ \\\" \\n \\t \\r \\xHH." );
+    ( "bad number",
+      "(lit 1.2.3)\n",
+      "E0105",
+      "A numeric literal is malformed.",
+      "malformed number \"1.2.3\"",
+      "Rewrite the value as one valid integer or real literal." );
+    ( "bad quoted symbol",
+      "(var 'Foo)\n",
+      "E0111",
+      "A quoted symbol is malformed.",
+      "invalid quoted symbol 'Foo",
+      "Rewrite the quoted symbol using the documented symbol grammar." );
+    ( "bad bare symbol",
+      "(var a@b)\n",
+      "E0112",
+      "A bare symbol is malformed.",
+      "invalid symbol \"a@b\"",
+      "Rewrite the name using the documented bare-symbol grammar." );
     ( "top-level scalar",
       "42\n",
-      "err.jqd:1:1-3: error[E0113]: expected a form at top level, found \"42\"" );
+      "E0113",
+      "A bootstrap file has a non-form top-level value.",
+      "expected a form at top level, found \"42\"",
+      "Wrap the top-level value in a kernel form." );
   ]
 
 let test_golden_errors () =
   List.iter
-    (fun (name, src, expected) ->
-      Alcotest.(check string) name expected (Diag.to_string (parse_err src)))
+    (fun (name, src, code, summary, cause, next_step) ->
+      let diagnostic = parse_err src in
+      Alcotest.(check string) (name ^ " code") code (Diag.code_or_uncoded diagnostic);
+      Alcotest.(check string) (name ^ " summary") summary (Diag.summary diagnostic);
+      Alcotest.(check string) (name ^ " cause") cause (Diag.cause diagnostic);
+      Alcotest.(check string) (name ^ " next step") next_step (Diag.next_step diagnostic))
     golden_errors
 
 let suite =

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -132,13 +132,14 @@ let test_pattern_binds_in_clause_body_only () =
   let _ = resolve_ok "(match (lit 1) (clause (pvar m) (var m)) (clause (pwild) (lit 0)))" in
   let ds = resolve_err "(match (lit 1) (clause (pvar m) (lit 0)) (clause (pwild) (var m)))" in
   match ds with
-  | [ d ] -> Alcotest.(check string) "unknown m" "E0301" d.Diag.code
+  | [ d ] -> Alcotest.(check string) "unknown m" "E0301" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected one diagnostic"
 
 let test_let_nonrec_value_no_self () =
   let ds = resolve_err "(let nonrec (pvar x) (var x) (lit 1))" in
   match ds with
-  | [ d ] -> Alcotest.(check string) "nonrec value can't see binder" "E0301" d.Diag.code
+  | [ d ] ->
+      Alcotest.(check string) "nonrec value can't see binder" "E0301" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected one diagnostic"
 
 let test_resume_bound_in_opclause () =
@@ -195,7 +196,9 @@ let test_group_mutual_references () =
 
 let test_duplicate_group_binding () =
   let ds = resolve_err "(defterm ((binding f () (lit 1)) (binding f () (lit 2))))" in
-  Alcotest.(check bool) "E0303 reported" true (List.exists (fun d -> d.Diag.code = "E0303") ds)
+  Alcotest.(check bool)
+    "E0303 reported" true
+    (List.exists (fun d -> Diag.code_or_uncoded d = "E0303") ds)
 
 (* --- unknown names and suggestions --- *)
 
@@ -208,8 +211,8 @@ let test_unknown_with_suggestion () =
   let ds = resolve_err "(app (var ad) (lit 1))" in
   match ds with
   | [ d ] ->
-      Alcotest.(check string) "code" "E0301" d.Diag.code;
-      let hint = Option.value ~default:"" d.Diag.hint in
+      Alcotest.(check string) "code" "E0301" (Diag.code_or_uncoded d);
+      let hint = Diag.cause d in
       Alcotest.(check bool)
         (Printf.sprintf "hint %S mentions add" hint)
         true (contains ~needle:"add" hint)
@@ -218,7 +221,8 @@ let test_unknown_with_suggestion () =
 let test_unknown_no_near_miss () =
   let ds = resolve_err "(app (var zzzzzzz) (lit 1))" in
   match ds with
-  | [ d ] -> Alcotest.(check (option string)) "no hint" None d.Diag.hint
+  | [ d ] ->
+      Alcotest.(check bool) "no contrastive hint" true (Option.is_none (Diag.contrastive_hint d))
   | _ -> Alcotest.fail "expected one diagnostic"
 
 let test_multiple_unknowns_all_reported () =
@@ -230,15 +234,15 @@ let test_multiple_unknowns_all_reported () =
 let test_kind_mismatch () =
   let ds = resolve_err "(app (var int) (lit 1))" in
   (match ds with
-  | [ d ] -> Alcotest.(check string) "type used as value" "E0302" d.Diag.code
+  | [ d ] -> Alcotest.(check string) "type used as value" "E0302" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected one diagnostic");
   let ds = resolve_err "(match (lit 1) (clause (pcon add) (lit 0)))" in
   (match ds with
-  | [ d ] -> Alcotest.(check string) "term used as constructor" "E0302" d.Diag.code
+  | [ d ] -> Alcotest.(check string) "term used as constructor" "E0302" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected one diagnostic");
   let ds = resolve_err "(ann (lit 1) (tref add))" in
   match ds with
-  | [ d ] -> Alcotest.(check string) "term used as type" "E0302" d.Diag.code
+  | [ d ] -> Alcotest.(check string) "term used as type" "E0302" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "expected one diagnostic"
 
 let test_types_and_rows_resolve () =
@@ -277,19 +281,21 @@ let test_quote_payload_untouched_but_splices_resolve () =
 
 let test_duplicate_pattern_var () =
   let ds = resolve_err "(match (lit 1) (clause (ptuple (pvar x) (pvar x)) (var x)))" in
-  Alcotest.(check bool) "E0304 reported" true (List.exists (fun d -> d.Diag.code = "E0304") ds);
+  Alcotest.(check bool)
+    "E0304 reported" true
+    (List.exists (fun d -> Diag.code_or_uncoded d = "E0304") ds);
   (* duplicates across sibling binders of one construct are rejected too *)
   let ds = resolve_err "(lam ((pvar x) (pvar x)) (var x))" in
   Alcotest.(check bool)
     "duplicate lam params" true
-    (List.exists (fun d -> d.Diag.code = "E0304") ds);
+    (List.exists (fun d -> Diag.code_or_uncoded d = "E0304") ds);
   let ds =
     resolve_err
       "(handle (lit 1) (ret (pvar x) (var x)) (opclause abort ((pvar k)) k (app (var k))))"
   in
   Alcotest.(check bool)
     "resume duplicating a param" true
-    (List.exists (fun d -> d.Diag.code = "E0304") ds)
+    (List.exists (fun d -> Diag.code_or_uncoded d = "E0304") ds)
 
 let test_group_member_shadows_global () =
   (* `add` is a stub global term; a group member of the same name wins *)

--- a/test/test_schedule_trace.ml
+++ b/test/test_schedule_trace.ml
@@ -79,7 +79,7 @@ let test_legacy_unknown_and_noncanonical_refused () =
   let legacy = diagnostic (Schedule_trace.parse "decision=0 runnable=[0#0] chosen=0#0\n") in
   Alcotest.(check bool)
     "unversioned refusal" true
-    (contains "unversioned schedule traces" legacy.message);
+    (contains "unversioned schedule traces" (Diag.cause legacy));
   let bytes = Schedule_trace.serialize (valid valid_events) in
   let replace_once source needle replacement =
     let index =
@@ -103,13 +103,13 @@ let test_legacy_unknown_and_noncanonical_refused () =
   in
   Alcotest.(check bool)
     "unknown version refusal" true
-    (contains "unsupported format version 2" unknown_version.message);
+    (contains "unsupported format version 2" (Diag.cause unknown_version));
   let noncanonical = diagnostic (Schedule_trace.parse (" " ^ bytes)) in
   Alcotest.(check bool)
     "whitespace refusal" true
-    (contains "unversioned schedule traces" noncanonical.message);
+    (contains "unversioned schedule traces" (Diag.cause noncanonical));
   let no_lf = diagnostic (Schedule_trace.parse (String.sub bytes 0 (String.length bytes - 1))) in
-  Alcotest.(check bool) "trailing LF required" true (contains "must end with LF" no_lf.message)
+  Alcotest.(check bool) "trailing LF required" true (contains "must end with LF" (Diag.cause no_lf))
 
 let test_impossible_events_refused () =
   let expect_with_bounds ~max_tasks ~max_decisions message events =
@@ -118,7 +118,7 @@ let test_impossible_events_refused () =
         ~policy:Concurrency_contract.Fail_fast ~max_tasks ~max_decisions events
       |> diagnostic
     in
-    Alcotest.(check bool) message true (contains message diagnostic.message)
+    Alcotest.(check bool) message true (contains message (Diag.cause diagnostic))
   in
   let expect = expect_with_bounds ~max_tasks:16 ~max_decisions:64 in
   expect "first event" (List.tl valid_events);
@@ -148,7 +148,7 @@ let test_impossible_events_refused () =
   in
   Alcotest.(check bool)
     "fork provenance matches branch" true
-    (contains "fork provenance chooses" diagnostic.message);
+    (contains "fork provenance chooses" (Diag.cause diagnostic));
   let impossible_creation =
     [
       Schedule_trace.Create { scope_path = [ 0 ]; task = root; parent = None };

--- a/test/test_scheduler_core.ml
+++ b/test/test_scheduler_core.ml
@@ -7,7 +7,7 @@ let ok = function
         (String.concat "\n" (List.map Diag.to_string diagnostics))
 
 let error_code = function
-  | Error ({ Diag.code; _ } :: _) -> code
+  | Error (diagnostic :: _) -> Diag.code_or_uncoded diagnostic
   | Error [] -> Alcotest.fail "scheduler returned an empty diagnostic list"
   | Ok _ -> Alcotest.fail "scheduler operation unexpectedly succeeded"
 

--- a/test/test_scope_policy.ml
+++ b/test/test_scope_policy.ml
@@ -341,74 +341,71 @@ let test_cancellation_cleanup_survives_drop_failure () =
   close scope
 
 let test_exact_diagnostics () =
+  let policy_error detail =
+    Printf.sprintf
+      "error[E0908]: Structured-concurrency scope policy is invalid\n\
+      \  Cause: The scope policy state is inconsistent: %s\n\
+      \  Next step: Record each child terminal state once in scheduler decision order."
+      detail
+  in
+  let escape_error detail =
+    Printf.sprintf
+      "error[E0907]: This task handle is outside its structured scope.\n\
+      \  Cause: a Task may not escape, outlive, or be used outside the structured scope that \
+       created it: %s\n\
+      \  Next step: Use the handle only with async.await or async.cancel inside its creating \
+       structured scope."
+      detail
+  in
   let scope, _ = Structured_scope.create ~body_resume:0 |> ok in
   let child = Structured_scope.spawn scope ~resume:1 |> ok in
   Alcotest.(check string)
     "duplicate child"
-    "error[E0908]: invalid structured-concurrency scope policy: duplicate child 0#1\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "duplicate child 0#1")
     (Scope_policy.create scope ~children:[ child; child ] |> error_text);
   let policy = Scope_policy.create scope ~children:[ child ] |> ok in
   Alcotest.(check string)
     "negative decision"
-    "error[E0908]: invalid structured-concurrency scope policy: decision sequence must be \
-     non-negative\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "decision sequence must be non-negative")
     (Scope_policy.record_terminal policy ~decision:(-1) child ~drop:ignore |> error_text);
   Alcotest.(check string)
     "early finish"
-    "error[E0908]: invalid structured-concurrency scope policy: scope results requested before all \
-     children terminated\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "scope results requested before all children terminated")
     (Scope_policy.finish policy |> error_text);
   Alcotest.(check string)
     "nonterminal observation"
-    "error[E0908]: invalid structured-concurrency scope policy: child 0#1 is not terminal\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "child 0#1 is not terminal")
     (Scope_policy.record_terminal policy ~decision:0 child ~drop:ignore |> error_text);
   finish_done scope child 1;
   Scope_policy.record_terminal policy ~decision:2 child ~drop:ignore |> ok;
   Alcotest.(check string)
     "duplicate observation checks sequence first"
-    "error[E0908]: invalid structured-concurrency scope policy: terminal observation (2,0) does \
-     not follow (2,0)\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "terminal observation (2,0) does not follow (2,0)")
     (Scope_policy.record_terminal policy ~decision:2 child ~drop:ignore |> error_text);
   Alcotest.(check string)
     "decreasing decision"
-    "error[E0908]: invalid structured-concurrency scope policy: terminal observation (1,0) does \
-     not follow (2,0)\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "terminal observation (1,0) does not follow (2,0)")
     (Scope_policy.record_terminal policy ~decision:1 child ~drop:ignore |> error_text);
   Alcotest.(check string)
     "increasing duplicate terminal observation"
-    "error[E0908]: invalid structured-concurrency scope policy: child 0#1 was already observed \
-     terminal\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "child 0#1 was already observed terminal")
     (Scope_policy.record_terminal policy ~decision:3 child ~drop:ignore |> error_text);
   let unregistered = Structured_scope.spawn scope ~resume:2 |> ok in
   Alcotest.(check string)
     "unregistered same-scope child"
-    "error[E0908]: invalid structured-concurrency scope policy: task 0#2 is not a registered child\n\
-    \  hint: record each child terminal state once in scheduler decision order"
+    (policy_error "task 0#2 is not a registered child")
     (Scope_policy.record_terminal policy ~decision:4 unregistered ~drop:ignore |> error_text);
   let nested, _ = Structured_scope.nest scope ~body_resume:10 |> ok in
   let nested_child = Structured_scope.spawn nested ~resume:11 |> ok in
   Alcotest.(check string)
     "foreign-scope child"
-    "error[E0907]: a Task may not escape, outlive, or be used outside the structured scope that \
-     created it: the handle belongs to another structured scope\n\
-    \  hint: use the handle only with async.await or async.cancel inside its creating structured \
-     scope"
+    (escape_error "the handle belongs to another structured scope")
     (Scope_policy.record_terminal policy ~decision:4 nested_child ~drop:ignore |> error_text);
   let foreign, _ = Structured_scope.create ~body_resume:20 |> ok in
   let foreign_child = Structured_scope.spawn foreign ~resume:21 |> ok in
   Alcotest.(check string)
     "foreign-run child"
-    "error[E0907]: a Task may not escape, outlive, or be used outside the structured scope that \
-     created it: the handle belongs to another run\n\
-    \  hint: use the handle only with async.await or async.cancel inside its creating structured \
-     scope"
+    (escape_error "the handle belongs to another run")
     (Scope_policy.record_terminal policy ~decision:4 foreign_child ~drop:ignore |> error_text);
   close foreign;
   close scope

--- a/test/test_secret.ml
+++ b/test/test_secret.ml
@@ -68,7 +68,7 @@ let test_schema_and_sealed_marker () =
   | Ok { Store.decl = { Kernel.it = Kernel.DefType { cons = [ _ ]; _ }; _ }; decl_hash; _ } -> (
       let marker = Canon.con_hash decl_hash 0 in
       match Store.locate store marker with
-      | Error [ { Diag.code = "E0601"; _ } ] -> ()
+      | Error [ diagnostic ] when Diag.code diagnostic = Some "E0601" -> ()
       | Error diagnostics -> fail_diags "locate secret marker" diagnostics
       | Ok _ -> Alcotest.fail "opaque Secret constructor remained addressable")
   | Ok _ -> Alcotest.fail "Secret type has the wrong declaration shape"
@@ -106,12 +106,14 @@ let test_diagnostics_never_render_payload () =
       Alcotest.(check bool) "redaction marker present" true (contains rendered "<secret redacted>")
   | Ok value -> Alcotest.failf "text serializer accepted %s" (Value.show value));
   (match check source with
-  | Error [ { Diag.code = "E0819"; message; _ } ] ->
-      Alcotest.(check bool) "checker message contains no fixture" false (contains message fixture)
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0819" ->
+      Alcotest.(check bool)
+        "checker message contains no fixture" false
+        (contains (Diag.cause diagnostic) fixture)
   | Error diagnostics -> fail_diags "Secret checker diagnostic" diagnostics
   | Ok _ -> Alcotest.fail "checker allowed Secret at a Text serialization boundary");
   (match check (Printf.sprintf "(app (var debug.inspect) %s)" read_secret) with
-  | Error [ { Diag.code = "E0819"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0819" -> ()
   | Error diagnostics -> fail_diags "Secret inspect diagnostic" diagnostics
   | Ok _ -> Alcotest.fail "checker allowed generic Secret inspection");
   let audit_source = Printf.sprintf "(app (var audit.entry-code) %s)" read_secret in
@@ -124,9 +126,10 @@ let test_diagnostics_never_render_payload () =
         (contains rendered "<secret redacted>")
   | Ok value -> Alcotest.failf "Audit encoder accepted %s" (Value.show value));
   match check audit_source with
-  | Error [ { Diag.code = "E0801"; message; _ } ] ->
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0801" ->
       Alcotest.(check bool)
-        "Audit checker diagnostic contains no fixture" false (contains message fixture)
+        "Audit checker diagnostic contains no fixture" false
+        (contains (Diag.cause diagnostic) fixture)
   | Error diagnostics -> fail_diags "Secret Audit diagnostic" diagnostics
   | Ok _ -> Alcotest.fail "checker allowed Secret into Audit encoding"
 

--- a/test/test_stdlib.ml
+++ b/test/test_stdlib.ml
@@ -485,7 +485,7 @@ let test_parallel_closed_rows () =
         Alcotest.(check bool)
           (label ^ " reports a type mismatch")
           true
-          (List.exists (fun (d : Diag.t) -> d.code = "E0801") ds)
+          (List.exists (fun (d : Diag.t) -> Diag.code_or_uncoded d = "E0801") ds)
   in
   rejects_effect "parallel.map"
     "(app (var parallel.map) (app (var cons) (lit 1) (var nil)) (lam ((pvar n)) (app (var emit) \

--- a/test/test_store.ml
+++ b/test/test_store.ml
@@ -107,7 +107,7 @@ let test_rename_only_names_file () =
 let test_rename_unknown () =
   let t = open_ok (fresh_root ()) in
   match Store.rename t ~old_name:"ghost" ~new_name:"g2" () with
-  | Error [ d ] -> Alcotest.(check string) "code" "E0602" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "code" "E0602" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "renaming an unknown name must fail"
 
 (* An invalid new name must be a clean diagnostic and must not damage names.jqd
@@ -121,7 +121,7 @@ let test_invalid_names_rejected_safely () =
   List.iter
     (fun bad ->
       match Store.rename t ~old_name:"bool" ~new_name:bad () with
-      | Error [ d ] -> Alcotest.(check string) (bad ^ " rejected") "E0605" d.Diag.code
+      | Error [ d ] -> Alcotest.(check string) (bad ^ " rejected") "E0605" (Diag.code_or_uncoded d)
       | _ -> Alcotest.failf "rename to %S must fail with E0605" bad)
     [ "Bad"; "a b"; ""; "9x" ];
   (* the index survived: still resolvable in memory and on disk *)
@@ -129,14 +129,14 @@ let test_invalid_names_rejected_safely () =
   let t2 = open_ok root in
   Alcotest.(check bool) "names.jqd intact" true (Store.lookup_name t2 "bool" <> None);
   match Store.bind_name t "Nope" hs.Canon.decl_hash with
-  | Error [ d ] -> Alcotest.(check string) "bind invalid name" "E0605" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "bind invalid name" "E0605" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "bind_name with invalid name must fail"
 
 let test_defterm_group_hash_not_nameable () =
   let t = open_ok (fresh_root ()) in
   let hs = put_ok t (decl_of ~names:Resolve.empty_names "(defterm ((binding one () (lit 1))))") in
   match Store.bind_name t "the-group" hs.Canon.decl_hash with
-  | Error [ d ] -> Alcotest.(check string) "code" "E0604" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "code" "E0604" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "naming a defterm group hash must fail"
 
 let test_task_private_hash_never_nameable () =
@@ -150,7 +150,8 @@ let test_task_private_hash_never_nameable () =
     "private constructor omitted" true
     (Store.lookup_kind store "task-opaque" Resolve.KCon = None);
   (match Store.bind_name store "leaked-task" private_hash with
-  | Error [ diagnostic ] -> Alcotest.(check string) "bind code" "E0907" diagnostic.Diag.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "bind code" "E0907" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics ->
       Alcotest.failf "unexpected private bind diagnostics: %s"
         (String.concat "; " (List.map Diag.to_string diagnostics))
@@ -160,7 +161,8 @@ let test_task_private_hash_never_nameable () =
   Printf.fprintf output "(named persisted-task con #%s)\n" (Hash.to_hex private_hash);
   close_out output;
   match Store.open_store root with
-  | Error [ diagnostic ] -> Alcotest.(check string) "persisted code" "E0907" diagnostic.Diag.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "persisted code" "E0907" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics ->
       Alcotest.failf "unexpected persisted private diagnostics: %s"
         (String.concat "; " (List.map Diag.to_string diagnostics))
@@ -181,7 +183,8 @@ let test_channel_private_hash_never_nameable () =
     "private constructor omitted" true
     (Store.lookup_kind store "channel-opaque" Resolve.KCon = None);
   (match Store.bind_name store "leaked-channel" private_hash with
-  | Error [ diagnostic ] -> Alcotest.(check string) "bind code" "E0907" diagnostic.Diag.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "bind code" "E0907" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics ->
       Alcotest.failf "unexpected private bind diagnostics: %s"
         (String.concat "; " (List.map Diag.to_string diagnostics))
@@ -191,7 +194,8 @@ let test_channel_private_hash_never_nameable () =
   Printf.fprintf output "(named persisted-channel con #%s)\n" (Hash.to_hex private_hash);
   close_out output;
   match Store.open_store root with
-  | Error [ diagnostic ] -> Alcotest.(check string) "persisted code" "E0907" diagnostic.Diag.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "persisted code" "E0907" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics ->
       Alcotest.failf "unexpected persisted private diagnostics: %s"
         (String.concat "; " (List.map Diag.to_string diagnostics))
@@ -318,7 +322,7 @@ and test_once_effect_survives_store_reopen () =
 let test_unknown_hash () =
   let t = open_ok (fresh_root ()) in
   match Store.get t (Hash.of_string "nothing") with
-  | Error [ d ] -> Alcotest.(check string) "code" "E0601" d.Diag.code
+  | Error [ d ] -> Alcotest.(check string) "code" "E0601" (Diag.code_or_uncoded d)
   | _ -> Alcotest.fail "unknown hash must fail"
 
 (* PV.1: origin sidecars — stamped, carried through reopen, never hash-relevant,

--- a/test/test_structured_scope.ml
+++ b/test/test_structured_scope.ml
@@ -7,7 +7,7 @@ let ok = function
         (String.concat "\n" (List.map Diag.to_string diagnostics))
 
 let error_code = function
-  | Error ({ Diag.code; _ } :: _) -> code
+  | Error (diagnostic :: _) -> Diag.code_or_uncoded diagnostic
   | Error [] -> Alcotest.fail "structured scope returned an empty diagnostic list"
   | Ok _ -> Alcotest.fail "structured-scope operation unexpectedly succeeded"
 
@@ -98,7 +98,10 @@ let test_returned_stored_and_ancestor_handles () =
     (Structured_scope.close left ~reason:Structured_scope.Normal ~escaping:[ foreign ] ~drop:ignore
     |> error_code)
 
-let abort_diagnostic = Diag.error ~code:"E9998" "scope body aborted"
+let abort_diagnostic =
+  Diag.error ~domain:Concurrency ~code:"E9998" ~summary:"Scope body aborted"
+    ~cause:"The structured-scope test body aborted." ~next_step:"Cancel and drain the scope."
+    ~contrast:None ()
 
 let test_bracket_cleans_normal_abort_and_exception () =
   let normal, _ = Structured_scope.create ~body_resume:1 |> ok in

--- a/test/test_surface_check.ml
+++ b/test/test_surface_check.ml
@@ -25,10 +25,12 @@ let analyze_with ?(file = "surface-check.jac") ~names context source =
   Surface_check.analyze ~names context (Surface_parse.recover_string ~file source)
 
 let codes report =
-  List.map (fun diagnostic -> diagnostic.Diag.code) report.Surface_check.diagnostics
+  List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) report.Surface_check.diagnostics
 
 let diagnostics code report =
-  List.filter (fun diagnostic -> diagnostic.Diag.code = code) report.Surface_check.diagnostics
+  List.filter
+    (fun diagnostic -> Diag.code_or_uncoded diagnostic = code)
+    report.Surface_check.diagnostics
 
 let contains needle text =
   let rec loop index =
@@ -41,54 +43,58 @@ let signature_names report = List.map fst report.Surface_check.signatures
 
 let diagnostic_golden diagnostic =
   let severity =
-    match diagnostic.Diag.severity with Error -> "error" | Warning -> "warning" | Info -> "info"
+    match Diag.severity diagnostic with Error -> "error" | Warning -> "warning" | Info -> "info"
   in
-  Printf.sprintf "%s|%s|%s|%s|%s" severity diagnostic.code
-    (Option.fold ~none:"<none>" ~some:Span.to_string diagnostic.span)
-    diagnostic.message
-    (Option.value ~default:"<none>" diagnostic.hint)
+  Printf.sprintf "%s|%s|%s|%s|%s|%s" severity (Diag.code_or_uncoded diagnostic)
+    (Option.fold ~none:"<none>" ~some:Span.to_string (Diag.span diagnostic))
+    (Diag.summary diagnostic) (Diag.cause diagnostic) (Diag.next_step diagnostic)
 
 let report_golden report = List.map diagnostic_golden report.Surface_check.diagnostics
+
+let expected_golden severity code span summary cause next_step =
+  String.concat "|" [ severity; code; span; summary; cause; next_step ]
+
+let e1210 span cause =
+  expected_golden "error" "E1210" span "The source contains an unexpected surface character." cause
+    "Remove the character or replace it with valid surface syntax."
+
+let e1220 span cause =
+  expected_golden "error" "E1220" span "Surface syntax is invalid" cause
+    "Correct the syntax at this location and parse the file again."
 
 let test_hole_kinds_and_independent_islands () =
   let cases =
     [
       ( "expression",
         "broken = @\nlater = 42\n",
-        [ "error|E1210|expression.jac:1:10-11|unexpected surface character `@`|<none>" ] );
+        [ e1210 "expression.jac:1:10-11" "unexpected surface character `@`" ] );
       ( "pattern",
         "broken = match True { | @ -> 0 | _ -> 1 }\nlater = 42\n",
-        [ "error|E1210|pattern.jac:1:25-26|unexpected surface character `@`|<none>" ] );
+        [ e1210 "pattern.jac:1:25-26" "unexpected surface character `@`" ] );
       ( "type",
         "broken : @\nbroken = 1\nlater = 42\n",
         [
-          "error|E1210|type.jac:1:10-11|unexpected surface character `@`|<none>";
-          "error|E1220|type.jac:1:10-11|expected a type, found invalid(E1210)|<none>";
+          e1210 "type.jac:1:10-11" "unexpected surface character `@`";
+          e1220 "type.jac:1:10-11" "expected a type, found invalid(E1210)";
         ] );
-      ( "top",
-        "@\nlater = 42\n",
-        [ "error|E1210|top.jac:1:1-2|unexpected surface character `@`|<none>" ] );
+      ("top", "@\nlater = 42\n", [ e1210 "top.jac:1:1-2" "unexpected surface character `@`" ]);
       ( "nested",
         "broken = [1, if @ then 2 else 3]\nlater = 42\n",
-        [ "error|E1210|nested.jac:1:17-18|unexpected surface character `@`|<none>" ] );
+        [ e1210 "nested.jac:1:17-18" "unexpected surface character `@`" ] );
       ( "structural",
         "broken = match True {}\nlater = 42\n",
         [
-          "error|E0209|structural.jac:1:10-23|`match` requires at least one clause|<none>";
-          "error|E1220|structural.jac:1:22-23|a `match` requires at least one arm|<none>";
+          expected_golden "error" "E0209" "structural.jac:1:10-23"
+            "A match expression has no clauses." "`match` requires at least one clause"
+            "Add at least one match clause.";
+          e1220 "structural.jac:1:22-23" "a `match` requires at least one arm";
         ] );
       ( "row-missing-tail",
         "broken : () ->{|} Int\nbroken() = 1\nlater = 42\n",
-        [
-          "error|E1220|row-missing-tail.jac:1:17-18|expected a lowercase row variable after \
-           `|`|<none>";
-        ] );
+        [ e1220 "row-missing-tail.jac:1:17-18" "expected a lowercase row variable after `|`" ] );
       ( "row-trailing-comma",
         "broken : () ->{Net,} Int\nbroken() = 1\nlater = 42\n",
-        [
-          "error|E1220|row-trailing-comma.jac:1:20-21|effect rows do not permit a trailing \
-           comma|<none>";
-        ] );
+        [ e1220 "row-trailing-comma.jac:1:20-21" "effect rows do not permit a trailing comma" ] );
     ]
   in
   List.iter
@@ -110,7 +116,7 @@ let test_malformed_row_checks_as_any_row () =
   in
   Alcotest.(check (list string))
     "only the primary malformed-row diagnostic"
-    [ "error|E1220|row-any.jac:1:20-21|effect rows do not permit a trailing comma|<none>" ]
+    [ e1220 "row-any.jac:1:20-21" "effect rows do not permit a trailing comma" ]
     (report_golden report);
   Alcotest.(check (list string))
     "surrounding declarations still check" [ "takes"; "quiet"; "_" ] (signature_names report)
@@ -120,9 +126,10 @@ let test_primary_plus_later_type_error () =
   Alcotest.(check (list string))
     "exact primary plus independent follow-on"
     [
-      "error|E1210|bounded.jac:1:10-11|unexpected surface character `@`|<none>";
-      "error|E0801|bounded.jac:2:4-5|if condition: expected int, got bool (type mismatch)|the \
-       expected side comes from the surrounding context; make both sides agree";
+      e1210 "bounded.jac:1:10-11" "unexpected surface character `@`";
+      expected_golden "error" "E0801" "bounded.jac:2:4-5" "Types do not agree"
+        "if condition: expected int, got bool (type mismatch)"
+        "the expected side comes from the surrounding context; make both sides agree";
     ]
     (report_golden report);
   Alcotest.(check bool) "later good island checked" true (List.mem "good" (signature_names report))
@@ -209,12 +216,11 @@ let test_handler_row_annotation_conflict_recipe () =
   in
   match diagnostics "E0804" bad with
   | [ diagnostic ] ->
-      Alcotest.(check (option string))
+      Alcotest.(check string)
         "handler conflict gives a compiling row recipe"
-        (Some
-           "include the handled effect on the callback row, for example `() ->{Abort | e} a`; the \
-            handler removes it from the outer row")
-        diagnostic.Diag.hint
+        "include the handled effect on the callback row, for example `() ->{Abort | e} a`; the \
+         handler removes it from the outer row"
+        (Diag.next_step diagnostic)
   | diagnostics ->
       Alcotest.failf "expected one E0804, got %d: %s" (List.length diagnostics)
         (String.concat "; " (List.map Diag.to_string bad.diagnostics))
@@ -273,20 +279,26 @@ let test_surface_wording_and_spans () =
     [
       ( "if",
         "if 1 then 2 else 3\n",
-        "error|E0801|wording.jac:1:4-5|if condition: expected int, got bool (type mismatch)|the \
-         expected side comes from the surrounding context; make both sides agree" );
+        expected_golden "error" "E0801" "wording.jac:1:4-5" "Types do not agree"
+          "if condition: expected int, got bool (type mismatch)"
+          "the expected side comes from the surrounding context; make both sides agree" );
       ( "list",
         "[1, \"x\"]\n",
-        "error|E0801|wording.jac:1:1-9|list elements: expected list int, got list text (type \
-         mismatch)|the expected side comes from the surrounding context; make both sides agree" );
+        expected_golden "error" "E0801" "wording.jac:1:1-9" "Types do not agree"
+          "list elements: expected list int, got list text (type mismatch)"
+          "the expected side comes from the surrounding context; make both sides agree" );
       ( "pipe",
         "1 |> 2\n",
-        "error|E0802|wording.jac:1:6-7|the `|>` right-hand side has type int, which is not a \
-         function|the right-hand side of `|>` must be callable" );
+        expected_golden "error" "E0802" "wording.jac:1:6-7" "This value is not callable"
+          "the `|>` right-hand side has type int, which is not a function"
+          "Make the right-hand side of `|>` callable." );
       ( "equation",
         "identity : (Int) ->{} Text\nidentity(value) = value\n",
-        "error|E0804|wording.jac:2:1-24|equation definition `identity` does not match its \
-         signature: expected (int) ->{} text, got (int) ->{} int (type mismatch)|<none>" );
+        expected_golden "error" "E0804" "wording.jac:2:1-24"
+          "The value does not satisfy its annotation"
+          "equation definition `identity` does not match its signature: expected (int) ->{} text, \
+           got (int) ->{} int (type mismatch)"
+          "Change the value or its annotation so the two types agree." );
     ]
   in
   List.iter
@@ -299,10 +311,12 @@ let test_surface_wording_and_spans () =
 let test_eta_guidance_matrix () =
   let positive_source = "condition = True\nbool.and-then(True, condition)\n" in
   let positive = one_error "E0807" positive_source in
-  Alcotest.(check bool) "targeted wording" true (contains "wrap it in `fn () ->" positive.message);
+  Alcotest.(check bool)
+    "targeted wording" true
+    (contains "wrap it in `fn () ->" (Diag.cause positive));
   Alcotest.(check (option string))
     "bare reference span" (Some "wording.jac:2:21-30")
-    (Option.map Span.to_string positive.span);
+    (Option.map Span.to_string (Diag.span positive));
   let thunked = analyze "bool.and-then(True, fn () -> bool.not(True))\n" in
   Alcotest.(check bool) "already thunked does not fire" false (List.mem "E0807" (codes thunked));
   let arbitrary = analyze "bool.and(True, bool.not)\n" in
@@ -338,9 +352,11 @@ let test_eta_exact_positive_and_negatives () =
   Alcotest.(check (list string))
     "positive golden"
     [
-      "error|E0807|eta-positive.jac:2:21-30|this position expects a thunk, but `condition` is a \
-       bare reference; wrap it in `fn () -> ...`|wrap the reference in `fn () -> ...` so the \
-       computation is delayed";
+      expected_golden "error" "E0807" "eta-positive.jac:2:21-30"
+        "A computation was used where a thunk is required"
+        "this position expects a thunk, but `condition` is a bare reference; wrap it in `fn () -> \
+         ...`"
+        "Wrap the reference in `fn () -> ...` so the computation is delayed.";
     ]
     (report_golden positive);
   let store, context = make () in
@@ -400,9 +416,11 @@ let test_eta_exact_positive_and_negatives () =
   Alcotest.(check (list string))
     "effectful expected thunk diagnostic"
     [
-      "error|E0807|effectful-eta.jac:4:7-16|this position expects a thunk, but `condition` is a \
-       bare reference; wrap it in `fn () -> ...`|wrap the reference in `fn () -> ...` so the \
-       computation is delayed";
+      expected_golden "error" "E0807" "effectful-eta.jac:4:7-16"
+        "A computation was used where a thunk is required"
+        "this position expects a thunk, but `condition` is a bare reference; wrap it in `fn () -> \
+         ...`"
+        "Wrap the reference in `fn () -> ...` so the computation is delayed.";
     ]
     (report_golden effectful_expected);
   let repaired =
@@ -429,7 +447,8 @@ let test_raw_jqd_eta_stability () =
             | Ok expression -> Check.check_top context (Kernel.Expr expression)))
   in
   match result with
-  | Error [ diagnostic ] -> Alcotest.(check string) "raw code unchanged" "E0801" diagnostic.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "raw code unchanged" "E0801" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics -> fail_diags "raw eta check" diagnostics
   | Ok _ -> Alcotest.fail "raw eta mismatch unexpectedly checked"
 
@@ -470,15 +489,11 @@ let test_wide_pattern_boundary_and_coexistence () =
   let wide = analyze "match 1 { | Five(a, b, c, d, e) -> 0 | _ -> 1 }\n" in
   (match diagnostics "W1202" wide with
   | [ warning ] ->
-      Alcotest.(check bool) "wide is warning" true (warning.severity = Diag.Warning);
+      Alcotest.(check bool) "wide is warning" true (Diag.severity warning = Diag.Warning);
       Alcotest.(check bool)
         "bounded guidance" true
-        (Option.fold ~none:false
-           ~some:(fun hint ->
-             contains "D36" hint
-             && contains "labeled constructor patterns unavailable" hint
-             && contains "four fields or fewer" hint)
-           warning.hint)
+        (contains "labeled constructor patterns are not available" (Diag.cause warning)
+        && contains "four fields or fewer" (Diag.next_step warning))
   | found -> Alcotest.failf "expected one wide warning, got %d" (List.length found));
   let boundary = analyze "match 1 { | Four(a, b, c, d) -> 0 | _ -> 1 }\n" in
   Alcotest.(check int) "four is allowed" 0 (List.length (diagnostics "W1202" boundary));
@@ -486,7 +501,7 @@ let test_wide_pattern_boundary_and_coexistence () =
   Alcotest.(check bool)
     "warning survives errors" true
     (List.mem "W1202" (codes both)
-    && List.exists (fun d -> d.Diag.severity = Diag.Error) both.diagnostics)
+    && List.exists (fun d -> Diag.severity d = Diag.Error) both.diagnostics)
 
 let test_large_match_scrutinee_lint_boundary () =
   let lint source =
@@ -498,24 +513,22 @@ let test_large_match_scrutinee_lint_boundary () =
   let boundary = "match f(\n  1,\n  2\n) { | _ -> 0 }\n" in
   Alcotest.(check int)
     "exact four-line boundary is inclusive" 0
-    (List.length (List.filter (fun d -> d.Diag.code = "W1203") (lint boundary)));
+    (List.length (List.filter (fun d -> Diag.code_or_uncoded d = "W1203") (lint boundary)));
   let large = "match f(\n  1,\n  2,\n  3\n) { | _ -> 0 }\n" in
-  match List.filter (fun d -> d.Diag.code = "W1203") (lint large) with
+  match List.filter (fun d -> Diag.code_or_uncoded d = "W1203") (lint large) with
   | [ warning ] ->
-      Alcotest.(check bool) "large is warning" true (warning.severity = Diag.Warning);
+      Alcotest.(check bool) "large is warning" true (Diag.severity warning = Diag.Warning);
       Alcotest.(check string)
         "first warning reports five source lines"
-        "this match scrutinee spans 5 lines; scrutinees longer than 4 lines are difficult to review"
-        warning.message;
+        "This match scrutinee spans 5 lines; scrutinees longer than 4 lines obscure the branch \
+         conditions."
+        (Diag.cause warning);
       Alcotest.(check (option string))
         "scrutinee span" (Some "scrutinee.jac:1:7-5:2")
-        (Option.map Span.to_string warning.span);
+        (Option.map Span.to_string (Diag.span warning));
       Alcotest.(check bool)
         "manual-only guidance" true
-        (Option.fold ~none:false
-           ~some:(fun hint ->
-             contains "introduce a `let` binding" hint && contains "never hoists" hint)
-           warning.hint)
+        (contains "Bind the expression with `let`" (Diag.next_step warning))
   | found -> Alcotest.failf "expected one scrutinee warning, got %d" (List.length found)
 
 let test_warning_exact_order_nested_raw_and_redundancy () =
@@ -533,14 +546,21 @@ let test_warning_exact_order_nested_raw_and_redundancy () =
   Alcotest.(check (list string))
     "exact warning/error golden"
     [
-      "warning|W0801|warnings.jac:1:23-31|this clause is redundant: earlier clauses match \
-       everything it does|<none>";
-      "error|E0301|warnings.jac:2:16-44|unknown constructor `missing`|<none>";
-      "warning|W1202|warnings.jac:2:24-43|this positional constructor pattern has 5 fields; \
-       labeled constructor patterns are the future fix|D36 keeps labeled constructor patterns \
-       unavailable for now; keep positional matches to four fields or fewer";
-      "error|E0802|warnings.jac:3:6-7|the `|>` right-hand side has type int, which is not a \
-       function|the right-hand side of `|>` must be callable";
+      expected_golden "warning" "W0801" "warnings.jac:1:23-31" "This match clause is redundant"
+        "Earlier clauses match every value this clause can match."
+        "Remove the redundant clause or narrow an earlier pattern.";
+      expected_golden "error" "E0301" "warnings.jac:2:16-44"
+        "This reference names something that is not in scope."
+        "No constructor named `missing` is in scope."
+        "Correct the reference to an in-scope name or declaration.";
+      expected_golden "warning" "W1202" "warnings.jac:2:24-43"
+        "Constructor pattern is difficult to review"
+        "This positional constructor pattern has 5 fields; labeled constructor patterns are not \
+         available in 0.1."
+        "Keep positional constructor patterns to four fields or fewer.";
+      expected_golden "error" "E0802" "warnings.jac:3:6-7" "This value is not callable"
+        "the `|>` right-hand side has type int, which is not a function"
+        "Make the right-hand side of `|>` callable.";
     ]
     rendered;
   let nested = analyze "match 1 { | Outer(Five(a, b, c, d, e)) -> 0 | _ -> 1 }\n" in
@@ -575,7 +595,8 @@ let test_analysis_isolation_repeatability_and_concurrency () =
   let synthetic = Hash.of_string "surface-recovery-member:0:0:a" in
   let forged = Kernel.{ it = Ref (synthetic, Term); meta = Meta.empty } in
   (match Check.check_top context (Kernel.Expr forged) with
-  | Error [ diagnostic ] -> Alcotest.(check string) "forged synthetic ref" "E0805" diagnostic.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "forged synthetic ref" "E0805" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics -> fail_diags "forged synthetic ref" diagnostics
   | Ok _ -> Alcotest.fail "forged synthetic ref reached the caller cache");
   let strict = Kernel.{ it = Lit (LInt 1); meta = Meta.empty } in
@@ -604,7 +625,8 @@ let test_semantic_boundaries_reject_nested_markers () =
   let _, checker = make () in
   let store = Check.store checker in
   let expect_e1202 label = function
-    | Error [ diagnostic ] -> Alcotest.(check string) label "E1202" diagnostic.Diag.code
+    | Error [ diagnostic ] ->
+        Alcotest.(check string) label "E1202" (Diag.code_or_uncoded diagnostic)
     | Error diagnostics -> fail_diags label diagnostics
     | Ok _ -> Alcotest.failf "%s accepted a recovery marker" label
   in
@@ -657,13 +679,14 @@ let test_strict_boundaries_reject_recovery () =
   | Error diagnostics ->
       Alcotest.(check bool)
         "strict reports syntax" true
-        (List.exists (fun diagnostic -> diagnostic.Diag.severity = Diag.Error) diagnostics)
+        (List.exists (fun diagnostic -> Diag.severity diagnostic = Diag.Error) diagnostics)
   | Ok _ -> Alcotest.fail "strict parser accepted a recovered hole");
   let meta = Meta.empty |> Meta.with_surface_hole "manual" in
   let sentinel = Kernel.{ it = Lit (LInt 0); meta } in
   let _, context = make () in
   match Check.check_top context (Kernel.Expr sentinel) with
-  | Error [ diagnostic ] -> Alcotest.(check string) "strict checker guard" "E1202" diagnostic.code
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "strict checker guard" "E1202" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics -> fail_diags "strict checker sentinel" diagnostics
   | Ok _ -> Alcotest.fail "strict checker accepted an analysis sentinel"
 

--- a/test/test_surface_control_sugar.ml
+++ b/test/test_surface_control_sugar.ml
@@ -3,6 +3,13 @@ open Jacquard
 let fail_diags label diagnostics =
   Alcotest.failf "%s: %s" label (String.concat "; " (List.map Diag.to_string diagnostics))
 
+let expected_diagnostic span code summary cause next_step =
+  Printf.sprintf "%s: error[%s]: %s\n  Cause: %s\n  Next step: %s" span code summary cause next_step
+
+let e1220 span cause =
+  expected_diagnostic span "E1220" "Surface syntax is invalid" cause
+    "Correct the syntax at this location and parse the file again."
+
 let parse ?(file = "ss13.jac") source =
   match Surface_parse.parse_string ~file source with
   | Ok tops -> tops
@@ -249,11 +256,13 @@ let test_noncallable_pipe_reaches_checker () =
   in
   match Check.check_top context (Kernel.Expr expression) with
   | Error [ diagnostic ] ->
-      Alcotest.(check string) "normal not-callable diagnostic" "E0802" diagnostic.code
+      Alcotest.(check string)
+        "normal not-callable diagnostic" "E0802" (Diag.code_or_uncoded diagnostic)
   | Error diagnostics -> fail_diags "non-callable pipe checker" diagnostics
   | Ok _ -> Alcotest.fail "calling an integer unexpectedly type checked"
 
-let diagnostic_codes diagnostics = List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+let diagnostic_codes diagnostics =
+  List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let test_resolution_diagnostics () =
   let check source resolver expected_names =
@@ -459,13 +468,13 @@ let test_malformed_and_recovery () =
   Alcotest.(check (list string))
     "exact malformed diagnostics"
     [
-      "bad-ss13.jac:1:4-5: error[E1220]: list literals do not permit a trailing comma";
-      "bad-ss13.jac:2:6-7: error[E1220]: unclosed `if`: expected `then` after the condition, found \
-       ident(a)\n\
-      \  hint: the `if` expression opened at bad-ss13.jac:2:1-3";
-      "bad-ss13.jac:3:13-14: error[E1220]: unclosed `if`: expected `else` after the then branch, \
-       found ident(b)\n\
-      \  hint: the `if` expression opened at bad-ss13.jac:3:1-3";
+      e1220 "bad-ss13.jac:1:4-5" "list literals do not permit a trailing comma";
+      e1220 "bad-ss13.jac:2:6-7"
+        "unclosed `if`: expected `then` after the condition, found ident(a) The `if` expression \
+         opened at bad-ss13.jac:2:1-3.";
+      e1220 "bad-ss13.jac:3:13-14"
+        "unclosed `if`: expected `else` after the then branch, found ident(b) The `if` expression \
+         opened at bad-ss13.jac:3:1-3.";
     ]
     (List.map Diag.to_string recovered.diagnostics);
   (match List.rev recovered.items with
@@ -474,7 +483,7 @@ let test_malformed_and_recovery () =
   let missing = Surface_parse.recover_string ~file:"missing-list.jac" "[1" in
   Alcotest.(check (list string))
     "missing bracket exact diagnostic"
-    [ "missing-list.jac:1:3-3: error[E1220]: expected `,` or `]`, found eof" ]
+    [ e1220 "missing-list.jac:1:3-3" "expected `,` or `]`, found eof" ]
     (List.map Diag.to_string missing.diagnostics)
 
 let test_top_level_recovery_boundaries () =
@@ -482,7 +491,7 @@ let test_top_level_recovery_boundaries () =
   let list_recovered = Surface_parse.recover_string ~file:"list-boundary.jac" list_source in
   Alcotest.(check (list string))
     "list boundary diagnostic"
-    [ "list-boundary.jac:2:1-6: error[E1220]: expected `,` or `]` before the next top-level item" ]
+    [ e1220 "list-boundary.jac:2:1-6" "expected `,` or `]` before the next top-level item" ]
     (List.map Diag.to_string list_recovered.diagnostics);
   (match list_recovered.items with
   | [
@@ -496,9 +505,9 @@ let test_top_level_recovery_boundaries () =
   Alcotest.(check (list string))
     "if boundary diagnostic"
     [
-      "if-boundary.jac:2:1-6: error[E1220]: unclosed `if`: expected `else` after the then branch \
-       before the next top-level item\n\
-      \  hint: the `if` expression opened at if-boundary.jac:1:1-3";
+      e1220 "if-boundary.jac:2:1-6"
+        "unclosed `if`: expected `else` after the then branch before the next top-level item The \
+         `if` expression opened at if-boundary.jac:1:1-3.";
     ]
     (List.map Diag.to_string if_recovered.diagnostics);
   match if_recovered.items with
@@ -532,15 +541,15 @@ let test_nested_recovery_boundaries () =
     [
       ( "nested-list-call.jac",
         "f([1\n)\nafter = 7\n",
-        "nested-list-call.jac:2:1-2: error[E1220]: expected `,` or `]`, found )" );
+        e1220 "nested-list-call.jac:2:1-2" "expected `,` or `]`, found )" );
       ( "nested-if-call.jac",
         "f(if c then a\n)\nafter = 7\n",
-        "nested-if-call.jac:2:1-2: error[E1220]: unclosed `if`: expected `else` after the then \
-         branch, found )\n\
-        \  hint: the `if` expression opened at nested-if-call.jac:1:3-5" );
+        e1220 "nested-if-call.jac:2:1-2"
+          "unclosed `if`: expected `else` after the then branch, found ) The `if` expression \
+           opened at nested-if-call.jac:1:3-5." );
       ( "nested-list-block.jac",
         "{\n[1\n}\nafter = 7\n",
-        "nested-list-block.jac:3:1-2: error[E1220]: expected `,` or `]`, found }" );
+        e1220 "nested-list-block.jac:3:1-2" "expected `,` or `]`, found }" );
     ]
   in
   List.iter

--- a/test/test_surface_decls.ml
+++ b/test/test_surface_decls.ml
@@ -62,9 +62,24 @@ let binding_names groups = List.map (List.map (fun binding -> binding.Kernel.bna
 let error_codes source =
   match Surface_parse.parse_string ~file:"bad-decls.jac" source with
   | Ok _ -> Alcotest.failf "expected this source to fail:\n%s" source
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let has_code code source = Alcotest.(check bool) source true (List.mem code (error_codes source))
+
+let expected_diagnostic span code summary cause next_step =
+  Printf.sprintf "%s: error[%s]: %s\n  Cause: %s\n  Next step: %s" span code summary cause next_step
+
+let e1221 span cause =
+  expected_diagnostic span "E1221" "A delimited construct is not closed" cause
+    "Close the construct with the expected delimiter."
+
+let e1225 span cause =
+  expected_diagnostic span "E1225" "A type or effect declaration is incomplete" cause
+    "Complete the declaration structure shown at this location."
+
+let e1236 span cause =
+  expected_diagnostic span "E1236" "An effect operation mode is invalid" cause
+    "Give each operation exactly one compatible `once` or `multi` mode."
 
 let lower_errors source =
   match Surface_lower.lower_tops (parse source) with
@@ -194,7 +209,9 @@ let test_duplicate_definition_names () =
   List.iter
     (fun source ->
       match lower_errors source with
-      | [ { Diag.code = "E0303"; span = Some span; _ } ] ->
+      | [ diagnostic ]
+        when Diag.code diagnostic = Some "E0303" && Option.is_some (Diag.span diagnostic) ->
+          let span = Option.get (Diag.span diagnostic) in
           Alcotest.(check int)
             (source ^ " duplicate starts at second definition")
             (String.index source ';' + 1)
@@ -308,18 +325,20 @@ let test_effect_declarations () =
   Alcotest.(check (list string))
     "mode diagnostics and spans"
     [
-      "bad-modes.jac:1:24-26: error[E1236]: surface effect operation `op` requires an explicit \
-       `once` or `multi` mode; during migration, choose `once` unless its handler deliberately \
-       searches, captures, or reuses continuations";
-      "bad-modes.jac:4:3-9: error[E1236]: surface effect operation `second` requires an explicit \
-       `once` or `multi` mode; during migration, choose `once` unless its handler deliberately \
-       searches, captures, or reuses continuations";
-      "bad-modes.jac:6:31-35: error[E1236]: `once` is already supplied by the effect-level \
-       shorthand; remove the operation-level mode";
-      "bad-modes.jac:7:30-35: error[E1236]: operation mode `multi` conflicts with the effect-level \
-       `once` shorthand";
-      "bad-modes.jac:8:30-34: error[E1236]: operation mode `once` is duplicated";
-      "bad-modes.jac:9:6-11: error[E1236]: effect-level mode `multi` conflicts with `once`";
+      e1236 "bad-modes.jac:1:24-26"
+        "surface effect operation `op` requires an explicit `once` or `multi` mode; during \
+         migration, choose `once` unless its handler deliberately searches, captures, or reuses \
+         continuations";
+      e1236 "bad-modes.jac:4:3-9"
+        "surface effect operation `second` requires an explicit `once` or `multi` mode; during \
+         migration, choose `once` unless its handler deliberately searches, captures, or reuses \
+         continuations";
+      e1236 "bad-modes.jac:6:31-35"
+        "`once` is already supplied by the effect-level shorthand; remove the operation-level mode";
+      e1236 "bad-modes.jac:7:30-35"
+        "operation mode `multi` conflicts with the effect-level `once` shorthand";
+      e1236 "bad-modes.jac:8:30-34" "operation mode `once` is duplicated";
+      e1236 "bad-modes.jac:9:6-11" "effect-level mode `multi` conflicts with `once`";
     ]
     rendered;
   let format source =
@@ -372,27 +391,24 @@ let test_declaration_recovery () =
       ( "type without constructor",
         "type Bad = |\nlater = 1\n",
         `Type,
-        [
-          "recover-decls.jac:2:1-6: error[E1225]: a type declaration requires a constructor after \
-           `|`";
-        ] );
+        [ e1225 "recover-decls.jac:2:1-6" "a type declaration requires a constructor after `|`" ] );
       ( "effect without operation or close",
         "once effect Bad where {\nlater = 1\n",
         `Effect,
-        [ "recover-decls.jac:2:1-6: error[E1221]: expected `}` before the next top-level item" ] );
+        [ e1221 "recover-decls.jac:2:1-6" "expected `}` before the next top-level item" ] );
       ( "field without type or close",
         "type Bad = | MkBad(field:\nlater = 1\n",
         `Type,
         [
-          "recover-decls.jac:2:1-6: error[E1225]: expected a field type in constructor `mk-bad` \
-           before the next top-level item";
+          e1225 "recover-decls.jac:2:1-6"
+            "expected a field type in constructor `mk-bad` before the next top-level item";
         ] );
       ( "parsed field type without close",
         "type Bad = | MkBad(field: (List T)\nlater = 1\n",
         `Type,
         [
-          "recover-decls.jac:2:1-6: error[E1225]: expected `)` to close constructor `mk-bad` \
-           before the next top-level item";
+          e1225 "recover-decls.jac:2:1-6"
+            "expected `)` to close constructor `mk-bad` before the next top-level item";
         ] );
     ]
   in

--- a/test/test_surface_handlers_quote.ml
+++ b/test/test_surface_handlers_quote.ml
@@ -31,12 +31,12 @@ let check_equivalent label surface jqd =
        (Kernel.expr_to_form (lower surface)))
 
 let diagnostic_codes recovered =
-  List.map (fun diagnostic -> diagnostic.Diag.code) recovered.Surface_ast.diagnostics
+  List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) recovered.Surface_ast.diagnostics
 
 let parse_error_codes source =
   match Surface_parse.parse_string ~file:"bad-handler.jac" source with
   | Ok _ -> Alcotest.failf "expected %S to fail parsing" source
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let test_handler_equivalence_and_clause_shapes () =
   check_equivalent "return-only handler" "handle body { | return Some(x) -> x }"
@@ -112,18 +112,21 @@ let find_following_definition recovered =
 
 let count_code code recovered =
   List.fold_left
-    (fun count diagnostic -> if String.equal diagnostic.Diag.code code then count + 1 else count)
+    (fun count diagnostic ->
+      if String.equal (Diag.code_or_uncoded diagnostic) code then count + 1 else count)
     0 recovered.Surface_ast.diagnostics
 
 let count_diagnostic code diagnostics =
   List.fold_left
-    (fun count diagnostic -> if String.equal diagnostic.Diag.code code then count + 1 else count)
+    (fun count diagnostic ->
+      if String.equal (Diag.code_or_uncoded diagnostic) code then count + 1 else count)
     0 diagnostics
 
 let count_reader_diagnostics diagnostics =
   List.fold_left
     (fun count diagnostic ->
-      if String.starts_with ~prefix:"E01" diagnostic.Diag.code then count + 1 else count)
+      if String.starts_with ~prefix:"E01" (Diag.code_or_uncoded diagnostic) then count + 1
+      else count)
     0 diagnostics
 
 let raw_top_ints recovered =
@@ -201,9 +204,12 @@ let test_missing_quote_brace_recovery () =
       true
       (find_following_definition recovered);
     (match
-       List.find_opt (fun diagnostic -> diagnostic.Diag.code = "E1221") recovered.diagnostics
+       List.find_opt
+         (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1221")
+         recovered.diagnostics
      with
-    | Some { span = Some span; _ } ->
+    | Some diagnostic when Option.is_some (Diag.span diagnostic) ->
+        let span = Option.get (Diag.span diagnostic) in
         Alcotest.(check string)
           (label ^ " boundary span") "missing-quote.jac:2:1-6" (Span.to_string span)
     | _ -> Alcotest.failf "%s did not retain the E1221 span" label);
@@ -235,7 +241,8 @@ let test_missing_quote_brace_recovery () =
     "commented boundary preserves the following definition" true
     (find_following_definition commented);
   (match commented.diagnostics with
-  | [ { span = Some span; _ } ] ->
+  | [ diagnostic ] when Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string)
         "commented boundary span" "missing-commented-quote.jac:3:1-6" (Span.to_string span)
   | _ -> Alcotest.fail "commented quote recovery produced an unexpected diagnostic shape");
@@ -348,10 +355,11 @@ after = 7
     (count_code "E0114" raw_reader_damage);
   (match
      List.find_opt
-       (fun diagnostic -> String.equal diagnostic.Diag.code "E0114")
+       (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0114")
        raw_reader_damage.diagnostics
    with
-  | Some { span = Some span; _ } ->
+  | Some diagnostic when Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string)
         "raw Reader diagnostic maps to the surface raw region" "recover-handler.jac:2:29-48"
         (Span.to_string span)
@@ -418,7 +426,9 @@ let test_quote_unquote_and_resolution () =
     "quoted name stays unresolved and live splice resolves" true
     (Form.equal_ignoring_meta expected (payload resolved));
   match Surface_lower.lower_expr (parse_expr "unquote(x)") with
-  | Error [ { Diag.code = "E0204"; span = Some _; _ } ] -> ()
+  | Error [ diagnostic ]
+    when Diag.code diagnostic = Some "E0204" && Option.is_some (Diag.span diagnostic) ->
+      ()
   | Error diagnostics -> fail_diags "unquote outside quote" diagnostics
   | Ok _ -> Alcotest.fail "unquote outside quote reached the kernel"
 
@@ -756,12 +766,13 @@ let test_quoted_namespace_depth_and_raw_markers () =
   List.iter
     (fun (label, source, expected_code) ->
       match Kernel.expr_of_form (parse_form source) with
-      | Error [ diagnostic ] -> Alcotest.(check string) label expected_code diagnostic.Diag.code
+      | Error [ diagnostic ] ->
+          Alcotest.(check string) label expected_code (Diag.code_or_uncoded diagnostic)
       | Error diagnostics -> fail_diags label diagnostics
       | Ok _ -> Alcotest.failf "%s marker was accepted" label)
     malformed;
   match Surface_lower.lower_expr (parse_expr "quote { jqd { (surface-ref-v0 invalid same) } }") with
-  | Error [ { Diag.code = "E0210"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E0210" -> ()
   | Error diagnostics -> fail_diags "malformed quoted raw marker" diagnostics
   | Ok _ -> Alcotest.fail "malformed marker survived quote validation"
 
@@ -794,7 +805,9 @@ let test_raw_jqd_inversion_and_round_trips () =
   (match
      Surface_lower.lower_expr (parse_expr ~file:"bad-raw.jac" "quote { jqd { (unquote (lit)) } }")
    with
-  | Error [ { Diag.code = "E0202"; span = Some span; _ } ] ->
+  | Error [ diagnostic ]
+    when Diag.code diagnostic = Some "E0202" && Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string) "raw validation span" "bad-raw.jac:1:24-29" (Span.to_string span)
   | Error diagnostics -> fail_diags "raw validation" diagnostics
   | Ok _ -> Alcotest.fail "malformed live raw unquote was accepted");
@@ -841,10 +854,11 @@ let test_raw_recovery_and_illegal_context () =
   let bad_reader = check_one "E0101" "quote { jqd { (lit @) } }\nafter = 7\n" in
   (match
      List.find_opt
-       (fun diagnostic -> String.equal diagnostic.Diag.code "E0101")
+       (fun diagnostic -> String.equal (Diag.code_or_uncoded diagnostic) "E0101")
        bad_reader.diagnostics
    with
-  | Some { span = Some span; _ } ->
+  | Some diagnostic when Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string)
         "Reader error span remaps into surface source" "malformed-raw.jac:1:20-20"
         (Span.to_string span)
@@ -866,7 +880,9 @@ let test_raw_recovery_and_illegal_context () =
        (parse_expr ~file:"nested-malformed-raw.jac"
           "quote { quote { jqd { (unquote (unquote (lit))) } } }")
    with
-  | Error [ { Diag.code = "E0202"; span = Some span; _ } ] ->
+  | Error [ diagnostic ]
+    when Diag.code diagnostic = Some "E0202" && Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string)
         "nested raw validation remaps the live splice span" "nested-malformed-raw.jac:1:41-46"
         (Span.to_string span)
@@ -966,8 +982,11 @@ let test_raw_candidate_eof_fallback () =
   Alcotest.(check int) "top fallback does not report E1221" 0 (count_code "E1221" top);
   Alcotest.(check bool)
     "top fallback preserves the following definition" true (find_following_definition top);
-  (match List.find_opt (fun diagnostic -> diagnostic.Diag.code = "E0106") top.diagnostics with
-  | Some { span = Some span; _ } ->
+  (match
+     List.find_opt (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E0106") top.diagnostics
+   with
+  | Some diagnostic when Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string)
         "top fallback maps the Reader span" "raw-fallback.jac:1:7-14" (Span.to_string span)
   | _ -> Alcotest.fail "top fallback Reader diagnostic had no mapped span");
@@ -1054,9 +1073,12 @@ after = 7
   in
   let reproduction = check_balanced_string_fallback "balanced brace string" {|"}"|} in
   (match
-     List.find_opt (fun diagnostic -> diagnostic.Diag.code = "E0106") reproduction.diagnostics
+     List.find_opt
+       (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E0106")
+       reproduction.diagnostics
    with
-  | Some { span = Some span; _ } ->
+  | Some diagnostic when Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string)
         "balanced brace string maps the Reader span" "raw-fallback.jac:1:7-26" (Span.to_string span)
   | _ -> Alcotest.fail "balanced brace string Reader diagnostic had no mapped span");
@@ -1091,7 +1113,7 @@ let test_unclosed_raw_always_reports_missing_brace () =
     let offsets =
       List.map
         (fun diagnostic ->
-          match diagnostic.Diag.span with
+          match Diag.span diagnostic with
           | Some span -> span.Span.start_pos.offset
           | None -> max_int)
         diagnostics
@@ -1112,7 +1134,7 @@ let test_unclosed_raw_always_reports_missing_brace () =
       | Error diagnostics ->
           Alcotest.(check (list string))
             (label ^ " strict codes") expected
-            (List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics);
+            (List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics);
           Alcotest.(check int)
             (label ^ " strict exactly one missing brace")
             1

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -702,8 +702,9 @@ let validate_release_docs ~decision ~followups ~index =
                      name (String.concat ", " claimed) (String.concat ", " actual))
         | _ -> add (name ^ " inventory must have exactly one three-column row")
       in
-      (* Successor evidence is checked against the live executable and repository inventories. *)
-      check_inventory "tests" (List.init (Lazy.force compiled_test_count) string_of_int) false;
+      (* This signed SS.22 decision records its historical inventory. Successor evidence is checked
+         against the live executable and repository inventories by [release_inventory_errors]. *)
+      check_inventory "tests" (List.init 738 string_of_int) false;
       check_inventory "doctests" (doctest_names ()) true;
       check_inventory "twins" (twin_names ()) true;
       check_inventory "demos" (demo_names ()) true);

--- a/test/test_surface_lex.ml
+++ b/test/test_surface_lex.ml
@@ -15,6 +15,9 @@ let token_names source =
 let shown source = lex source |> without_eof |> List.map Surface_lex.show
 let recover_lex source = Surface_lex.lex_recover ~file:"tokens.jac" source
 
+let expected_diagnostic span code summary cause next_step =
+  Printf.sprintf "%s: error[%s]: %s\n  Cause: %s\n  Next step: %s" span code summary cause next_step
+
 let recovered_token_names source =
   (recover_lex source).Surface_lex.tokens |> without_eof
   |> List.map (fun token -> Surface_lex.show_token token.Surface_lex.token)
@@ -167,7 +170,7 @@ let test_strict_group_indices () =
   List.iter
     (fun source ->
       match Surface_lex.lex ~file:"group.jac" source with
-      | Error [ { Diag.code = "E1217"; _ } ] -> ()
+      | Error [ diagnostic ] when Diag.code diagnostic = Some "E1217" -> ()
       | _ -> Alcotest.failf "%s: non-decimal group index was accepted" source)
     [ "#group[+12]"; "#group[0x10]"; "#group[1_2]"; "#group[]"; "#group[12" ]
 
@@ -195,8 +198,8 @@ let test_malformed_tokens () =
     (fun (source, code, expected_span) ->
       match Surface_lex.lex ~file:"bad.jac" source with
       | Error [ diagnostic ] -> (
-          Alcotest.(check string) (source ^ " code") code diagnostic.Diag.code;
-          match diagnostic.span with
+          Alcotest.(check string) (source ^ " code") code (Diag.code_or_uncoded diagnostic);
+          match Diag.span diagnostic with
           | Some span ->
               Alcotest.(check string) (source ^ " span") expected_span (Span.to_string span)
           | None -> Alcotest.failf "%s: missing diagnostic span" source)
@@ -208,7 +211,9 @@ let test_malformed_tokens () =
 let test_invalid_raw_utf8 () =
   let source = String.init 3 (function 0 | 2 -> '"' | _ -> Char.chr 0xff) in
   match Surface_lex.lex ~file:"utf8.jac" source with
-  | Error [ { Diag.code = "E1218"; span = Some span; _ } ] ->
+  | Error [ diagnostic ]
+    when Diag.code diagnostic = Some "E1218" && Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string) "invalid byte span" "utf8.jac:1:2-3" (Span.to_string span)
   | _ -> Alcotest.fail "invalid raw UTF-8 byte was accepted"
 
@@ -230,10 +235,16 @@ let test_recovering_lexer_preserves_surrounding_tokens () =
     (recovered_token_names source);
   Alcotest.(check (list string))
     "recovery diagnostics"
-    [ "tokens.jac:2:1-2: error[E1210]: unexpected surface character `@`" ]
+    [
+      expected_diagnostic "tokens.jac:2:1-2" "E1210"
+        "The source contains an unexpected surface character." "unexpected surface character `@`"
+        "Remove the character or replace it with valid surface syntax.";
+    ]
     (List.map Diag.to_string recovered.diagnostics);
   match Surface_lex.lex ~file:"tokens.jac" source with
-  | Error [ { Diag.code = "E1210"; span = Some span; _ } ] ->
+  | Error [ diagnostic ]
+    when Diag.code diagnostic = Some "E1210" && Option.is_some (Diag.span diagnostic) ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string) "strict span unchanged" "tokens.jac:2:1-2" (Span.to_string span)
   | _ -> Alcotest.fail "strict lexer no longer stops at its first lexical error"
 
@@ -246,7 +257,11 @@ let test_recovering_lexer_resynchronizes_strings () =
     |> List.map (fun token -> Surface_lex.show_token token.Surface_lex.token));
   Alcotest.(check (list string))
     "bounded truncated string diagnostic"
-    [ "tokens.jac:2:1-11: error[E1213]: unterminated string literal" ]
+    [
+      expected_diagnostic "tokens.jac:2:1-11" "E1213" "A surface string literal is not closed."
+        "unterminated string literal"
+        "Close the string with a double quote before the end of the line or file.";
+    ]
     (List.map Diag.to_string truncated.diagnostics);
   let malformed = recover_lex "before\n\"bad\\q\"\nafter\n" in
   Alcotest.(check (list string))
@@ -256,7 +271,10 @@ let test_recovering_lexer_resynchronizes_strings () =
     |> List.map (fun token -> Surface_lex.show_token token.Surface_lex.token));
   Alcotest.(check (list string))
     "malformed escape diagnostic"
-    [ "tokens.jac:2:5-6: error[E1214]: invalid string escape `\\q`" ]
+    [
+      expected_diagnostic "tokens.jac:2:5-6" "E1214" "A surface string contains an invalid escape."
+        "invalid string escape `\\q`" "Replace the escape with one supported by surface strings.";
+    ]
     (List.map Diag.to_string malformed.diagnostics);
   let multiline = recover_lex "before\n\"line one\nbad\\q\"\nafter\n" in
   Alcotest.(check (list string))
@@ -266,7 +284,10 @@ let test_recovering_lexer_resynchronizes_strings () =
     |> List.map (fun token -> Surface_lex.show_token token.Surface_lex.token));
   Alcotest.(check (list string))
     "multiline malformed escape diagnostic"
-    [ "tokens.jac:3:4-5: error[E1214]: invalid string escape `\\q`" ]
+    [
+      expected_diagnostic "tokens.jac:3:4-5" "E1214" "A surface string contains an invalid escape."
+        "invalid string escape `\\q`" "Replace the escape with one supported by surface strings.";
+    ]
     (List.map Diag.to_string multiline.diagnostics);
   let escaped_newline = recover_lex "\"bad\\\nafter\n" in
   Alcotest.(check (list string))
@@ -276,7 +297,11 @@ let test_recovering_lexer_resynchronizes_strings () =
     |> List.map (fun token -> Surface_lex.show_token token.Surface_lex.token));
   Alcotest.(check (list string))
     "escaped newline diagnostic"
-    [ "tokens.jac:1:5-6: error[E1214]: invalid string escape `\\\n`" ]
+    [
+      expected_diagnostic "tokens.jac:1:5-6" "E1214" "A surface string contains an invalid escape."
+        ("invalid string escape `\\\n" ^ String.make 9 ' ' ^ "`")
+        "Replace the escape with one supported by surface strings.";
+    ]
     (List.map Diag.to_string escaped_newline.diagnostics)
 
 let test_raw_bootstrap_candidates () =

--- a/test/test_surface_parse.ml
+++ b/test/test_surface_parse.ml
@@ -31,7 +31,7 @@ let check_equivalent label surface jqd =
 let error_codes source =
   match Surface_parse.parse_string ~file:"bad.jac" source with
   | Ok _ -> Alcotest.failf "expected %S to fail surface parsing" source
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let lower_error source =
   let expression = parse_surface_expr source in
@@ -64,12 +64,14 @@ let test_functions_and_patterns () =
       Alcotest.(check bool)
         (source ^ " is rejected during lowering")
         true
-        (List.exists (fun diagnostic -> diagnostic.Diag.code = "E0205") (lower_error source)))
+        (List.exists
+           (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E0205")
+           (lower_error source)))
     [ "fn (1) -> 2"; "fn (Some(x)) -> 2" ];
   Alcotest.(check bool)
     "refutable let is rejected during lowering" true
     (List.exists
-       (fun diagnostic -> diagnostic.Diag.code = "E0206")
+       (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E0206")
        (lower_error "{ let 1 = 2; 3 }"));
   check_equivalent "irrefutable as parameter" "fn (x as whole) -> whole"
     "(lam ((pas whole (pvar x))) (var whole))"
@@ -116,8 +118,11 @@ let test_forall_row_var_requirement () =
     (fun source ->
       match Surface_parse.parse_string ~file:"forall.jac" source with
       | Error diagnostics -> (
-          match List.find_opt (fun diagnostic -> diagnostic.Diag.code = "E1220") diagnostics with
-          | Some { Diag.span = Some span; _ } ->
+          match
+            List.find_opt (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1220") diagnostics
+          with
+          | Some diagnostic when Option.is_some (Diag.span diagnostic) ->
+              let span = Option.get (Diag.span diagnostic) in
               let dot = String.index source '.' in
               Alcotest.(check int) (source ^ " diagnostic offset") dot span.Span.start_pos.offset
           | Some _ -> Alcotest.failf "%s: forall row-variable diagnostic has no span" source
@@ -156,15 +161,21 @@ let test_newline_and_separator_rules () =
 
 let test_block_lowering_errors () =
   (match lower_error "{}" with
-  | [ { Diag.code = "E1231"; span = Some span; _ } ] ->
+  | [ diagnostic ] when Diag.code diagnostic = Some "E1231" && Option.is_some (Diag.span diagnostic)
+    ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string) "empty block span" "surface.jac:1:1-3" (Span.to_string span)
   | diagnostics -> fail_diags "empty block diagnostic" diagnostics);
   (match lower_error "{ let x = 1 }" with
-  | [ { Diag.code = "E1232"; span = Some span; _ } ] ->
+  | [ diagnostic ] when Diag.code diagnostic = Some "E1232" && Option.is_some (Diag.span diagnostic)
+    ->
+      let span = Option.get (Diag.span diagnostic) in
       Alcotest.(check string) "final let span" "surface.jac:1:3-12" (Span.to_string span)
   | diagnostics -> fail_diags "final let diagnostic" diagnostics);
   match lower_error "{ let rec (f, g)(x) = x; f }" with
-  | [ { Diag.code = "E1233"; span = Some _; _ } ] -> ()
+  | [ diagnostic ] when Diag.code diagnostic = Some "E1233" && Option.is_some (Diag.span diagnostic)
+    ->
+      ()
   | diagnostics -> fail_diags "recursive binder diagnostic" diagnostics
 
 let test_generated_spans_and_provenance () =
@@ -200,7 +211,9 @@ let test_recovery_preserves_later_expression () =
   let recovered = Surface_parse.recover_string ~file:"recover.jac" "f(,)\n42\n" in
   Alcotest.(check bool)
     "diagnostic survives" true
-    (List.exists (fun diagnostic -> diagnostic.Diag.code = "E1220") recovered.diagnostics);
+    (List.exists
+       (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1220")
+       recovered.diagnostics);
   match List.rev recovered.items with
   | { Surface_ast.it = TopExpr { it = Lit (LInt 42); _ }; _ } :: _ -> ()
   | _ -> Alcotest.fail "call recovery discarded the later valid top-level expression"
@@ -209,7 +222,7 @@ let test_nested_lexical_recovery () =
   let recovered = Surface_parse.recover_string ~file:"recover.jac" "f(1, @, 2)\n42\n" in
   Alcotest.(check (list string))
     "nested lexical diagnostic retained" [ "E1210" ]
-    (List.map (fun diagnostic -> diagnostic.Diag.code) recovered.diagnostics);
+    (List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) recovered.diagnostics);
   match List.rev recovered.items with
   | { Surface_ast.it = TopExpr { it = Lit (LInt 42); _ }; _ } :: _ -> ()
   | _ -> Alcotest.fail "nested lexical recovery discarded the later expression"

--- a/test/test_surface_parse_recovery.ml
+++ b/test/test_surface_parse_recovery.ml
@@ -3,9 +3,16 @@ open Jacquard
 let recover source = Surface_parse.recover_string ~file:"recover.jac" source
 
 let diagnostic_codes recovered =
-  List.map (fun diagnostic -> diagnostic.Diag.code) recovered.Surface_ast.diagnostics
+  List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) recovered.Surface_ast.diagnostics
 
 let rendered_diagnostics recovered = List.map Diag.to_string recovered.Surface_ast.diagnostics
+
+let expected_diagnostic span code summary cause next_step =
+  Printf.sprintf "%s: error[%s]: %s\n  Cause: %s\n  Next step: %s" span code summary cause next_step
+
+let e1220 span cause =
+  expected_diagnostic span "E1220" "Surface syntax is invalid" cause
+    "Correct the syntax at this location and parse the file again."
 
 let metadata_golden id meta =
   let span = Option.fold ~none:"<missing>" ~some:Span.to_string (Meta.span meta) in
@@ -18,8 +25,8 @@ let test_recovery_golden () =
   Alcotest.(check (list string))
     "all parser diagnostics"
     [
-      "recover.jac:3:1-2: error[E1220]: stray `|` at top level";
-      "recover.jac:5:1-5: error[E1220]: expected an expression, found keyword(then)";
+      e1220 "recover.jac:3:1-2" "stray `|` at top level";
+      e1220 "recover.jac:5:1-5" "expected an expression, found keyword(then)";
     ]
     (rendered_diagnostics recovered);
   (match recovered.items with
@@ -114,7 +121,7 @@ let test_empty_and_malformed_inputs_do_not_raise () =
       | Error diagnostics ->
           Alcotest.(check (list string))
             (label ^ " strict") expected_codes
-            (List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics)
+            (List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics)
       | Ok _ -> Alcotest.failf "%s: strict parsing accepted malformed input" label)
     malformed
 
@@ -132,8 +139,10 @@ let test_mixed_lexical_and_parser_recovery () =
   Alcotest.(check (list string))
     "mixed diagnostics"
     [
-      "recover.jac:2:1-2: error[E1210]: unexpected surface character `@`";
-      "recover.jac:3:1-2: error[E1220]: unmatched `}` at top level";
+      expected_diagnostic "recover.jac:2:1-2" "E1210"
+        "The source contains an unexpected surface character." "unexpected surface character `@`"
+        "Remove the character or replace it with valid surface syntax.";
+      e1220 "recover.jac:3:1-2" "unmatched `}` at top level";
     ]
     (rendered_diagnostics recovered);
   (match recovered.items with
@@ -152,7 +161,7 @@ let test_mixed_lexical_and_parser_recovery () =
   | Error diagnostics ->
       Alcotest.(check (list string))
         "strict mixed diagnostics" [ "E1210"; "E1220" ]
-        (List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics)
+        (List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics)
   | Ok _ -> Alcotest.fail "strict parsing accepted a mixed-damage partial tree"
 
 let test_mixed_lexical_recovery_inside_block () =
@@ -236,7 +245,7 @@ let test_unterminated_list_recovery_holes () =
   let recovered = recover "[1\nafter = 7\n" in
   Alcotest.(check (list string))
     "top-level diagnostics"
-    [ "recover.jac:2:1-6: error[E1220]: expected `,` or `]` before the next top-level item" ]
+    [ e1220 "recover.jac:2:1-6" "expected `,` or `]` before the next top-level item" ]
     (rendered_diagnostics recovered);
   (match recovered.items with
   | [
@@ -257,7 +266,7 @@ let test_unterminated_list_recovery_holes () =
   | _ -> Alcotest.fail "unterminated list lost its item, hole, or following definition");
   let without_diagnostics = { recovered with Surface_ast.diagnostics = [] } in
   match Surface_parse.strict_file without_diagnostics with
-  | Error [ { Diag.code = "E1202"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E1202" -> ()
   | Error diagnostics ->
       Alcotest.failf "strict_file returned unexpected diagnostics:\n%s"
         (String.concat "\n" (List.map Diag.to_string diagnostics))
@@ -267,7 +276,7 @@ let test_list_holes_at_container_boundaries () =
   let call = recover "f([1)\n" in
   Alcotest.(check (list string))
     "call diagnostics"
-    [ "recover.jac:1:5-6: error[E1220]: expected `,` or `]`, found )" ]
+    [ e1220 "recover.jac:1:5-6" "expected `,` or `]`, found )" ]
     (rendered_diagnostics call);
   (match call.items with
   | [
@@ -290,7 +299,7 @@ let test_list_holes_at_container_boundaries () =
   let block = recover "{ [1 }\n" in
   Alcotest.(check (list string))
     "block diagnostics"
-    [ "recover.jac:1:6-7: error[E1220]: expected `,` or `]`, found }" ]
+    [ e1220 "recover.jac:1:6-7" "expected `,` or `]`, found }" ]
     (rendered_diagnostics block);
   (match block.items with
   | [
@@ -310,7 +319,7 @@ let test_list_holes_at_container_boundaries () =
   let arm = recover "match x { | Bad -> [1 | Later -> 9 }\n" in
   Alcotest.(check (list string))
     "arm diagnostics"
-    [ "recover.jac:1:23-24: error[E1220]: expected `,` or `]`, found |" ]
+    [ e1220 "recover.jac:1:23-24" "expected `,` or `]`, found |" ]
     (rendered_diagnostics arm);
   (match arm.items with
   | [
@@ -343,7 +352,7 @@ let test_list_holes_at_container_boundaries () =
   let closing_arm = recover "match x { | Bad -> [1 }\n" in
   Alcotest.(check (list string))
     "closing-arm diagnostics"
-    [ "recover.jac:1:23-24: error[E1220]: expected `,` or `]`, found }" ]
+    [ e1220 "recover.jac:1:23-24" "expected `,` or `]`, found }" ]
     (rendered_diagnostics closing_arm);
   match closing_arm.items with
   | [

--- a/test/test_surface_patterns.ml
+++ b/test/test_surface_patterns.ml
@@ -30,12 +30,12 @@ let check_equivalent label surface jqd =
 let parse_codes source =
   match Surface_parse.parse_string ~file:"bad-patterns.jac" source with
   | Ok _ -> Alcotest.failf "expected %S to fail parsing" source
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let lower_codes source =
   match Surface_lower.lower_expr (parse_expr source) with
   | Ok _ -> Alcotest.failf "expected %S to fail lowering" source
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let resolve names expression =
   match Resolve.resolve_expr names expression with
@@ -141,7 +141,7 @@ let test_contextual_restrictions_and_duplicates () =
   | Error diagnostics ->
       Alcotest.(check (list string))
         "duplicate remains resolver-owned" [ "E0304" ]
-        (List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics)
+        (List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics)
   | Ok _ -> Alcotest.fail "resolver accepted a duplicate match binder"
 
 let test_resolved_hash_parity () =
@@ -194,7 +194,9 @@ let test_ambiguous_nested_recovery () =
   let recovered = Surface_parse.recover_string ~file:"recover-patterns.jac" block in
   Alcotest.(check bool)
     "damaged block reports missing structure" true
-    (List.exists (fun diagnostic -> diagnostic.Diag.code = "E1221") recovered.diagnostics);
+    (List.exists
+       (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1221")
+       recovered.diagnostics);
   let nested = "match x { | Bad -> match y { | Inner -> 1 | Later -> 9 }" in
   Alcotest.(check bool)
     "unterminated nested match retains outer Later" true (later_arm_survives nested);
@@ -217,7 +219,7 @@ let test_missing_match_before_definition () =
   let recovered = Surface_parse.recover_string ~file:"recover-patterns.jac" source in
   Alcotest.(check (list string))
     "ordered diagnostics" [ "E1221" ]
-    (List.map (fun diagnostic -> diagnostic.Diag.code) recovered.diagnostics);
+    (List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) recovered.diagnostics);
   match recovered.items with
   | [
    { it = TopExpr { it = Match (_, clauses); _ }; _ };

--- a/test/test_surface_scaffold.ml
+++ b/test/test_surface_scaffold.ml
@@ -109,7 +109,7 @@ let test_holes_stop_at_strict_boundary () =
   in
   Alcotest.(check bool) "hole detected" true (Surface_ast.has_holes_top top);
   match Surface_parse.strict recovered with
-  | Error [ { Diag.code = "E1202"; _ } ] -> ()
+  | Error [ diagnostic ] when Diag.code diagnostic = Some "E1202" -> ()
   | _ -> Alcotest.fail "strict parsing must reject holes before lowering or hashing"
 
 let test_entry_point_contract () =

--- a/test/test_surface_sugar.ml
+++ b/test/test_surface_sugar.ml
@@ -159,17 +159,20 @@ let test_wildcard_spelling () =
 let diagnostic_codes source =
   match Surface_parse.parse_string ~file:"bad-ss12.jac" source with
   | Ok _ -> []
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let diagnostic_strings source =
   match Surface_parse.parse_string ~file:"bad-ss12.jac" source with
   | Ok _ -> []
   | Error diagnostics -> List.map Diag.to_string diagnostics
 
+let expected_diagnostic span code summary cause next_step =
+  Printf.sprintf "%s: error[%s]: %s\n  Cause: %s\n  Next step: %s" span code summary cause next_step
+
 let lowering_codes source =
   match Surface_lower.lower_tops (parse source) with
   | Ok _ -> []
-  | Error diagnostics -> List.map (fun diagnostic -> diagnostic.Diag.code) diagnostics
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
 
 let test_block_edges_and_diagnostics () =
   Alcotest.(check bool)
@@ -183,8 +186,9 @@ let test_block_edges_and_diagnostics () =
   Alcotest.(check (list string))
     "missing rec params text"
     [
-      "bad-ss12.jac:1:14-15: error[E1233]: `let rec` requires a lowercase name followed by a \
-       parameter list";
+      expected_diagnostic "bad-ss12.jac:1:14-15" "E1233" "A local recursive binding is malformed"
+        "`let rec` requires a lowercase name followed by a parameter list"
+        "Use a lowercase function name followed by its parameters.";
     ]
     (diagnostic_strings "{ let rec go = 1; go }");
   Alcotest.(check (list string))
@@ -323,7 +327,7 @@ let raw_error_code source =
   | Ok form -> (
       match Kernel.expr_of_form form with
       | Ok _ -> Alcotest.fail "invalid raw recursive let validated"
-      | Error [ diagnostic ] -> diagnostic.Diag.code
+      | Error [ diagnostic ] -> Diag.code_or_uncoded diagnostic
       | Error diagnostics -> fail_diags "raw rec validation" diagnostics)
 
 let test_raw_rec_validation_and_printer () =

--- a/test/test_surface_types.ml
+++ b/test/test_surface_types.ml
@@ -468,13 +468,17 @@ let test_malformed_rows_and_recovery () =
       let recovered = Surface_parse.recover_string ~file:"types.jac" source in
       Alcotest.(check bool)
         (label ^ " reports E1220") true
-        (List.exists (fun diagnostic -> diagnostic.Diag.code = "E1220") recovered.diagnostics))
+        (List.exists
+           (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1220")
+           recovered.diagnostics))
     cases;
   let legacy = "f : () ->{e} Text\nf = 0\n" in
   let legacy_recovered = Surface_parse.recover_string ~file:"types.jac" legacy in
   Alcotest.(check bool)
     "legacy tail-only row rejected" true
-    (List.exists (fun diagnostic -> diagnostic.Diag.code = "E1220") legacy_recovered.diagnostics);
+    (List.exists
+       (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1220")
+       legacy_recovered.diagnostics);
   Alcotest.(check string) "legacy tail-only exact recovery" legacy (print_recovered legacy);
   let recovered =
     Surface_parse.recover_string ~file:"types.jac" "broken : () ->{Net\nlater = 42\n"
@@ -482,8 +486,12 @@ let test_malformed_rows_and_recovery () =
   Alcotest.(check (list string))
     "missing brace diagnostic"
     [
-      "types.jac:2:1-6: error[E1220]: expected `}` before the next top-level item";
-      "types.jac:2:1-6: error[E1224]: signature for `broken` cannot attach to definition `later`";
+      "types.jac:2:1-6: error[E1220]: Surface syntax is invalid\n\
+      \  Cause: expected `}` before the next top-level item\n\
+      \  Next step: Correct the syntax at this location and parse the file again.";
+      "types.jac:2:1-6: error[E1224]: A signature is detached from its definition\n\
+      \  Cause: signature for `broken` cannot attach to definition `later`\n\
+      \  Next step: Place the matching definition immediately after its signature.";
     ]
     (List.map Diag.to_string recovered.diagnostics);
   match List.rev recovered.items with
@@ -515,7 +523,9 @@ let test_forall_newline_recovery_and_owners () =
       let recovered = Surface_parse.recover_string ~file:"types.jac" source in
       Alcotest.(check bool)
         (label ^ " rejected") true
-        (List.exists (fun diagnostic -> diagnostic.Diag.code = "E1220") recovered.diagnostics);
+        (List.exists
+           (fun diagnostic -> Diag.code_or_uncoded diagnostic = "E1220")
+           recovered.diagnostics);
       Alcotest.(check string) (label ^ " exact recovery") source (print_recovered source);
       match recovered.items with
       | { Surface_ast.it = Signature (_, annotation); _ } :: _ ->

--- a/test/test_warp.ml
+++ b/test/test_warp.ml
@@ -290,7 +290,7 @@ let test_schedule_seed_splitting_and_cache_identity () =
   | Error (Runtime_err.Scheduler_error message) ->
       Alcotest.(check bool)
         "wrong duplicate-label leaf strict replay is refused before execution" true
-        (String.starts_with ~prefix:"schedule replay drift: program identity expected" message)
+        (String.starts_with ~prefix:"Schedule replay drift: program identity expected" message)
   | Error error ->
       Alcotest.failf "wrong-leaf replay returned the wrong error: %s" (Runtime_err.to_string error)
   | Ok _ -> Alcotest.fail "wrong duplicate-label leaf replay unexpectedly succeeded");
@@ -311,7 +311,7 @@ let test_schedule_seed_splitting_and_cache_identity () =
         "bound refusal reports seed and rerun without claiming a complete log"
         "random schedule 1 of 1 refused before a complete trace (decision seed 77)\n\
          replay: jacquard test bounds.jac --schedules 1 --seed 42 --no-cache\n\
-         runtime error: error[E0908]: decision bound exceeded"
+         runtime error: decision bound exceeded"
         hard
   | _ -> Alcotest.fail "bounded seeded schedule did not return the expected hard failure"
 


### PR DESCRIPTION
## Context

Jacquard's failures already carried stable codes in many subsystems, but their public shape was inconsistent. Some paths emitted a code and prose, others flattened one diagnostic into another, native failures used independent formatting, and automation had no versioned machine-readable contract. That made the same failure harder for a person to act on and harder for tooling to consume consistently across `check`, `run`, `build`, governance, store, Warp, and native binaries.

This PR makes diagnostics a production boundary. Every primary diagnostic identifies its domain, severity, summary, technical cause, and next step; spans and contrastive guidance are present where they add information. Text remains the human default, while `json-v1` gives agents and other tools an explicit schema. The change preserves the language, 27 kernel forms, HASH_V0, surface syntax, successful command output, and existing exit-code contract.

## What changed

- Made `Diag.t` abstract behind a documented interface and added validated constructors/accessors for domain, severity, span, stable code, summary, cause, next step, and optional contrastive guidance.
- Added one canonical text renderer and `jacquard-diagnostic-v1` JSON rendering. All leaf commands accept `--diagnostic-format=text|json-v1`; the option changes diagnostic encoding, not success output or exit status. JSON rendering preserves valid UTF-8 and replaces each malformed source, path, or host-message byte with U+FFFD so the wire format is always decodable.
- Enforced diagnostic invariants at construction time: only historical Runtime errors may omit a stable code, error/warning codes must agree with severity, required prose cannot be empty, and public spans use valid one-based lines/columns with nondecreasing exclusive ends.
- Normalized reader, resolver, checker, store, inference, Warp, governance, audit, scheduler, runtime, CLI-process, and native failures onto the shared contract, including an explicit E0003 process-boundary fallback.
- Preserved deliberate code-less Runtime errors instead of inventing release identities. Runtime warnings and informational diagnostics still require codes, and existing coded runtime and concurrency failures retain their assigned codes.
- Preserved typed inference diagnostics through the evaluator boundary, so program-reachable `dist.sample-lw` E0901/E0902 failures are primary Inference diagnostics and are byte-identical between interpreter and native execution. A thread-local native inference depth adds one E0902 cause layer per active inference driver, including ordinary failures and two- and three-level nested models.
- Reworked native C diagnostic helpers to produce the same multiline structure with dynamically sized formatting. Long user-controlled values are no longer silently truncated.
- Updated the native-eligibility refusal manifest to match the structured E0301 summary while preserving the same eight intentionally ineligible carriers.
- Defined nested causes as a compact human-facing projection. Machine consumers key primary identity by `(domain, code)`; nested child diagnostics are not a second JSON object.
- Added the diagnostic contract and catalog to `docs/errors.md`, regenerated the diagnostic golden corpus, and updated CLI/documentation fixtures to pin exact text, JSON shape, stream, ordering, and exit behavior.
- Added focused regressions for JSON governance output, strict UTF-8 JSON under malformed source bytes, process-level E0003 handling, secret redaction, multiline causes, span endpoint ordering, code-less Runtime severity restrictions, exact interpreter/native E0901/E0902 parity (including ordinary and two- and three-level nested model failures), and a 400-character unsupported native grant.
- Updated the top-level README's live evidence inventory from 738/43 to the current 742 compiled tests and 44 cram transcripts; historical release evidence counts remain unchanged.
- Updated the README, effect-review guide, and concurrency guide to show the structured Summary/Cause/Next-step output pinned by their live E0814 and E0907 transcripts; frozen historical evidence remains unchanged.

## Why it was done this way

The schema separates what happened from what to do next. A short summary is scannable, the cause keeps technical evidence, and the next step gives one concrete recovery action. Contrastive hints stay optional because they are useful only when a likely misconception is known.

`json-v1` is explicitly versioned so automation can depend on field meanings without scraping terminal prose. The text and JSON renderers consume the same abstract value, which prevents independent command paths from drifting. Domain remains part of machine identity because a few historical code numbers intentionally overlap across domains.

Diagnostic fields can include arbitrary bytes copied from damaged source, filesystem paths, or host errors. Sanitizing only the JSON projection preserves the original human diagnostic and D3's valid UTF-8 bytes without allowing malformed external bytes to corrupt the machine-readable stream.

Runtime errors cross several existing single-error channels, so a typed diagnostic can now travel through that channel without being flattened into an unrelated arithmetic/runtime wrapper. Native code uses the same semantic fields and exit rules rather than maintaining a looser parallel vocabulary.

This is a release-hardening change, not a language feature. Frozen surface-syntax evidence, kernel serialization, hashing, evaluation semantics, and successful CLI output are left alone.

## How it was checked

- `dune build @all` and `dune build @doc` passed.
- Forced full `dune runtest` passed: all 742 compiled/property tests and all 44 CLI transcript files.
- All 27 documentation examples across 8 documents passed.
- `runtime/check.sh` passed, including ASAN/native memory checks and fatal-diagnostic parity.
- The native differential harness passed with 69 identical programs and 8 manifested refusals.
- The complete `scripts/release/reproduce-0.1.sh` workflow passed on exact commit `070347ec727869fb7afed8196cf74fc5831d6442`, including build/test reproduction, runtime memory checks, native differential/leak/fuzz checks (1,000 fuzz cases), installer smoke, release demos, CLI/gauntlet coverage, and formatting.
- `dune fmt` and the repository whitespace policy passed.
- Native/interpreter stderr and exit status are compared exactly for E0901, unhandled-operation E0902, ordinary runtime E0902, and nested E0901-to-E0902 failures through three active inference drivers.
- The repair, manifest, and round-robin transcripts pin the same E0814/E0907 structures shown in the live README, effect-review, and concurrency documentation.
- The long native grant regression confirms all 400 user-controlled characters survive formatting.
- The immutable surface-syntax manifest remains byte-identical to main (`c8c245de2c999c805a3902089d9f2c23f698931a451b93e354514811cc069515`).
- Independent GPT-5.6 Sol xhigh review cycles found and drove fixes for typed inference parity, native fixed-buffer truncation, nested inference depth, code-less severity restrictions, malformed UTF-8 JSON, and the live README evidence count. A fresh review of exact commit `070347ec727869fb7afed8196cf74fc5831d6442` found no blockers and judged it PR-ready.
