### PR TITLE
CI: attest historical release manifests by commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
           mkdir -p "$TMPDIR"
           scripts/check-temp-policy.sh
 
+      - name: Verify historical release manifests
+        run: |
+          scripts/release/check-historical-manifests.sh \
+            --commit "$GITHUB_SHA" \
+            --require-history
+          scripts/release/test-historical-manifests.sh --commit "$GITHUB_SHA"
+
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@v3.6.1
         with:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -22,6 +22,10 @@ check from becoming green while the local review surface is failing.
 The gate runs:
 
 ```sh
+scripts/release/check-historical-manifests.sh \
+  --commit "$(git rev-parse HEAD)" \
+  --require-history
+scripts/release/test-historical-manifests.sh --commit "$(git rev-parse HEAD)"
 opam install --deps-only . --with-test --with-doc --with-dev-setup -y
 opam exec -- dune build @all
 opam exec -- dune runtest
@@ -32,6 +36,29 @@ _build/default/bin/main.exe --version
 
 The `dune fmt` plus `git diff --exit-code` pair is deliberate: if formatting
 auto-promotes anything, CI fails and prints the diff.
+
+The historical-manifest gate attests the immutable commit named by
+`GITHUB_SHA`, not the mutable runner worktree. The candidate commit must retain
+the exact published effect-linearity, structured-concurrency, and SC.17
+correction-pack manifest and checker bytes. The gate reconstructs each pinned
+publication commit and runs that publication's checker inside the reconstructed
+tree. Generated and untracked runner files are outside this evidence contract;
+the separate formatting cleanliness check still rejects tracked worktree
+changes.
+
+The mutation test works only in disposable copies under `.scratch/tmp`. It
+changes one retained digest in each legacy manifest and proves that the gate
+rejects both candidates. A no-Git source archive cannot satisfy this
+history-backed gate: full history is required so CI cannot confuse an
+anchor-only diagnostic with publication reconstruction. The legacy EL and SC
+manifests describe historical publication overlays, not today's checkout; run
+their legacy checkers only in the corresponding reconstructed publication
+trees. This was not merely a theoretical distinction when the gate was added:
+at base commit `7cd3054652674eeaae4bfae8483c909819589f66`, direct current-tree
+checks reported 123 EL mismatches and 60 legacy SC mismatches because later
+successor work had legitimately changed listed files. Those observed counts
+explain the choice of tree semantics; they are diagnostic history, not a
+permanent gate contract.
 
 ## Governance Playground
 

--- a/scripts/release/check-historical-manifests.sh
+++ b/scripts/release/check-historical-manifests.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+set -eu
+
+# CI attests an immutable commit object, not the mutable runner worktree. The
+# candidate must retain the exact published EL and SC manifest/checker bytes;
+# their legacy checkers are then executed inside their pinned publication
+# trees. --candidate-root is a test-only seam for disposable mutation copies.
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  check-historical-manifests.sh --commit <commit> --require-history
+  check-historical-manifests.sh --candidate-root <directory> --require-history
+EOF
+  exit 2
+}
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+candidate_commit=
+candidate_root=
+require_history=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --commit)
+      [ "$#" -ge 2 ] || usage
+      [ -z "$candidate_commit$candidate_root" ] || usage
+      candidate_commit=$2
+      shift 2
+      ;;
+    --candidate-root)
+      [ "$#" -ge 2 ] || usage
+      [ -z "$candidate_commit$candidate_root" ] || usage
+      candidate_root=$2
+      shift 2
+      ;;
+    --require-history)
+      require_history=true
+      shift
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[ -n "$candidate_commit$candidate_root" ] || usage
+if [ "$require_history" != true ]; then
+  echo "--require-history is mandatory for release attestation" >&2
+  exit 2
+fi
+
+umask 077
+mkdir -p "$repo_root/.scratch/tmp"
+temp_root=$(mktemp -d "$repo_root/.scratch/tmp/historical-manifests.XXXXXX")
+cleanup() {
+  rm -rf -- "$temp_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+cd "$repo_root"
+git_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ "$git_top" != "$repo_root" ]; then
+  echo "history-backed release attestation requires this repository's Git history" >&2
+  exit 1
+fi
+
+resolve_commit() {
+  commit=$1
+  git rev-parse --verify "$commit^{commit}" 2>/dev/null
+}
+
+archive_commit() {
+  commit=$1
+  destination=$2
+  archive=$3
+  mkdir -p "$destination"
+  git archive --format=tar --output="$archive" "$commit"
+  tar -xf "$archive" -C "$destination"
+}
+
+if [ -n "$candidate_commit" ]; then
+  candidate_oid=$(resolve_commit "$candidate_commit") || {
+    echo "candidate commit is unavailable: $candidate_commit" >&2
+    exit 1
+  }
+  if [ -n "${GITHUB_SHA:-}" ]; then
+    github_oid=$(resolve_commit "$GITHUB_SHA") || {
+      echo "GITHUB_SHA is unavailable: $GITHUB_SHA" >&2
+      exit 1
+    }
+    if [ "$candidate_oid" != "$github_oid" ]; then
+      echo "candidate commit $candidate_oid does not match GITHUB_SHA $github_oid" >&2
+      exit 1
+    fi
+  fi
+  candidate_root="$temp_root/candidate"
+  archive_commit "$candidate_oid" "$candidate_root" "$temp_root/candidate.tar"
+else
+  candidate_root=$(CDPATH= cd -- "$candidate_root" 2>/dev/null && pwd) || {
+    echo "candidate root is unavailable: $candidate_root" >&2
+    exit 1
+  }
+fi
+
+check_retained_file() {
+  label=$1
+  expected=$2
+  relative_path=$3
+  file="$candidate_root/$relative_path"
+  if [ ! -f "$file" ] || [ -L "$file" ]; then
+    echo "$label retained file is missing or not regular: $relative_path" >&2
+    exit 1
+  fi
+  actual=$(sha256sum "$file" | awk '{print $1}')
+  if [ "$actual" != "$expected" ]; then
+    echo "$label retained file drifted: $relative_path" >&2
+    echo "expected $expected" >&2
+    echo "actual   $actual" >&2
+    exit 1
+  fi
+}
+
+check_publication() {
+  label=$1
+  publication=$2
+  manifest_path=$3
+  manifest_sha=$4
+  checker_path=$5
+  checker_sha=$6
+
+  publication_oid=$(resolve_commit "$publication") || {
+    echo "$label publication commit is unavailable: $publication" >&2
+    exit 1
+  }
+  if [ -n "$candidate_commit" ] &&
+    ! git merge-base --is-ancestor "$publication_oid" "$candidate_oid"; then
+    echo "$label publication $publication_oid is not an ancestor of candidate $candidate_oid" >&2
+    exit 1
+  fi
+
+  check_retained_file "$label" "$manifest_sha" "$manifest_path"
+  check_retained_file "$label" "$checker_sha" "$checker_path"
+
+  publication_root="$temp_root/publication-$label"
+  archive_commit \
+    "$publication_oid" "$publication_root" "$temp_root/publication-$label.tar"
+
+  publication_manifest_sha=$(sha256sum "$publication_root/$manifest_path" | awk '{print $1}')
+  publication_checker_sha=$(sha256sum "$publication_root/$checker_path" | awk '{print $1}')
+  if [ "$publication_manifest_sha" != "$manifest_sha" ] ||
+    [ "$publication_checker_sha" != "$checker_sha" ]; then
+    echo "$label publication anchors do not match the pinned byte identities" >&2
+    exit 1
+  fi
+
+  (
+    cd "$publication_root"
+    GIT_DIR=/nonexistent "$checker_path" >/dev/null
+  )
+  echo "$label historical evidence verified at publication $publication_oid"
+}
+
+check_publication \
+  EL \
+  9f04e972cb990257a85331943f486c1623cb57b5 \
+  docs/release/effect-linearity/MANIFEST.sha256 \
+  c4b7fe35abefd2e77de124a57fe5baa8d7e844969eb778955f1c520161241d0b \
+  scripts/release/check-effect-linearity-manifest.sh \
+  c1c4fd476119732fae529b1100d5307f061d0a275bd28b3f3551bcf2b89cfdb2
+
+check_publication \
+  SC \
+  81c14506e0d099dabe04a40b00c1d4fc45b42d47 \
+  docs/release/structured-concurrency/MANIFEST.sha256 \
+  3ca69edb0121713deb211042dfe2099bbd425c05292789d46a5db00e4d52ffd9 \
+  scripts/release/check-structured-concurrency-manifest.sh \
+  d0b40d94343a06343f08dbcf2a11c7b11fcf8a465df4e3375b4bfd703b62a495
+
+check_publication \
+  SC17 \
+  7cd3054652674eeaae4bfae8483c909819589f66 \
+  docs/release/structured-concurrency/SC17-MANIFEST.sha256 \
+  dd597d01e8d806fa8d962db419ca23ecb16031989526dd3ee01b130567eb6c50 \
+  scripts/release/check-sc17-manifest.sh \
+  4e35e42c06b251d9caefb34970f7d66cd5aca58c4f4caaa342efb20045e036ae

--- a/scripts/release/test-historical-manifests.sh
+++ b/scripts/release/test-historical-manifests.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  echo "usage: test-historical-manifests.sh --commit <commit>" >&2
+  exit 2
+}
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+checker="$repo_root/scripts/release/check-historical-manifests.sh"
+candidate_commit=
+
+if [ "$#" -eq 2 ] && [ "$1" = "--commit" ]; then
+  candidate_commit=$2
+else
+  usage
+fi
+
+cd "$repo_root"
+candidate_oid=$(git rev-parse --verify "$candidate_commit^{commit}" 2>/dev/null) || {
+  echo "candidate commit is unavailable: $candidate_commit" >&2
+  exit 1
+}
+if [ -n "${GITHUB_SHA:-}" ]; then
+  github_oid=$(git rev-parse --verify "$GITHUB_SHA^{commit}" 2>/dev/null) || {
+    echo "GITHUB_SHA is unavailable: $GITHUB_SHA" >&2
+    exit 1
+  }
+  if [ "$candidate_oid" != "$github_oid" ]; then
+    echo "candidate commit $candidate_oid does not match GITHUB_SHA $github_oid" >&2
+    exit 1
+  fi
+fi
+
+umask 077
+mkdir -p "$repo_root/.scratch/tmp"
+temp_root=$(mktemp -d "$repo_root/.scratch/tmp/historical-manifest-test.XXXXXX")
+cleanup() {
+  rm -rf -- "$temp_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+git archive --format=tar --output="$temp_root/candidate.tar" "$candidate_oid"
+mkdir -p "$temp_root/el" "$temp_root/sc"
+tar -xf "$temp_root/candidate.tar" -C "$temp_root/el"
+tar -xf "$temp_root/candidate.tar" -C "$temp_root/sc"
+
+drift_first_digest() {
+  manifest=$1
+  replacement="$manifest.mutated"
+  awk '
+    BEGIN { changed = 0 }
+    !changed && $0 !~ /^#/ && NF == 2 {
+      printf "%064d  %s\n", 0, $2
+      changed = 1
+      next
+    }
+    { print }
+    END {
+      if (!changed)
+        exit 1
+    }
+  ' "$manifest" >"$replacement"
+  mv "$replacement" "$manifest"
+}
+
+assert_rejected() {
+  label=$1
+  root=$2
+  if "$checker" --candidate-root "$root" --require-history >/dev/null 2>&1; then
+    echo "$label manifest drift was accepted" >&2
+    exit 1
+  fi
+  echo "$label manifest drift rejected"
+}
+
+drift_first_digest "$temp_root/el/docs/release/effect-linearity/MANIFEST.sha256"
+assert_rejected EL "$temp_root/el"
+
+drift_first_digest "$temp_root/sc/docs/release/structured-concurrency/MANIFEST.sha256"
+assert_rejected SC "$temp_root/sc"


### PR DESCRIPTION
## Context

A release-hardening review found that CI did not execute the effect-linearity or structured-concurrency release-manifest checkers. That left a known failure mode unguarded: a manifest or checker could drift while the ordinary build and test gate remained green.

The original task assumed both legacy manifests were clean against current HEAD. Successor work made that premise stale. At exact base `7cd3054652674eeaae4bfae8483c909819589f66`, running the old checkers directly against the current tree reports 123 EL mismatches and 60 legacy SC mismatches. Those are legitimate changes after the historical publications, not dirty evidence. Wiring the legacy scripts directly to a moving checkout would therefore reject healthy commits and misrepresent historical overlays as current-tree inventories.

This PR closes the CI gap while preserving the evidence model: Jacquard ships and reviews an immutable commit object, and each historical evidence pack remains bound to its exact publication tree. It changes CI, release-checking scripts, and CI documentation only. It does not change the language, kernel, runtime, command line, syntax, hashes, or any frozen release manifest.

## What changed

- Added a history-backed release-manifest gate that resolves the candidate once to an immutable Git object and, in CI, requires it to equal `GITHUB_SHA`.
- Pinned the exact retained manifest and checker bytes for:
  - EL publication `9f04e972cb990257a85331943f486c1623cb57b5`
  - legacy SC publication `81c14506e0d099dabe04a40b00c1d4fc45b42d47`
  - SC.17 correction publication `7cd3054652674eeaae4bfae8483c909819589f66`
- Required every publication to be an ancestor of the candidate commit.
- Reconstructed each publication from Git into private repository-local scratch space and executed that publication's retained checker inside its own no-Git tree.
- Added an explicit test-only candidate-root seam and a mutation test. The test creates two disposable candidate copies, changes one real digest in the EL manifest in one copy and the legacy SC manifest in the other, and proves both are rejected.
- Added the gate to `CI / Development gate` immediately after checkout and temporary-storage preparation, before OCaml setup.
- Documented the commit-object contract, full-history requirement, historical-publication semantics, mutation boundary, and why direct moving-worktree checks are incorrect.

## Why it was done this way

The stable artifact reviewers approve and releases ship is the commit named by GitHub, not incidental generated or untracked state in a runner worktree. Resolving that object once and reconstructing publications from pinned Git objects makes the gate deterministic and sharply limits mutable-ref and worktree-ordering ambiguity.

The historical checker is executed from its historical publication, rather than from current candidate code. A later PR therefore cannot satisfy the gate merely by weakening the live legacy checker. The candidate must retain the exact published manifest and checker bytes, and the retained checker must still validate the tree it originally attested.

The mutation seam is deliberately separate from the production path. It proves fail-closed behavior without modifying the real checkout or making release evidence depend on test order. The gate is not registered as a Dune test because Dune sandboxes and source archives intentionally lack the Git history required for publication reconstruction; an anchor-only result must not be mistaken for the authoritative CI attestation.

The old EL and SC manifests, their old checkers, and the frozen surface-syntax evidence remain byte-for-byte untouched. SC.17 is retained as the active correction pack rather than running its bounded overlay inventory against every future moving HEAD.

## How it was checked

All final checks used exact commit `1def0171450cf6e3d63a22bac1bdf7e5656c7079`:

- The history-backed EL, legacy SC, and SC.17 publication gate passed with `GITHUB_SHA` set to the exact commit.
- Disposable EL and legacy SC digest mutations were both rejected.
- Missing `--require-history` and a mismatched `GITHUB_SHA` were rejected.
- The untouched surface-syntax checker passed against immutable SS.22 boundary `52f36133b95349ae481f091e0043e71bc1452bc3`.
- Full `dune build @all` passed.
- The forced suite passed all 826 compiled/property tests and all 51 command-line transcript tests.
- All 27 documentation examples across 8 documents passed.
- Runtime checks and the 9-condition readability protocol passed.
- `dune build @doc`, formatting, tracked-diff cleanliness, and project whitespace checks passed.
- The worktree was clean and the diff against main contained only the workflow, CI documentation, and two new release-checking scripts.
- An independent GPT-5.6 Sol xhigh review passed with no blocking or nonblocking findings. It also validated a locally constructed two-parent synthetic PR merge commit, POSIX/dash/BusyBox behavior, YAML parsing, publication ancestry and hashes, temporary-storage policy, and adversarial fail-closed paths.
