### PR TITLE
runtime: add internal host readiness lifecycle seam

### DIFF
--- a/src/host_readiness.ml
+++ b/src/host_readiness.ml
@@ -1,0 +1,206 @@
+type registration = { id : int; task : Concurrency_contract.task_id }
+
+type entry = {
+  registration : registration;
+  handle : Scheduler_core.handle;
+  descriptor : Unix.file_descr;
+}
+
+type descriptor_ops = {
+  duplicate : Unix.file_descr -> Unix.file_descr;
+  close : Unix.file_descr -> unit;
+  poll_readable : Unix.file_descr list -> Unix.file_descr list;
+}
+
+type ('resume, 'value) t = {
+  scheduler : ('resume, 'value) Scheduler_core.t;
+  descriptor_ops : descriptor_ops;
+  mutable next_id : int;
+  mutable entries : entry list;
+  mutable closed : bool;
+}
+
+type wake_result = { awakened : Scheduler_core.handle list; cleanup_diagnostics : Diag.t list }
+
+type poll_result = {
+  awakened : Scheduler_core.handle list;
+  decisions : registration list;
+  cleanup_diagnostics : Diag.t list;
+}
+
+let diagnostic cause =
+  Diag.error ~domain:Concurrency ~code:"E0908"
+    ~summary:"The internal host-readiness lifecycle is invalid." ~cause
+    ~next_step:"Discard the stale readiness decision and recreate the structured scheduler scope."
+    ~contrast:None ()
+
+let error cause = Error [ diagnostic cause ]
+
+let unix_descriptor_ops =
+  {
+    duplicate = (fun descriptor -> Unix.dup ~cloexec:true descriptor);
+    close = Unix.close;
+    poll_readable =
+      (fun descriptors ->
+        let readable, _, _ = Unix.select descriptors [] [] 0.0 in
+        readable);
+  }
+
+let create ?(descriptor_ops = unix_descriptor_ops) scheduler =
+  { scheduler; descriptor_ops; next_id = 0; entries = []; closed = false }
+
+let registration_count registry = List.length registry.entries
+
+let close_descriptor registry descriptor =
+  match registry.descriptor_ops.close descriptor with
+  | () -> Ok ()
+  | exception Unix.Unix_error _ ->
+      error "A host-readiness descriptor could not be released; ownership was still retired."
+
+let retire registry entry =
+  registry.entries <-
+    List.filter (fun current -> current.registration.id <> entry.registration.id) registry.entries;
+  close_descriptor registry entry.descriptor
+
+let retire_matching registry predicate =
+  let retiring, retained = List.partition predicate registry.entries in
+  registry.entries <- retained;
+  List.fold_left
+    (fun result entry ->
+      match (result, close_descriptor registry entry.descriptor) with
+      | Error diagnostics, _ -> Error diagnostics
+      | Ok (), Ok () -> Ok ()
+      | Ok (), Error diagnostics -> Error diagnostics)
+    (Ok ()) retiring
+
+let next_registration registry task =
+  if registry.next_id = max_int then error "Host-readiness registration identities are exhausted."
+  else Ok { id = registry.next_id; task }
+
+let register registry ~task ~descriptor ~resume =
+  if registry.closed then error "A closed host-readiness registry cannot accept registrations."
+  else
+    Result.bind (Scheduler_core.id registry.scheduler task) (fun task_id ->
+        Result.bind (next_registration registry task_id) (fun registration ->
+            Result.bind
+              (Scheduler_core.prepare_host_suspend Task_capability.runtime registry.scheduler task
+                 ~registration:registration.id ~resume) (fun prepared ->
+                match registry.descriptor_ops.duplicate descriptor with
+                | duplicate ->
+                    Scheduler_core.commit_host_suspend Task_capability.runtime prepared;
+                    registry.next_id <- registry.next_id + 1;
+                    registry.entries <-
+                      registry.entries @ [ { registration; handle = task; descriptor = duplicate } ];
+                    Ok registration
+                | exception Unix.Unix_error _ ->
+                    error "The supplied host-readiness descriptor could not be duplicated.")))
+
+let find_exact registry registration =
+  List.find_opt
+    (fun entry ->
+      entry.registration.id = registration.id
+      && Concurrency_contract.compare_task_id entry.registration.task registration.task = 0)
+    registry.entries
+
+let wake registry entry =
+  Result.bind
+    (Scheduler_core.wake_host_readiness Task_capability.runtime registry.scheduler entry.handle
+       ~registration:entry.registration.id) (fun () ->
+      let cleanup_diagnostics =
+        match retire registry entry with Ok () -> [] | Error diagnostics -> diagnostics
+      in
+      Ok (entry.handle, cleanup_diagnostics))
+
+let reconcile registry =
+  let no_longer_owned entry =
+    match Scheduler_core.inspect registry.scheduler entry.handle with
+    | Ok
+        {
+          Scheduler_core.lifecycle = Concurrency_contract.Suspended;
+          suspension = Some (Scheduler_core.Host_readiness registration);
+          owns_resume = true;
+          _;
+        } ->
+        registration <> entry.registration.id
+    | Ok _ -> true
+    | Error _ -> true
+  in
+  retire_matching registry no_longer_owned
+
+let poll_live registry =
+  if registry.closed then error "A closed host-readiness registry cannot be polled."
+  else
+    Result.bind (reconcile registry) (fun () ->
+        let descriptors = List.map (fun entry -> entry.descriptor) registry.entries in
+        match registry.descriptor_ops.poll_readable descriptors with
+        | readable ->
+            let is_readable descriptor = List.exists (( = ) descriptor) readable in
+            let ready = List.filter (fun entry -> is_readable entry.descriptor) registry.entries in
+            let rec wake_all awakened decisions cleanup_diagnostics = function
+              | [] ->
+                  Ok
+                    {
+                      awakened = List.rev awakened;
+                      decisions = List.rev decisions;
+                      cleanup_diagnostics = List.rev cleanup_diagnostics;
+                    }
+              | entry :: rest ->
+                  Result.bind (wake registry entry) (fun (handle, cleanup) ->
+                      wake_all (handle :: awakened) (entry.registration :: decisions)
+                        (List.rev_append cleanup cleanup_diagnostics)
+                        rest)
+            in
+            wake_all [] [] [] ready
+        | exception Unix.Unix_error _ -> error "Live host-readiness polling failed.")
+
+let replay registry ~registrations =
+  if registry.closed then error "A closed host-readiness registry cannot replay decisions."
+  else
+    Result.bind (reconcile registry) (fun () ->
+        let rec consume awakened cleanup_diagnostics = function
+          | [] ->
+              Ok
+                { awakened = List.rev awakened; cleanup_diagnostics = List.rev cleanup_diagnostics }
+          | registration :: rest -> (
+              match find_exact registry registration with
+              | None -> error "A replayed host-readiness decision is stale or duplicate."
+              | Some entry ->
+                  Result.bind (wake registry entry) (fun (handle, cleanup) ->
+                      consume (handle :: awakened)
+                        (List.rev_append cleanup cleanup_diagnostics)
+                        rest))
+        in
+        consume [] [] registrations)
+
+let drop_all drop resumes =
+  let first_exception = ref None in
+  List.iter
+    (fun resume ->
+      match drop resume with
+      | () -> ()
+      | exception exn -> if Option.is_none !first_exception then first_exception := Some exn)
+    resumes;
+  Option.iter raise !first_exception
+
+let cancel registry task ~drop =
+  if registry.closed then error "A closed host-readiness registry cannot cancel tasks."
+  else
+    Result.bind (Scheduler_core.request_cancel registry.scheduler task) (fun () ->
+        Result.bind
+          (Scheduler_core.deliver_cancel registry.scheduler
+             ~point:Concurrency_contract.Routed_effect task) (fun (awakened, resumes) ->
+            let release = retire_matching registry (fun entry -> entry.handle == task) in
+            drop_all drop resumes;
+            let cleanup_diagnostics =
+              match release with Ok () -> [] | Error diagnostics -> diagnostics
+            in
+            Ok { awakened; cleanup_diagnostics }))
+
+let shutdown registry ~drop =
+  if registry.closed then Ok ()
+  else (
+    registry.closed <- true;
+    let release = retire_matching registry (fun _ -> true) in
+    let resumes = Scheduler_core.close registry.scheduler in
+    drop_all drop resumes;
+    release)

--- a/src/host_readiness.mli
+++ b/src/host_readiness.mli
@@ -1,0 +1,101 @@
+(** Internal C4-preparatory host-readiness lifecycle seam.
+
+    This module is deliberately not a Jacquard effect handler, CLI surface, scheduler policy, or
+    portability promise. It owns duplicated Unix descriptors only while a task is suspended, and
+    uses the existing runtime capability and scheduler task identity. Callers retain ownership of
+    the descriptor supplied to {!register}; the duplicated registration descriptor is released
+    exactly once on wake, cancellation, or {!shutdown}. This is an OCaml runtime-preparatory API,
+    not a Jacquard language or CLI interface. It is currently exported by the wrapped library for
+    focused lifecycle tests; that export is not a supported host-I/O product contract. It installs
+    no language effect and cannot add, remove, or launder a Jacquard capability row. A future
+    handler must still bind this lifecycle to {!Structured_scope}, charge every child world effect
+    to its parent row, and define its public platform and trace contracts. *)
+
+type registration = { id : int; task : Concurrency_contract.task_id }
+(** A deterministic readiness decision. [id] is local to one registry and [task] is the existing
+    scheduler identity. It is a replay token, not an unforgeable capability: an equivalent fresh
+    scheduler run deliberately accepts the same task identity and local registration ordinal. *)
+
+type ('resume, 'value) t
+(** A registry owned by exactly one scheduler core. *)
+
+type wake_result = { awakened : Scheduler_core.handle list; cleanup_diagnostics : Diag.t list }
+(** A completed scheduler handoff. [cleanup_diagnostics] reports descriptor-retirement failures
+    without hiding tasks that already became runnable. Callers must enqueue every [awakened] handle
+    before surfacing those diagnostics. *)
+
+type poll_result = {
+  awakened : Scheduler_core.handle list;
+  decisions : registration list;
+  cleanup_diagnostics : Diag.t list;
+}
+(** The ordered result of one non-blocking live poll. Decisions are in registration order, never
+    host select-set order. Cleanup diagnostics never suppress already-completed wakeups. *)
+
+type descriptor_ops = {
+  duplicate : Unix.file_descr -> Unix.file_descr;
+  close : Unix.file_descr -> unit;
+  poll_readable : Unix.file_descr list -> Unix.file_descr list;
+}
+(** Injectable descriptor boundary for hermetic lifecycle tests. Production {!create} uses
+    close-on-exec duplication, [Unix.close], and one zero-time [Unix.select] read poll. *)
+
+val create :
+  ?descriptor_ops:descriptor_ops -> ('resume, 'value) Scheduler_core.t -> ('resume, 'value) t
+(** [create scheduler] transfers responsibility for closing [scheduler] to a new empty opt-in
+    registry. The caller must route readiness cancellation through the registry and must not close
+    or mutate the scheduler behind it. Creation does not change scheduler policy or inspect
+    descriptors. [descriptor_ops] exists only to prove descriptor ownership and replay isolation;
+    callers constructing production registries should omit it. *)
+
+val register :
+  ('resume, 'value) t ->
+  task:Scheduler_core.handle ->
+  descriptor:Unix.file_descr ->
+  resume:'resume ->
+  (registration, Diag.t list) result
+(** [register registry ~task ~descriptor ~resume] duplicates [descriptor], transfers [resume] from
+    its checked-out task into an internal readiness suspension, and returns the recorded decision.
+    Duplication or lifecycle refusal returns E0908 without suspending the task or taking ownership
+    of the caller's descriptor. A task can hold at most one registration because it is suspended. *)
+
+val poll_live : ('resume, 'value) t -> (poll_result, Diag.t list) result
+(** [poll_live registry] performs one non-blocking Unix read-readiness poll and wakes the matching
+    suspended tasks in registration order. It is the only operation in this module that polls host
+    descriptors. Closed registries return E0908. *)
+
+val replay :
+  ('resume, 'value) t -> registrations:registration list -> (wake_result, Diag.t list) result
+(** [replay registry ~registrations] strictly consumes the supplied recorded decisions in order and
+    wakes only their exact suspended tasks. It never polls, reads, or writes live descriptors;
+    retirement may close the registry-owned duplicate as required by the lifecycle contract. Stale
+    or duplicate decisions return E0908. Equivalent fresh scheduler runs may replay the same task
+    identity and ordinal; callers must authenticate trace provenance outside this internal seam.
+    Descriptor-retirement failures are returned in [cleanup_diagnostics] so they cannot discard
+    handles whose scheduler transition already completed. *)
+
+val cancel :
+  ('resume, 'value) t ->
+  Scheduler_core.handle ->
+  drop:('resume -> unit) ->
+  (wake_result, Diag.t list) result
+(** [cancel registry task ~drop] requests and delivers routed-effect cancellation for [task]. A
+    matching registration is deregistered and its duplicate closed before [drop] receives the task's
+    transferred resume. Repeated cancellation is idempotent and never closes twice. With active
+    registrations this is the required cancellation path: direct [Scheduler_core] cancellation is
+    unsupported because it bypasses descriptor teardown. Descriptor-retirement failures are returned
+    alongside, rather than instead of, already-awakened handles. *)
+
+val reconcile : ('resume, 'value) t -> (unit, Diag.t list) result
+(** [reconcile registry] defensively retires registrations whose tasks no longer have their exact
+    readiness suspension because of an unsupported direct scheduler transition. It never polls.
+    Direct callers remain responsible for dropping any resume transferred by that lower-level
+    transition. *)
+
+val shutdown : ('resume, 'value) t -> drop:('resume -> unit) -> (unit, Diag.t list) result
+(** [shutdown registry ~drop] releases every remaining duplicated descriptor and closes the owned
+    scheduler core, transferring each remaining resume once to [drop]. Repeated shutdown is a no-op.
+    Cleanup continues after a descriptor-close failure and reports E0908 deterministically. *)
+
+val registration_count : ('resume, 'value) t -> int
+(** [registration_count] returns the number of currently owned duplicated descriptors. *)

--- a/src/scheduler_core.ml
+++ b/src/scheduler_core.ml
@@ -5,6 +5,7 @@ type suspension =
   | Awaiting of Concurrency_contract.task_id
   | Channel_sending of Channel_contract.channel_id
   | Channel_receiving of Channel_contract.channel_id
+  | Host_readiness of int
 
 type ('resume, 'value) entry = {
   handle : handle;
@@ -56,6 +57,13 @@ type ('resume, 'value) prepared_channel_wake = {
   wake_entry : ('resume, 'value) entry;
   wake_resume : 'resume;
   mutable wake_committed : bool;
+}
+
+type ('resume, 'value) prepared_host_suspend = {
+  host_suspend_entry : ('resume, 'value) entry;
+  host_suspend_registration : int;
+  host_suspend_resume : 'resume;
+  mutable host_suspend_committed : bool;
 }
 
 let diagnostic message =
@@ -303,6 +311,38 @@ let commit_channel_wake _capability prepared =
   prepared.wake_entry.lifecycle <- Concurrency_contract.Runnable;
   prepared.wake_entry.suspension <- None
 
+let prepare_host_suspend _capability scheduler handle ~registration ~resume =
+  if registration < 0 then error "host readiness registration must be non-negative"
+  else
+    Result.bind (validate scheduler handle) (fun (entry : (_, _) entry) ->
+        Result.map
+          (fun () ->
+            {
+              host_suspend_entry = entry;
+              host_suspend_registration = registration;
+              host_suspend_resume = resume;
+              host_suspend_committed = false;
+            })
+          (ensure_checked_out entry))
+
+let commit_host_suspend _capability prepared =
+  if prepared.host_suspend_committed then
+    failwith "Bug_scheduler_core: prepared host readiness suspension committed twice";
+  prepared.host_suspend_committed <- true;
+  prepared.host_suspend_entry.resume <- Some prepared.host_suspend_resume;
+  prepared.host_suspend_entry.lifecycle <- Concurrency_contract.Suspended;
+  prepared.host_suspend_entry.suspension <- Some (Host_readiness prepared.host_suspend_registration)
+
+let wake_host_readiness _capability scheduler handle ~registration =
+  Result.bind (validate scheduler handle) (fun (entry : (_, _) entry) ->
+      match (entry.lifecycle, entry.suspension, entry.resume) with
+      | Concurrency_contract.Suspended, Some (Host_readiness waiting), Some _
+        when waiting = registration ->
+          entry.lifecycle <- Concurrency_contract.Runnable;
+          entry.suspension <- None;
+          Ok ()
+      | _ -> error "only a task suspended on the exact host readiness registration can be woken")
+
 let wake_channel_with scheduler handle ~channel ~map_resume =
   Result.map
     (fun prepared -> commit_channel_wake Task_capability.runtime prepared)
@@ -330,7 +370,8 @@ let wake_waiters scheduler (entry : (_, _) entry) =
              &&
              match waiter.suspension with
              | Some (Awaiting target) -> equal_id target entry.id
-             | Some (Yielded | Channel_sending _ | Channel_receiving _) | None -> false ->
+             | Some (Yielded | Channel_sending _ | Channel_receiving _ | Host_readiness _) | None ->
+                 false ->
           waiter.lifecycle <- Concurrency_contract.Runnable;
           waiter.suspension <- None;
           Some waiter.handle

--- a/src/scheduler_core.mli
+++ b/src/scheduler_core.mli
@@ -12,7 +12,7 @@ type suspension =
   | Awaiting of Concurrency_contract.task_id
   | Channel_sending of Channel_contract.channel_id
   | Channel_receiving of Channel_contract.channel_id
-      (** Why a task is suspended. A task has at most one live await edge. *)
+  | Host_readiness of int  (** Why a task is suspended. A task has at most one live await edge. *)
 
 type ('resume, 'value) t
 (** Scheduler state for one structured scope. Resume tokens and task values remain opaque to the
@@ -23,6 +23,10 @@ type ('resume, 'value) prepared_channel_suspend
 
 type ('resume, 'value) prepared_channel_wake
 (** Runtime-private proof containing a successfully mapped resume for one exact channel waiter. *)
+
+type ('resume, 'value) prepared_host_suspend
+(** Runtime-private proof that a checked-out task can be suspended on one internal readiness
+    registration. *)
 
 type 'value task_view = {
   id : Concurrency_contract.task_id;
@@ -155,6 +159,29 @@ val prepare_channel_wake :
 
 val commit_channel_wake : Task_capability.t -> ('resume, 'value) prepared_channel_wake -> unit
 (** [commit_channel_wake] makes one previously prepared waiter runnable without further failure. *)
+
+val prepare_host_suspend :
+  Task_capability.t ->
+  ('resume, 'value) t ->
+  handle ->
+  registration:int ->
+  resume:'resume ->
+  (('resume, 'value) prepared_host_suspend, Diag.t list) result
+(** [prepare_host_suspend] validates a runtime-private host-readiness suspension without changing
+    task state. Negative registration identities and invalid lifecycle state return E0908. *)
+
+val commit_host_suspend : Task_capability.t -> ('resume, 'value) prepared_host_suspend -> unit
+(** [commit_host_suspend] applies one prepared host-readiness suspension. Calling it twice is an
+    internal invariant failure. *)
+
+val wake_host_readiness :
+  Task_capability.t ->
+  ('resume, 'value) t ->
+  handle ->
+  registration:int ->
+  (unit, Diag.t list) result
+(** [wake_host_readiness] makes exactly the task suspended on [registration] runnable. A stale,
+    cancelled, or mismatched registration returns E0908 without changing task state. *)
 
 val suspend_channel :
   ('resume, 'value) t ->

--- a/src/scope_policy.ml
+++ b/src/scope_policy.ml
@@ -77,7 +77,8 @@ let find_child controller id =
 let cancellation_point = function
   | Scheduler_core.Yielded -> Concurrency_contract.Yield
   | Scheduler_core.Awaiting _ -> Concurrency_contract.Await
-  | Scheduler_core.Channel_sending _ | Scheduler_core.Channel_receiving _ ->
+  | Scheduler_core.Channel_sending _ | Scheduler_core.Channel_receiving _
+  | Scheduler_core.Host_readiness _ ->
       Concurrency_contract.Routed_effect
 
 let cancel_unfinished controller ~drop =

--- a/src/structured_scope.ml
+++ b/src/structured_scope.ml
@@ -396,7 +396,8 @@ let cancel scope ~caller ~target ~resume ~drop =
                       match suspension with
                       | Scheduler_core.Yielded -> Concurrency_contract.Yield
                       | Scheduler_core.Awaiting _ -> Concurrency_contract.Await
-                      | Scheduler_core.Channel_sending _ | Scheduler_core.Channel_receiving _ ->
+                      | Scheduler_core.Channel_sending _ | Scheduler_core.Channel_receiving _
+                      | Scheduler_core.Host_readiness _ ->
                           Concurrency_contract.Routed_effect
                     in
                     Result.map
@@ -521,7 +522,11 @@ let channel_deadlocked scope =
                 match view.suspension with
                 | Some (Scheduler_core.Channel_sending _ | Scheduler_core.Channel_receiving _) ->
                     true
-                | Some (Scheduler_core.Yielded | Scheduler_core.Awaiting _) | None -> false
+                | Some
+                    ( Scheduler_core.Yielded | Scheduler_core.Awaiting _
+                    | Scheduler_core.Host_readiness _ )
+                | None ->
+                    false
               in
               (all_suspended && suspended, has_channel || channel_wait, live_count + 1))
         (all_suspended, has_channel, live_count)

--- a/test/test_host_readiness.ml
+++ b/test/test_host_readiness.ml
@@ -1,0 +1,374 @@
+open Jacquard
+
+let ok = function
+  | Ok value -> value
+  | Error diagnostics ->
+      Alcotest.failf "unexpected host-readiness diagnostic: %s"
+        (String.concat "\n" (List.map Diag.to_string diagnostics))
+
+let error_code = function
+  | Error (diagnostic :: _) -> Diag.code_or_uncoded diagnostic
+  | Error [] -> Alcotest.fail "host-readiness returned an empty diagnostic list"
+  | Ok _ -> Alcotest.fail "host-readiness operation unexpectedly succeeded"
+
+let view scheduler task = Scheduler_core.inspect scheduler task |> ok
+
+let test_live_pipe_wakeup_and_recording () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:17 |> ok in
+  let registry = Host_readiness.create scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  let registration = Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok in
+  Alcotest.(check int)
+    "one duplicated descriptor is owned" 1
+    (Host_readiness.registration_count registry);
+  Alcotest.(check bool)
+    "task suspended on host readiness" true
+    ((view scheduler task).suspension = Some (Scheduler_core.Host_readiness registration.id));
+  ignore (Unix.write_substring writer "x" 0 1);
+  let poll = Host_readiness.poll_live registry |> ok in
+  Alcotest.(check int) "one readiness decision" 1 (List.length poll.decisions);
+  Alcotest.(check bool)
+    "recorded decision retains task identity" true
+    (poll.decisions = [ registration ]);
+  Alcotest.(check int) "wake returns task" 1 (List.length poll.awakened);
+  Alcotest.(check int)
+    "readiness descriptor retires after wake" 0
+    (Host_readiness.registration_count registry);
+  Alcotest.(check bool)
+    "task became runnable" true
+    ((view scheduler task).lifecycle = Concurrency_contract.Runnable);
+  Alcotest.(check int) "resume token is unchanged" 17 (Scheduler_core.checkout scheduler task |> ok);
+  ignore (Scheduler_core.complete scheduler task () |> ok);
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let counting_ops closed poll_count =
+  {
+    Host_readiness.duplicate = (fun descriptor -> Unix.dup ~cloexec:true descriptor);
+    close =
+      (fun descriptor ->
+        incr closed;
+        Unix.close descriptor);
+    poll_readable =
+      (fun descriptors ->
+        incr poll_count;
+        let readable, _, _ = Unix.select descriptors [] [] 0.0 in
+        readable);
+  }
+
+let test_cancellation_and_shutdown_release_once () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:21 |> ok in
+  let closed = ref 0 in
+  let poll_count = ref 0 in
+  let registry = Host_readiness.create ~descriptor_ops:(counting_ops closed poll_count) scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  ignore (Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok);
+  let dropped = ref [] in
+  Host_readiness.cancel registry task ~drop:(fun value -> dropped := value :: !dropped)
+  |> ok |> ignore;
+  Alcotest.(check (list int)) "cancellation drops the suspended resume once" [ 21 ] !dropped;
+  Alcotest.(check int)
+    "cancellation retires descriptor" 0
+    (Host_readiness.registration_count registry);
+  Alcotest.(check int) "cancellation closes its owned duplicate exactly once" 1 !closed;
+  Host_readiness.cancel registry task ~drop:(fun value -> dropped := value :: !dropped)
+  |> ok |> ignore;
+  Alcotest.(check (list int)) "repeated cancellation does not drop twice" [ 21 ] !dropped;
+  let survivor = Scheduler_core.spawn scheduler ~resume:22 |> ok in
+  let survivor_resume = Scheduler_core.checkout scheduler survivor |> ok in
+  ignore
+    (Host_readiness.register registry ~task:survivor ~descriptor:reader ~resume:survivor_resume
+    |> ok);
+  Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped) |> ok;
+  Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped) |> ok;
+  Alcotest.(check (list int)) "shutdown drops its suspended resume once" [ 22; 21 ] !dropped;
+  Alcotest.(check int) "shutdown closes its owned duplicate exactly once" 2 !closed;
+  Unix.close reader;
+  Unix.close writer
+
+let test_strict_replay_never_needs_live_readiness () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:34 |> ok in
+  let closed = ref 0 in
+  let poll_count = ref 0 in
+  let registry = Host_readiness.create ~descriptor_ops:(counting_ops closed poll_count) scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  let registration = Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok in
+  (* The injected poller increments a counter. Replay must not invoke it, whether or not the pipe
+     is ready. *)
+  let replay = Host_readiness.replay registry ~registrations:[ registration ] |> ok in
+  Alcotest.(check int) "replay wakes recorded task" 1 (List.length replay.awakened);
+  Alcotest.(check int)
+    "successful replay has no cleanup diagnostic" 0
+    (List.length replay.cleanup_diagnostics);
+  Alcotest.(check int) "replay retired descriptor" 0 (Host_readiness.registration_count registry);
+  Alcotest.(check int) "replay closed its duplicate" 1 !closed;
+  Alcotest.(check int) "replay never polled live descriptors" 0 !poll_count;
+  Alcotest.(check int) "replay preserves resume" 34 (Scheduler_core.checkout scheduler task |> ok);
+  Alcotest.(check string)
+    "duplicate replay is refused deterministically" "E0908"
+    (Host_readiness.replay registry ~registrations:[ registration ] |> error_code);
+  ignore (Scheduler_core.complete scheduler task () |> ok);
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let test_equivalent_fresh_run_replays_recorded_identity () =
+  let old_reader, old_writer = Unix.pipe () in
+  let old_scheduler, old_task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:1 |> ok in
+  let old_registry = Host_readiness.create old_scheduler in
+  let old_resume = Scheduler_core.checkout old_scheduler old_task |> ok in
+  let recorded =
+    Host_readiness.register old_registry ~task:old_task ~descriptor:old_reader ~resume:old_resume
+    |> ok
+  in
+  Host_readiness.shutdown old_registry ~drop:ignore |> ok;
+  Unix.close old_reader;
+  Unix.close old_writer;
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:2 |> ok in
+  let closed = ref 0 in
+  let poll_count = ref 0 in
+  let registry = Host_readiness.create ~descriptor_ops:(counting_ops closed poll_count) scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  ignore (Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok);
+  Host_readiness.replay registry ~registrations:[ recorded ] |> ok |> ignore;
+  Alcotest.(check int) "equivalent replay never polled" 0 !poll_count;
+  Alcotest.(check int) "equivalent replay closes owned duplicate" 1 !closed;
+  ignore (Scheduler_core.checkout scheduler task |> ok);
+  ignore (Scheduler_core.complete scheduler task () |> ok);
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let close_once_failure_ops close_count poll_count =
+  {
+    Host_readiness.duplicate = (fun descriptor -> Unix.dup ~cloexec:true descriptor);
+    close =
+      (fun descriptor ->
+        incr close_count;
+        Unix.close descriptor;
+        if !close_count = 1 then raise (Unix.Unix_error (Unix.EIO, "close", "injected")));
+    poll_readable =
+      (fun descriptors ->
+        incr poll_count;
+        descriptors);
+  }
+
+let check_cleanup_error label diagnostics =
+  Alcotest.(check (list string)) label [ "E0908" ] (List.map Diag.code_or_uncoded diagnostics)
+
+let test_poll_close_failure_preserves_all_wakeups () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, root = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:300 |> ok in
+  let child = Scheduler_core.spawn scheduler ~resume:301 |> ok in
+  let close_count = ref 0 in
+  let poll_count = ref 0 in
+  let registry =
+    Host_readiness.create ~descriptor_ops:(close_once_failure_ops close_count poll_count) scheduler
+  in
+  let root_resume = Scheduler_core.checkout scheduler root |> ok in
+  ignore (Host_readiness.register registry ~task:root ~descriptor:reader ~resume:root_resume |> ok);
+  let child_resume = Scheduler_core.checkout scheduler child |> ok in
+  ignore (Host_readiness.register registry ~task:child ~descriptor:reader ~resume:child_resume |> ok);
+  let poll = Host_readiness.poll_live registry |> ok in
+  Alcotest.(check int) "poll returns every completed wakeup" 2 (List.length poll.awakened);
+  Alcotest.(check int) "poll records every completed decision" 2 (List.length poll.decisions);
+  check_cleanup_error "poll carries close failure beside wakeups" poll.cleanup_diagnostics;
+  Alcotest.(check int) "poll continues closing later descriptors" 2 !close_count;
+  Alcotest.(check int) "poll executes one readiness query" 1 !poll_count;
+  Alcotest.(check int)
+    "poll retires every registration despite close failure" 0
+    (Host_readiness.registration_count registry);
+  Alcotest.(check bool)
+    "root remains available to the caller's runnable queue" true
+    ((view scheduler root).lifecycle = Concurrency_contract.Runnable);
+  Alcotest.(check bool)
+    "child remains available to the caller's runnable queue" true
+    ((view scheduler child).lifecycle = Concurrency_contract.Runnable);
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let test_replay_close_failure_preserves_wakeup_without_polling () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:310 |> ok in
+  let close_count = ref 0 in
+  let poll_count = ref 0 in
+  let registry =
+    Host_readiness.create ~descriptor_ops:(close_once_failure_ops close_count poll_count) scheduler
+  in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  let registration = Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok in
+  let replay = Host_readiness.replay registry ~registrations:[ registration ] |> ok in
+  Alcotest.(check int) "replay returns completed wakeup" 1 (List.length replay.awakened);
+  check_cleanup_error "replay carries close failure beside wakeup" replay.cleanup_diagnostics;
+  Alcotest.(check int) "replay attempts descriptor close once" 1 !close_count;
+  Alcotest.(check int) "replay still performs no readiness query" 0 !poll_count;
+  Alcotest.(check bool)
+    "replayed task remains available to caller" true
+    ((view scheduler task).lifecycle = Concurrency_contract.Runnable);
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let test_cancel_close_failure_preserves_wakeups () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:320 |> ok in
+  let waiter = Scheduler_core.spawn scheduler ~resume:321 |> ok in
+  let close_count = ref 0 in
+  let poll_count = ref 0 in
+  let registry =
+    Host_readiness.create ~descriptor_ops:(close_once_failure_ops close_count poll_count) scheduler
+  in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  ignore (Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok);
+  let waiter_resume = Scheduler_core.checkout scheduler waiter |> ok in
+  ignore (Scheduler_core.await scheduler ~waiter ~target:task ~resume:waiter_resume |> ok);
+  let dropped = ref [] in
+  let cancellation =
+    Host_readiness.cancel registry task ~drop:(fun value -> dropped := value :: !dropped) |> ok
+  in
+  check_cleanup_error "cancel carries close failure beside wakeups" cancellation.cleanup_diagnostics;
+  Alcotest.(check int)
+    "cancel returns waiter awakened by terminal transition" 1
+    (List.length cancellation.awakened);
+  Alcotest.(check bool)
+    "cancelled task's waiter remains available to caller" true
+    ((view scheduler waiter).lifecycle = Concurrency_contract.Runnable);
+  Alcotest.(check (list int)) "cancel still transfers resume exactly once" [ 320 ] !dropped;
+  Alcotest.(check int) "cancel attempts descriptor close once" 1 !close_count;
+  Alcotest.(check int) "cancel never polls" 0 !poll_count;
+  Alcotest.(check int)
+    "cancel retires registration despite close failure" 0
+    (Host_readiness.registration_count registry);
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let test_reconcile_defensively_retires_direct_cancellation () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:89 |> ok in
+  let closed = ref 0 in
+  let poll_count = ref 0 in
+  let registry = Host_readiness.create ~descriptor_ops:(counting_ops closed poll_count) scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  ignore (Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok);
+  Scheduler_core.request_cancel scheduler task |> ok;
+  let _, transferred =
+    Scheduler_core.deliver_cancel scheduler ~point:Concurrency_contract.Routed_effect task |> ok
+  in
+  Alcotest.(check (list int))
+    "direct core cancellation transfers resume to its caller" [ 89 ] transferred;
+  Host_readiness.reconcile registry |> ok;
+  Alcotest.(check int)
+    "reconciliation retires stranded duplicate" 0
+    (Host_readiness.registration_count registry);
+  Alcotest.(check int) "reconciliation closes duplicate once" 1 !closed;
+  Alcotest.(check int) "reconciliation never polls" 0 !poll_count;
+  Host_readiness.shutdown registry ~drop:ignore |> ok;
+  Unix.close reader;
+  Unix.close writer
+
+let test_active_shutdown_releases_owned_state_once () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:144 |> ok in
+  let closed = ref 0 in
+  let poll_count = ref 0 in
+  let registry = Host_readiness.create ~descriptor_ops:(counting_ops closed poll_count) scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  ignore (Host_readiness.register registry ~task ~descriptor:reader ~resume |> ok);
+  let dropped = ref [] in
+  Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped) |> ok;
+  Alcotest.(check int) "active shutdown closes its duplicate once" 1 !closed;
+  Alcotest.(check (list int)) "active shutdown transfers its resume once" [ 144 ] !dropped;
+  Alcotest.(check int)
+    "active shutdown owns no registrations" 0
+    (Host_readiness.registration_count registry);
+  Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped) |> ok;
+  Alcotest.(check int) "repeated active shutdown does not close twice" 1 !closed;
+  Alcotest.(check (list int)) "repeated active shutdown does not drop twice" [ 144 ] !dropped;
+  Alcotest.(check int) "shutdown never polls" 0 !poll_count;
+  Unix.close reader;
+  Unix.close writer
+
+let test_shutdown_continues_after_close_failure () =
+  let reader, writer = Unix.pipe () in
+  let scheduler, root = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:233 |> ok in
+  let child = Scheduler_core.spawn scheduler ~resume:234 |> ok in
+  let close_count = ref 0 in
+  let descriptor_ops =
+    {
+      Host_readiness.duplicate = (fun descriptor -> Unix.dup ~cloexec:true descriptor);
+      close =
+        (fun descriptor ->
+          incr close_count;
+          Unix.close descriptor;
+          if !close_count = 1 then raise (Unix.Unix_error (Unix.EIO, "close", "injected")));
+      poll_readable =
+        (fun descriptors ->
+          let readable, _, _ = Unix.select descriptors [] [] 0.0 in
+          readable);
+    }
+  in
+  let registry = Host_readiness.create ~descriptor_ops scheduler in
+  let root_resume = Scheduler_core.checkout scheduler root |> ok in
+  ignore (Host_readiness.register registry ~task:root ~descriptor:reader ~resume:root_resume |> ok);
+  let child_resume = Scheduler_core.checkout scheduler child |> ok in
+  ignore (Host_readiness.register registry ~task:child ~descriptor:reader ~resume:child_resume |> ok);
+  let dropped = ref [] in
+  Alcotest.(check string)
+    "close failure maps to a structured diagnostic" "E0908"
+    (Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped)
+    |> error_code);
+  Alcotest.(check int) "shutdown attempted every descriptor close" 2 !close_count;
+  Alcotest.(check (list int))
+    "shutdown transferred every resume despite close failure" [ 233; 234 ]
+    (List.sort Int.compare !dropped);
+  Alcotest.(check int)
+    "failed close retired all registrations" 0
+    (Host_readiness.registration_count registry);
+  Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped) |> ok;
+  Alcotest.(check int) "repeated failed shutdown does not close twice" 2 !close_count;
+  Alcotest.(check (list int))
+    "repeated failed shutdown does not drop twice" [ 233; 234 ] (List.sort Int.compare !dropped);
+  Unix.close reader;
+  Unix.close writer
+
+let test_descriptor_refusal_preserves_checked_out_task () =
+  let reader, writer = Unix.pipe () in
+  Unix.close reader;
+  let scheduler, task = Scheduler_core.create ~scope_path:[ 0 ] ~body_resume:55 |> ok in
+  let registry = Host_readiness.create scheduler in
+  let resume = Scheduler_core.checkout scheduler task |> ok in
+  Alcotest.(check string)
+    "closed descriptor maps to structured diagnostic" "E0908"
+    (Host_readiness.register registry ~task ~descriptor:reader ~resume |> error_code);
+  Alcotest.(check int)
+    "failed registration owns no descriptor" 0
+    (Host_readiness.registration_count registry);
+  Alcotest.(check bool)
+    "failure left task runnable and checked out" true
+    ((view scheduler task).lifecycle = Concurrency_contract.Runnable
+    && not (view scheduler task).owns_resume);
+  Scheduler_core.suspend_yield scheduler task ~resume |> ok;
+  let dropped = ref [] in
+  Host_readiness.shutdown registry ~drop:(fun value -> dropped := value :: !dropped) |> ok;
+  Alcotest.(check (list int)) "shutdown transfers exactly the remaining resume" [ 55 ] !dropped;
+  Unix.close writer
+
+let run () =
+  test_live_pipe_wakeup_and_recording ();
+  test_cancellation_and_shutdown_release_once ();
+  test_strict_replay_never_needs_live_readiness ();
+  test_equivalent_fresh_run_replays_recorded_identity ();
+  test_poll_close_failure_preserves_all_wakeups ();
+  test_replay_close_failure_preserves_wakeup_without_polling ();
+  test_cancel_close_failure_preserves_wakeups ();
+  test_reconcile_defensively_retires_direct_cancellation ();
+  test_active_shutdown_releases_owned_state_once ();
+  test_shutdown_continues_after_close_failure ();
+  test_descriptor_refusal_preserves_checked_out_task ()

--- a/test/test_scheduler_core.ml
+++ b/test/test_scheduler_core.ml
@@ -394,6 +394,7 @@ let run () =
   test_foreign_handle_diagnostic ();
   QCheck.Test.check_exn prop_transition_table;
   QCheck.Test.check_exn prop_public_transitions_match_contract;
-  QCheck.Test.check_exn prop_cycle_wakeups_are_live
+  QCheck.Test.check_exn prop_cycle_wakeups_are_live;
+  Test_host_readiness.run ()
 
 let suite = [ Alcotest.test_case "lifecycle, waits, cycles, and ownership" `Quick run ]


### PR DESCRIPTION
## Context

Jacquard's released structured-concurrency evidence proves deterministic FIFO,
seeded, exhaustive, cached, and strict-replay scheduling through C3. It
deliberately does not claim real host asynchronous I/O. Before a future host
handler can safely suspend tasks on sockets or files, the runtime needs a
smaller invariant-bearing seam: the scheduler must retain the task's affine
resume, the host side must own and retire its descriptor, cancellation and
shutdown must release both exactly once, and replay must not consult live I/O.

Without that seam, a later host handler would have to invent resource ownership
and replay behavior at the same time as its public effect, CLI, platform, and
support contracts. That would make descriptor leaks, double cleanup, or hidden
host-timing dependencies much harder to isolate.

This PR adds only that internal lifecycle foundation. It does not add a
`run-host` command, a Jacquard effect or syntax, a public world-handler set,
native scheduling, or a C4/product-readiness claim. Deterministic round-robin
remains the default and existing schedule bytes are unchanged.

## What changed

- Added a capability-gated `Host_readiness` suspension to the
  policy-independent scheduler core, using the existing run-local `TaskId`.
- Added an opt-in runtime registry that:
  - duplicates caller-owned Unix descriptors with close-on-exec enabled;
  - gives registrations deterministic task/ordinal identities;
  - suspends checked-out tasks without changing runnable-queue policy;
  - polls read readiness non-blockingly and wakes ready tasks in registration
    order;
  - returns readiness decisions that equivalent fresh runs can replay without
    polling, reading, or writing live descriptors;
  - routes cancellation through the existing cooperative routed-effect
    boundary;
  - closes every owned duplicate and transfers every owned resume exactly once
    on wake, cancellation, or shutdown;
  - continues wakeup and teardown after a close error, returning completed
    runnable handles together with the E0908 cleanup diagnostic;
  - defensively reconciles registrations if unsupported lower-level code
    bypasses the registry lifecycle.
- Updated existing exhaustive suspension matches so host-readiness suspension
  retains the routed-effect cancellation semantics without changing channel
  deadlock or scope-policy behavior.
- Added controlled local-pipe and injected-boundary tests for live wakeup,
  deterministic decisions, equivalent-run replay, zero live polling during
  replay, descriptor refusal, direct-transition reconciliation, cancellation,
  shutdown, close-error cleanup, and repeated-operation idempotence.
- Folded the new checks into the existing scheduler-core Alcotest case. The
  historical release evidence remains byte-unchanged at 799 cases.

## Why it was done this way

The registry duplicates descriptors instead of taking the caller's original.
That gives one explicit owner to the readiness suspension while keeping the
caller's pre-existing ownership contract intact. Close-on-exec prevents those
owned duplicates from leaking into child processes.

Suspension is prepared before descriptor duplication but committed only after
duplication succeeds. A duplicate failure therefore leaves the task runnable
with its resume still checked out. Once committed, wake, cancellation, and
shutdown all retire the registry entry before reporting completion, so repeated
operations cannot close or drop the same resource twice. If descriptor
retirement fails after a scheduler transition, the result carries both the
completed runnable handles and cleanup diagnostics. A caller can therefore
enqueue every wakeup before surfacing the cleanup failure instead of silently
stranding runnable work.

Recorded decisions use the scheduler's stable task identity plus a
registry-local ordinal. That is enough for an equivalent fresh run to reproduce
the lifecycle choice, while the module explicitly treats the decision as a
replay token rather than an authorization capability. Provenance
authentication and integration into the canonical schedule format remain
responsibilities of a future public host handler.

The descriptor boundary is injectable only so tests can observe exact close
counts, force a close failure, and prove that replay never invokes the poller.
Normal construction uses `Unix.dup`, `Unix.close`, and a zero-time
`Unix.select`.

The seam is exported from the wrapped OCaml library for focused lifecycle
testing, but its interface documents that it is not a supported Jacquard host
I/O contract. A future handler must still bind it to `Structured_scope`,
preserve child-effect row charging, define supported operations and platforms,
authenticate trace provenance, and establish blocking/event-loop policy.

## Explicit limits

- Read readiness only; no write/error interest or timeout/select combinator.
- Unix backend only; no portability or support matrix.
- No public CLI, surface syntax, effect declaration, or blessed world adapter.
- No `Round_robin` or `Schedule_trace` integration and no trace-format change.
- No native scheduler, threads, actors, supervision, or channel extension.
- Registry callers must route active readiness cancellation and shutdown
  through the registry; direct scheduler mutation is unsupported, with
  reconciliation provided only as defensive cleanup.
- This is a C4 precursor, not completion of host asynchronous I/O.

## How it was checked

- Full build passed on exact commit
  `019c1ea78e0c384312b8a359fba3ec498969618a` (tree
  `162b06536ef434af0b861797e2496e8b10280820`).
- All 799 compiled/property tests passed on that exact commit.
- Focused scheduler-core/host-readiness checks passed.
- Frozen release evidence counts and manifests passed without modification.
- Formatting and trailing-whitespace checks passed.
- The existing native sanitizer, resource-leak, and differential lanes in the
  full test gate passed.
- The 1,000-case seeded interpreter/native fuzz lane passed with zero
  divergences.
- `origin/main` remained at
  `16780609dfdf81f574443aab1658748e15c1b2df` while the head was validated.
- Independent Sol xhigh review found one medium lifecycle handoff issue in
  cycle 1: a descriptor-close error could hide scheduler wakeups that had
  already completed. The implementation now returns those wakeups alongside
  cleanup diagnostics and tests live poll, replay, and cancellation failures.
  Cycle 2 reviewed the exact head above and passed with no findings.
