### PR TITLE
Clarify Jacquard's Collect policy boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,8 @@ surface is implemented and supported but remains an evolving v0 projection
 onto the permanent 27-form kernel. Native AOT compilation and C-toolchain
 optimization ship. `parallel.map` and `parallel.both` remain pure, sequential
 optimization hints. The interpreted runtime now supports opaque scoped Tasks,
-cooperative cancellation, fail-fast/collect, FIFO and seeded scheduling,
+cooperative cancellation, fail-fast language scopes, an OCaml-only Collect
+policy seam, FIFO and seeded scheduling,
 versioned strict replay, bounded exhaustive schedule enumeration, and scoped
 typed channels with rendezvous and buffered FIFO behavior, close, cancellation,
 and exact run/scope ownership. It does not provide native root scheduling or

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,11 +44,13 @@ project shape from file names alone.
 - `client-playground.md`: local-only Workspace v0 governance decision-chain
   viewer, normalized projection, trust boundary, evidence language,
   accessibility contract, and explicit product non-claims.
-- `concurrency.md`: SC.14 ships the exact scoped typed Channel contract frozen
-  by SC.13 through deterministic, seeded, replay, exhaustive, and cached
-  interpreted scheduling. It publishes exact identities, capacity/backpressure,
-  close, cancellation, fan-in, ownership, and policy interaction. Native
-  Channel execution, host I/O readiness, and actors remain deferred to C4+.
+- `concurrency.md`: SC.14 ships fail-fast Jacquard scopes, an explicit
+  OCaml-only Collect policy seam, and the exact scoped typed Channel contract
+  frozen by SC.13 through deterministic, seeded, replay, exhaustive, and
+  cached interpreted scheduling. It publishes exact identities,
+  capacity/backpressure, close, cancellation, fan-in, ownership, and policy
+  interaction. Native Channel execution, host I/O readiness, and actors remain
+  deferred to C4+.
 - `warp-testing.md`: Warp test model, rows, handlers, cache, properties, and
   world lanes.
 - `errors.md`: diagnostic code catalog.
@@ -130,6 +132,9 @@ Read these together when judging whether the release candidate is credible:
   schedule parity, counts, claim-to-test links, and the SC.17 correction pointer.
 - `release/structured-concurrency/SC17-EVIDENCE.md`: correction evidence proving
   direct and fail-fast cancellation cannot orphan nested scheduler work.
+- `release/structured-concurrency/COLLECT-SURFACE.md`: current-contract
+  clarification that Jacquard 0.1 exposes fail-fast `async.scope`, while
+  Collect is available only to explicit OCaml library callers.
 - `release/structured-concurrency/LIMITS.md`: dynamic Task and Channel lifetime
   checks, cooperative cancellation, explicit bracket cleanup, interpreter-only
   scheduling, sequential C0 hints, and explicit C4 exclusions.

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -3,13 +3,14 @@
 Status: SC.16 publishes the C0-C2 evidence and limits for SC.12 budgeted
 exhaustive schedule enumeration and SC.11 seeded randomized schedule testing
 over SC.10 versioned scheduler traces and strict replay, SC.9 deterministic
-round-robin, SC.8 fail-fast/collect scope policies, SC.7 cooperative
+round-robin, SC.8 fail-fast/Collect OCaml scope policies, SC.7 cooperative
 cancellation, SC.6 structured-scope ownership, the SC.5
 policy-independent lifecycle core, and the SC.4 generalized child-effect law
 (D46-D50), July 2026. This document is authoritative for C1's static
 non-laundering law, lifecycle and nested ownership, cancellation delivery, and
-homogeneous scope aggregation, plus C2's record/replay and seeded decision
-policies. SC.14 also ships the C3 scoped typed-Channel runtime through those
+fail-fast language scope plus the OCaml scope-policy seam, plus C2's
+record/replay and seeded decision policies. SC.14 also ships the C3 scoped
+typed-Channel runtime through those
 same deterministic, seeded, replay, exhaustive, and cached interpreter routes.
 The default CLI, prelude-evaluation, and Warp Case paths drive real evaluator
 states and affine continuations through the Async and Channel scheduler.
@@ -294,9 +295,9 @@ scope may complete. Direct `async.cancel` and fail-fast sibling cancellation
 share this path. No descendant may receive another scheduler choice or invoke
 a routed world callback after delivery to the ancestor.
 
-## 3. Scope APIs and failure shapes
+## 3. Shipped language scope and OCaml policy seam
 
-The general handler and homogeneous convenience APIs are frozen as:
+The scope contract records these three schemas:
 
 ```text
 async.scope : (() ->{Async | e} a) ->{| e} TaskResult a
@@ -304,27 +305,42 @@ async.scope-fail-fast : (List (() ->{Async | e} a)) ->{| e} TaskResult (List a)
 async.scope-collect : (List (() ->{Async | e} a)) ->{| e} List (TaskResult a)
 ```
 
-`async.scope` uses fail-fast by default. It discharges only `Async`; all child
-world effects remain in `e`. Its body may spawn, await, cancel, and yield
+Their reachability differs in Jacquard 0.1:
+
+| schema | 0.1 reachability |
+|---|---|
+| `async.scope` | shipped Jacquard term binding; always fail-fast |
+| `async.scope-fail-fast` | OCaml/library design schema; not a Jacquard term binding |
+| `async.scope-collect` | OCaml/library design schema; not a Jacquard term binding |
+
+Jacquard 0.1 binds only `async.scope`. The prelude, CLI, Warp, and nested
+scheduler do not expose a failure-policy selector. `async.scope-fail-fast` and
+`async.scope-collect` are contract schemas, not Jacquard term bindings. They
+name the two homogeneous result shapes implemented at the OCaml library seam;
+they must not be read as callable public-language helpers.
+
+The shipped `async.scope` term uses fail-fast. It discharges only `Async`; all
+child world effects remain in `e`. Its body may spawn, await, cancel, and yield
 directly. A successfully returned body value is `Done`; the first child
 non-success selected by scheduler decision order is its exact `Failed` or
 `Cancelled` result.
 
-`async.scope-fail-fast` is the homogeneous aggregate: `Done(values)` preserves
-input/creation order. The first scheduler-ordered `Failed` or `Cancelled`
-cancels unfinished siblings and returns no partial value list.
-`async.scope-collect` never cancels siblings merely because one failed and
-returns one `TaskResult` per input, in input/creation order. These separate
-shapes avoid pretending that
+At the OCaml policy seam, fail-fast homogeneous aggregation returns
+`Done(values)` in input/creation order. The first scheduler-ordered `Failed` or
+`Cancelled` cancels unfinished siblings and returns no partial value list.
+Collect is explicit only at the OCaml library seam. It never cancels siblings
+merely because one failed and returns one `TaskResult` per input, in
+input/creation order. These separate shapes avoid pretending that
 heterogeneously typed child values can inhabit one list. Within a general scope,
 programs obtain heterogeneous typed results explicitly with `async.await`.
 
-SC.8 implements these two policies in `Scope_policy`. A controller registers an
-ordered same-scope child list and consumes terminal observations carrying a
-strictly increasing lexicographic `(D46 decision, sub-observation ordinal)`
-pair. The ordinal is zero for the first terminal observed in a step and rises
-in stable scope-child order when one step terminalizes more children through
-fail-fast cancellation. Fail-fast is the default. Its
+SC.8 implements both policies for OCaml callers in `Scope_policy`. A controller
+registers an ordered same-scope child list and consumes terminal observations
+carrying a strictly increasing lexicographic
+`(D46 decision, sub-observation ordinal)` pair. The ordinal is zero for the
+first terminal observed in a step and rises in stable scope-child order when
+one step terminalizes more children through fail-fast cancellation. Fail-fast
+is the default and the only policy selected by a Jacquard scope. Its
 first observed `Failed(message)` or `Cancelled` freezes that exact non-success,
 requests cancellation of each unfinished sibling in input order, and
 immediately delivers already-suspended siblings through the SC.7 destruction
@@ -349,12 +365,14 @@ waiter-registration order. A scheduler drains them exactly once through
 `Scope_policy.take_awakened` before its next choice; the policy layer never
 silently discards or independently schedules them.
 
-Collect never requests sibling cancellation. It waits for every registered
-child and returns the immutable terminal results in input order, independently
-of terminal observation order. Zero children produce `Done([])` under
-fail-fast and `[]` under collect. These controllers consume scheduler decisions
-but do not create a runnable queue, choose a task, resume a continuation,
-consult host timing, or install a root handler.
+The OCaml-only Collect policy never requests sibling cancellation. It waits for
+every registered child and returns the immutable terminal results in input
+order, independently of terminal observation order. Zero children produce
+`Done([])` under fail-fast and `[]` under Collect. These controllers consume
+scheduler decisions but do not create a runnable queue, choose a task, resume a
+continuation, consult host timing, or install a root handler. Scheduling policy
+(FIFO, seeded, replay, or exhaustive) is orthogonal to failure policy and does
+not make Collect reachable from Jacquard.
 
 ## 4. Cancellation and resources
 
@@ -468,9 +486,9 @@ its creating scope or is reused by a later scheduler invocation on the same
 evaluator. Routed root dispatch snapshots and rechecks the suspended affine
 resume together with the operation, arguments, and result, so a hostile root
 callback cannot mutate the continuation graph to smuggle a foreign Task.
-Positive task and decision bounds close and drain
-the scheduler on refusal. Fail-fast and collect reuse the D50 result shapes,
-and all results remain in task-creation order. Cache identity is the canonical
+Positive task and decision bounds close and drain the scheduler on refusal. The
+OCaml fail-fast and Collect policies reuse the D50 result shapes, and all
+results remain in task-creation order. Cache identity is the canonical
 program hash plus scheduler version, failure policy, and both bounds. Entries
 contain trace/decision proof only; they never retain evaluator closures,
 continuations, results, or Task handles, and a hit is checked against a fresh
@@ -489,8 +507,9 @@ jacquard-schedule format=1 scheduler=S program=HASH policy=P max-tasks=N max-dec
 
 `S` is `fifo-round-robin-v0`; `HASH` is the 64-lowercase-hex `HASH_V0` identity
 of the single scheduled expression; `P` is `fail-fast` or `collect`; both
-bounds are positive decimal integers; and `F` is `-` or `K:TASK`. Remaining
-lines use one of two closed records:
+bounds are positive decimal integers; and `F` is `-` or `K:TASK`. Jacquard CLI
+and Warp traces use `fail-fast`; `collect` identifies an explicit OCaml library
+run. Remaining lines use one of two closed records:
 
 ```text
 create scope=PATH task=TASK parent=-|TASK
@@ -560,8 +579,9 @@ run/scope-local Task carrier in both runtime representations. SC.5 adds the
 policy-independent lifecycle engine, SC.6 adds same-run nested scope ownership,
 recursive cleanup, and complete runtime-value escape scans, and SC.7 adds
 cooperative delivery at await, yield, and routed-effect boundaries. SC.8 adds
-deterministic fail-fast and collect aggregation over explicit terminal decision
-events. SC.9 adds the default deterministic queue and real evaluator-state Async
+deterministic fail-fast and Collect aggregation over explicit terminal decision
+events at the OCaml policy seam; Jacquard scopes select fail-fast. SC.9 adds the
+default deterministic queue and real evaluator-state Async
 driver used by interpreted CLI and Warp Case execution. SC.10 adds canonical
 record, fail-closed replay, and provenance-preserving explicit fork over that
 same driver. Raw `Eval.run_expr` remains the low-level unscheduled evaluator
@@ -601,7 +621,8 @@ The public language has no `async.current-task` operation, so a checked
 Jacquard program cannot name its own handle and self-cancel. The scheduler
 lifecycle integration test therefore exercises self-cancel at the real
 `Structured_scope.cancel` route; the real-evaluator suite covers failing-child
-fail-fast/collect and same-step cancellation ordinals. Warp Case coverage is
+fail-fast behavior, the OCaml integration suite covers Collect, and both cover
+same-step cancellation ordinals. Warp Case coverage is
 limited to checker-representable programs (nested spawn/await/yield/cancel).
 Ill-typed child faults and direct self-handle injection remain hostile OCaml
 integration cases, not purported checked Warp programs. Warp Props still vary
@@ -678,7 +699,8 @@ fallback. The prerequisite audit, parity/sanitizer lane, and benchmark are in
 ## 7. Phases and indexed decisions
 
 C0 is pure parallel hints. C1 is Task lifecycle, Async, structured scopes,
-cooperative cancellation, fail-fast/collect, and the deterministic scheduler.
+cooperative cancellation, fail-fast Jacquard scopes, an OCaml-only Collect
+policy seam, and the deterministic scheduler.
 C2 adds schedule tooling. SC.10 implements versioned record/strict replay,
 SC.11 adds seeded randomized Warp schedules, and SC.12 implements budgeted
 exhaustive schedules. C3 adds typed channels: SC.13 freezes their interface and
@@ -703,7 +725,7 @@ no-detached-task rule; its separate successor evidence is
 | D47 | cancellation | cooperative at the three suspension classes above; bracket for cleanup; finalizers deferred |
 | D48 | task escape | E0907 dynamic defect in v0; rank-2 static scoping is future work |
 | D49 | channels and actors | SC.13 freezes scoped typed channels for C3; SC.14 implements them; actors/supervision remain C4+ |
-| D50 | scope failure policy | fail-fast default; collect explicit, with the exact result shapes in §3 |
+| D50 | scope failure policy | Jacquard scopes are fail-fast; Collect is explicit only through the OCaml library seam, with the exact result shapes in §3 |
 
 ## 8. Typed channels (SC.13-SC.14 / C3 contract)
 
@@ -934,20 +956,21 @@ E0907 before continuation consumption or channel mutation. Nested scopes create
 their own channels; parent/descendant channel sharing is deliberately absent in
 v1.
 
-### 8.6 Scope policy, teardown, and deadlock
+### 8.6 OCaml scope policy, teardown, and deadlock
 
-Fail-fast and collect do not change FIFO, close results, or deadlock detection:
+At the OCaml policy seam, fail-fast and Collect do not change FIFO, close
+results, or deadlock detection. Jacquard scopes select fail-fast:
 
 - fail-fast selects the existing first decision-ordered non-success, requests
   sibling cancellation in creation order, removes channel-blocked siblings via
   §8.5, then closes owned channels in ChannelId order during scope teardown;
   cancelled operations yield Task `Cancelled`, not `Err(ChannelClosed)`;
-- collect does not cancel siblings or implicitly close a channel when one child
+- Collect does not cancel siblings or implicitly close a channel when one child
   fails. Other children may continue to communicate and their results remain in
   creation order;
 - under either policy, if every remaining live task is channel-blocked and no
   channel transition is possible, the scheduler reports deadlock E0908. In
-  particular, fail-fast has no failure to prefer in this state; collect cannot
+  particular, fail-fast has no failure to prefer in this state; Collect cannot
   return a partial aggregate. Deadlock never implies an implicit close. Cleanup
   removes waiters and destroys continuations;
 - explicit close while the scope is active uses §8.3 regardless of policy;
@@ -976,7 +999,7 @@ SC.14 is conforming only if all of the following remain true:
   double continuation consumption;
 - [x] exact run/scope ownership, recursive escape scans, hostile callback
   revalidation, and deterministic ChannelId creation;
-- [x] fail-fast cancellation, collect non-interference, policy-independent
+- [x] fail-fast cancellation, OCaml Collect non-interference, policy-independent
   all-channel-blocked E0908 refusal, and exception-safe teardown;
 - [x] rendezvous and buffered contract traces plus positive/negative checker
   fixtures.

--- a/docs/release/structured-concurrency/COLLECT-SURFACE.md
+++ b/docs/release/structured-concurrency/COLLECT-SURFACE.md
@@ -1,0 +1,55 @@
+# Collect Surface Clarification
+
+Status: current 0.1 contract clarification, July 2026.
+
+## Context
+
+The structured-concurrency design records schemas for fail-fast and Collect
+homogeneous aggregation. Earlier prose called all three scope schemas APIs,
+which could be read as saying that a Jacquard program can call
+`async.scope-collect`. That term is not bound by the prelude, accepted by the
+CLI as a policy selector, or exposed through Warp. The implemented language
+surface has always provided `async.scope`, and nested language scopes select
+fail-fast.
+
+This note corrects that reachability claim. It does not add or remove a
+language operation.
+
+## Current contract
+
+| name | status in Jacquard 0.1 |
+|---|---|
+| `async.scope` | shipped Jacquard term; always fail-fast |
+| `async.scope-fail-fast` | OCaml/library design schema; not a Jacquard term |
+| `async.scope-collect` | OCaml/library design schema; not a Jacquard term |
+| `Concurrency_contract.Collect` | explicit OCaml embedding policy |
+
+An OCaml caller that explicitly selects Collect gets one immutable
+`TaskResult` per child in creation order. A child failure does not cancel its
+siblings, and completion waits for all registered children. Fail-fast remains
+the OCaml default and the only policy selected by Jacquard scopes.
+
+Scheduling and failure policy are separate choices. FIFO, seeded, replay, and
+exhaustive scheduling do not make Collect reachable from Jacquard and do not
+silently change a scope's failure policy.
+
+## Evidence
+
+- The prelude binds `async.scope` and does not bind either homogeneous helper.
+- Exposure regression coverage checks the shipped binding and both absences.
+- The scope-policy transcript identifies its executable as an OCaml evidence
+  helper rather than a `jacquard run` example.
+- `Concurrency_contract.failure_policy` keeps both library policies and
+  documents the explicit embedding seam.
+
+## Deliberate exclusions
+
+This clarification does not change the prelude, evaluator, scheduler, CLI,
+Warp, trace format, `HASH_V0`, native runtime, or canonical identities. A
+future public Collect operation would be a separate language and product
+decision with its own typing, lowering, diagnostics, and cross-engine evidence.
+
+The frozen structured-concurrency evidence documents and manifests remain
+byte-for-byte historical publications. They are not rewritten by this
+successor clarification. The historical-publication gate reconstructs and
+checks them at their pinned commits.

--- a/src/concurrency_contract.mli
+++ b/src/concurrency_contract.mli
@@ -110,7 +110,10 @@ val detect_wait_cycle : wait_edge list -> task_id list option
 
 type failure_policy =
   | Fail_fast
-  | Collect  (** Scope sibling-failure policy. [Fail_fast] is the default. *)
+  | Collect
+      (** Scope sibling-failure policy for OCaml scheduler/library callers. [Fail_fast] is the
+          default and the only policy selected by the shipped Jacquard [async.scope] term. [Collect]
+          must be requested explicitly through the OCaml API. *)
 
 type 'a fail_fast_result = 'a list task_result
 (** Homogeneous fail-fast aggregation: [Done values] preserves creation/input order; the first
@@ -128,14 +131,17 @@ type schemas = {
   scope_fail_fast : string;
   scope_collect : string;
 }
-(** Exact whitespace-normalized surface schemas frozen by SC.0. They are data for conformance
-    checks, not a substitute for the checker's resolved structural typing rule. *)
+(** Exact whitespace-normalized contract schemas frozen by SC.0. Only [scope] names a shipped
+    Jacquard term binding in 0.1. [scope_fail_fast] and [scope_collect] describe homogeneous
+    OCaml/library design shapes; they are not callable Jacquard helpers. The schemas are data for
+    conformance checks, not a substitute for the checker's resolved structural typing rule. *)
 
 val schemas : schemas
 (** [schemas] returns the exact Task/Async/scope spellings indexed in [docs/concurrency.md]. *)
 
 val default_failure_policy : failure_policy
-(** [default_failure_policy] is [Fail_fast] (D50). *)
+(** [default_failure_policy] is [Fail_fast] (D50). Jacquard and nested language scopes always use
+    this policy; an OCaml caller must explicitly request [Collect]. *)
 
 type cancellation_point =
   | Await

--- a/test/cli/concurrency-evidence.t
+++ b/test/cli/concurrency-evidence.t
@@ -19,10 +19,21 @@ complete, unique, replayable schedules.
 
 SC.17 keeps the historical SC.16 attestation intact and adds a separately
 reconstructible correction pack for transitive cancellation of nested runs.
-The Dune sandbox has no standalone Git history, so the checker says exactly
-which reduced verification it performed.
+The Dune sandbox pins the retained manifest and checker bytes without applying
+their historical inventories to the moving source tree. The production
+history gate reconstructs and executes each checker at its registered
+publication commit.
 
-  $ ../../scripts/release/check-sc17-manifest.sh
-  note: historical reconstructions unavailable; verified pinned SC.16/GM.21 attestations and SC.17 overlay
-  SC.16 and GM.21 historical attestations are preserved and byte-consistent
-  SC.17 cancellation correction pack is complete and byte-consistent
+  $ sha256sum \
+  >   ../../docs/release/structured-concurrency/MANIFEST.sha256 \
+  >   ../../scripts/release/check-structured-concurrency-manifest.sh \
+  >   ../../docs/release/governed-membranes/GM21-MANIFEST.sha256 \
+  >   ../../scripts/release/check-gm21-manifest.sh \
+  >   ../../docs/release/structured-concurrency/SC17-MANIFEST.sha256 \
+  >   ../../scripts/release/check-sc17-manifest.sh
+  3ca69edb0121713deb211042dfe2099bbd425c05292789d46a5db00e4d52ffd9  ../../docs/release/structured-concurrency/MANIFEST.sha256
+  d0b40d94343a06343f08dbcf2a11c7b11fcf8a465df4e3375b4bfd703b62a495  ../../scripts/release/check-structured-concurrency-manifest.sh
+  19603651590eb6de890a7e3597b009403f03234d6d5f022b076497d8a638e45f  ../../docs/release/governed-membranes/GM21-MANIFEST.sha256
+  14fcc2ec9274d1dde793ef534591c4d757934089d0510424e52187e9b0fd5a82  ../../scripts/release/check-gm21-manifest.sh
+  dd597d01e8d806fa8d962db419ca23ecb16031989526dd3ee01b130567eb6c50  ../../docs/release/structured-concurrency/SC17-MANIFEST.sha256
+  4e35e42c06b251d9caefb34970f7d66cd5aca58c4f4caaa342efb20045e036ae  ../../scripts/release/check-sc17-manifest.sh

--- a/test/cli/scope-policy.t
+++ b/test/cli/scope-policy.t
@@ -1,3 +1,6 @@
+This transcript runs an OCaml evidence helper directly, not `jacquard run`.
+It proves the two library policy shapes and does not claim that
+`async.scope-fail-fast` or `async.scope-collect` is a public Jacquard term.
 SC.8 consumes explicit scheduler decision order; running the same policy trace
 twice is byte-identical and aggregation remains in creation/input order.
 
@@ -7,4 +10,3 @@ twice is byte-identical and aggregation remains in creation/input order.
   $ cat first.out
   fail-fast decision=7 result=failed(first) dropped=21,31
   collect input-order=[done(10),failed(later),done(30)]
-

--- a/test/test_effect_taxonomy.ml
+++ b/test/test_effect_taxonomy.ml
@@ -1675,6 +1675,29 @@ let test_governance_and_links () =
     "documented root boundaries exactly match grantable names"
     (List.sort String.compare Prelude.grantable_names)
     root_grants;
+  Alcotest.(check bool)
+    "async.scope is the only shipped Jacquard scope term" true
+    (Store.lookup_kind store "async.scope" Resolve.KTerm <> None);
+  List.iter
+    (fun name ->
+      Alcotest.(check bool)
+        (name ^ " remains an unbound OCaml contract schema")
+        true
+        (Store.lookup_kind store name Resolve.KTerm = None))
+    [ "async.scope-fail-fast"; "async.scope-collect" ];
+  let concurrency = normalize_whitespace concurrency in
+  List.iter
+    (fun phrase ->
+      Alcotest.(check bool)
+        ("scope reachability contract: " ^ phrase)
+        true
+        (contains_string concurrency phrase))
+    [
+      "Jacquard 0.1 binds only `async.scope`";
+      "`async.scope-fail-fast` and `async.scope-collect` are contract schemas, not Jacquard term \
+       bindings";
+      "Collect is explicit only at the OCaml library seam";
+    ];
   let reserved =
     rows ()
     |> List.filter (fun row -> String.equal row.status "reserved")


### PR DESCRIPTION
## Context

The structured-concurrency documentation presented `async.scope`, `async.scope-fail-fast`, and `async.scope-collect` together as if all three were callable Jacquard APIs. The implemented 0.1 language has always bound only `async.scope`, and language scopes always use fail-fast behavior. Collect exists as an explicit policy for OCaml embedders, not as a prelude term, CLI option, or Warp selector.

That mismatch could lead readers to design Jacquard programs around a helper that does not exist. This PR corrects the published boundary. It changes documentation, interface comments, and evidence tests only; it does not change the language or runtime.

## What changed

- Reworked the scope section around a reachability table: `async.scope` is the shipped Jacquard term, while the two homogeneous helper names are OCaml/library design schemas.
- Clarified throughout the concurrency contract that Jacquard scopes are fail-fast and that Collect must be selected explicitly by an OCaml caller.
- Clarified that FIFO, seeded, replay, and exhaustive scheduling choose task order; they do not select a different failure policy.
- Updated the README and documentation index so the public limits are accurate at first contact.
- Added a current-contract clarification note without rewriting the historical structured-concurrency publications.
- Updated the public OCaml interface comments to describe the same boundary.
- Added regression coverage proving that `async.scope` resolves from the prelude and that `async.scope-fail-fast` and `async.scope-collect` do not.
- Labeled the scope-policy transcript as an OCaml evidence helper rather than a `jacquard run` example.
- Replaced an obsolete Dune-sandbox invocation of the frozen SC.17 checker with exact retained manifest/checker hash pins. The production history gate still reconstructs and executes every historical checker at its registered publication commit.

## Why it was done this way

Release hardening should describe the system that actually ships instead of adding a late trusted language feature to make older prose true. A public Collect term would require new typing, evaluator routing, result conversion, diagnostics, compatibility commitments, and cross-engine evidence. That is a separate product and language decision.

Keeping Collect at the existing OCaml seam preserves useful embedding behavior: it waits for every registered sibling, does not cancel siblings merely because one fails, and returns results in creation order. Jacquard programs keep the simpler reviewed contract that every scope is fail-fast.

Historical manifests attest their publication commits, not today's moving documentation tree. The Dune transcript now checks immutable historical identities, while the required Git-backed CI gate performs the semantic reconstruction. Frozen evidence, manifests, and checker bytes remain unchanged.

## Deliberate exclusions

- No new prelude term, trusted marker, CLI flag, or Warp option.
- No evaluator, scheduler, trace-format, cache, `HASH_V0`, native-runtime, or canonical-identity change.
- No rewrite of the frozen SC.16 or SC.17 evidence publications.
- No removal or behavioral change to the OCaml Collect API.

The public-looking homogeneous schema strings remain design vocabulary and future debt. A future public Collect operation requires a separate owner decision and evidence plan.

## How it was checked

- The new reachability regression failed before the documentation correction and passed afterward.
- All 826 compiled/property tests passed on the exact reviewed commit in the final forced run (341 seconds).
- Focused scope-policy and concurrency-evidence transcript tests passed.
- Full `dune build @all` passed.
- API documentation build passed.
- Formatting and whitespace checks passed with a clean worktree.
- The production historical-publication gate passed all 35 registered manifests across 19 publication commits.
- Frozen SC.16 and SC.17 manifest hashes remain byte-identical.
- GPT-5.6 Sol xhigh independently reviewed exact commit `13c1b74915f694e526e4fe6dd8fe3f4920f4a25c` and returned PASS with no blockers or architecture conflicts.

The independent reviewer noted two optional evidence improvements for unchanged behavior: a black-box negative surface test and a direct nested-fail-fast-under-OCaml-Collect test. The resolved-store test already proves the shipped binding boundary, and the unchanged scheduler explicitly hard-codes nested language scopes to fail-fast.
