### PR TITLE
Make budget-stopped schedule prefixes strictly replayable

### DIFF
--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `826`
+- Alcotest/QCheck cases: `827`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 826 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 827 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -738,7 +738,7 @@ eight independently selectable groups and their case counts are:
 | `cancellation` | 1 | cooperative boundary delivery |
 | `scope-policy` | 1 | fail-fast and collect aggregation |
 | `round-robin` | 1 | real evaluator FIFO lifecycle, including Channel seeded/replay/cache parity |
-| `schedule-trace` | 3 | canonical identity; refusal compatibility; impossible-event refusal |
+| `schedule-trace` | 4 | canonical identity; refusal compatibility; impossible-event refusal; task-budget prefix replay |
 | `exhaustive-schedule` | 8 | hand counts and Channel worlds; Warp/replay; failures; budgets; hermeticity; Once ownership |
 
 The exact discovery and focused execution commands are:
@@ -757,7 +757,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `826`
+- Alcotest/QCheck cases: `827`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled

--- a/src/round_robin.ml
+++ b/src/round_robin.ml
@@ -278,7 +278,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
     let is_body run handle = same_handle run handle run.body_handle in
     let has_seen run handle = List.exists (same_handle run handle) run.seen_terminal in
     let drop _resume = () in
-    let allocate_task () =
+    let ensure_task_budget () =
       if !task_count >= bounds.max_tasks then (
         budget_refusal := Some Task_limit;
         let diagnostics =
@@ -286,11 +286,13 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
         in
         fatal_diagnostics := diagnostics;
         Error diagnostics)
-      else (
-        incr task_count;
-        incr live_count;
-        max_live := max !max_live !live_count;
-        Ok ())
+      else Ok ()
+    in
+    let allocate_task () =
+      incr task_count;
+      incr live_count;
+      max_live := max !max_live !live_count;
+      Ok ()
     in
     let rec queue_ids acc = function
       | [] -> Ok (List.rev acc)
@@ -600,6 +602,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
                           ~scope_path:(Structured_scope.scope_path run.scope)
                           ~spawn_index:(List.length run.children + 1)
                       in
+                      let* () = ensure_task_budget () in
                       let* () =
                         validate_creation
                           Schedule_trace.
@@ -842,6 +845,7 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
                       let nested_id =
                         Concurrency_contract.task_id ~scope_path:nested_path ~spawn_index:0
                       in
+                      let* () = ensure_task_budget () in
                       let* () =
                         validate_creation
                           Schedule_trace.

--- a/src/round_robin.mli
+++ b/src/round_robin.mli
@@ -130,7 +130,8 @@ val run_expr_scheduled_attempt :
 (** [run_expr_scheduled_attempt] is the bounded-search seam. Task and decision exhaustion return a
     [Stopped] canonical prefix after recursive cleanup; invalid inputs, lifecycle defects, and
     replay drift remain [Error]. The prefix contains no evaluator state, Task handle, or resumption.
-    Callers must never count [Stopped] as a complete world. *)
+    Strict replay of a task-budget prefix with the same bounds reproduces the same refusal and a
+    byte-identical prefix. Callers must never count [Stopped] as a complete world. *)
 
 val run_call :
   Eval.ctx ->

--- a/src/schedule_control.ml
+++ b/src/schedule_control.ml
@@ -248,23 +248,24 @@ let observe_operation controller operation =
       in
       Result.map (fun () -> current.operation <- Some operation) result
 
+let decision_event current =
+  Schedule_trace.Decide
+    {
+      sequence = current.sequence;
+      runnable = current.runnable;
+      chosen = current.chosen;
+      operation = Option.get current.operation;
+    }
+
+let chronological_events current = decision_event current :: List.rev current.creations_rev
+
 let finish_decision controller =
   match controller.current with
   | None -> error "no scheduler decision is active"
   | Some { operation = None; sequence; _ } ->
       error (Printf.sprintf "decision %d did not observe an operation" sequence)
   | Some current ->
-      let decision =
-        Schedule_trace.Decide
-          {
-            sequence = current.sequence;
-            runnable = current.runnable;
-            chosen = current.chosen;
-            operation = Option.get current.operation;
-          }
-      in
-      let chronological = decision :: List.rev current.creations_rev in
-      controller.events_rev <- List.rev_append chronological controller.events_rev;
+      controller.events_rev <- List.rev_append (chronological_events current) controller.events_rev;
       controller.current <- None;
       Ok ()
 
@@ -272,15 +273,7 @@ let snapshot_prefix controller =
   let events_rev =
     match controller.current with
     | None | Some { operation = None; _ } -> controller.events_rev
-    | Some current ->
-        Schedule_trace.Decide
-          {
-            sequence = current.sequence;
-            runnable = current.runnable;
-            chosen = current.chosen;
-            operation = Option.get current.operation;
-          }
-        :: controller.events_rev
+    | Some current -> List.rev_append (chronological_events current) controller.events_rev
   in
   Schedule_trace.make ~scheduler:controller.scheduler ~program:controller.program
     ~policy:controller.policy ~max_tasks:controller.max_tasks

--- a/src/schedule_control.mli
+++ b/src/schedule_control.mli
@@ -45,9 +45,9 @@ val finish_decision : t -> (unit, Diag.t list) result
 val snapshot_prefix : t -> (Schedule_trace.t, Diag.t list) result
 (** [snapshot_prefix controller] returns the canonical replayable prefix observed so far without
     requiring a complete run. If the current decision has observed its operation, the decision is
-    retained but any not-yet-committed creation records are omitted. This is the budget-refusal
-    seam: exhaustive search can fork the decision and every earlier choice without treating the
-    stopped prefix as a complete world. *)
+    retained followed by every creation already validated during that decision. This is the
+    budget-refusal seam: exhaustive search can fork the decision and every earlier choice without
+    treating the stopped prefix as a complete world. *)
 
 val finish : t -> (Schedule_trace.t, Diag.t list) result
 (** Refuses missing or extra replay events and returns the canonical fresh trace. *)

--- a/test/test_schedule_trace.ml
+++ b/test/test_schedule_trace.ml
@@ -51,6 +51,50 @@ let contains needle haystack =
   in
   loop 0
 
+let expression store source =
+  match Reader.parse_one ~file:"schedule-prefix-replay.jqd" source with
+  | Error diagnostics -> Eval_support.fail_diags "parse schedule-prefix fixture" diagnostics
+  | Ok form -> (
+      match Kernel.expr_of_form form with
+      | Error diagnostics -> Eval_support.fail_diags "validate schedule-prefix fixture" diagnostics
+      | Ok expression -> (
+          match Resolve.resolve_expr (Store.names_view store) expression with
+          | Ok expression -> expression
+          | Error diagnostics ->
+              Eval_support.fail_diags "resolve schedule-prefix fixture" diagnostics))
+
+let task_stopped label = function
+  | Ok (Round_robin.Stopped { budget = Round_robin.Task_limit; error; schedule_prefix }) ->
+      (error, schedule_prefix)
+  | Ok (Round_robin.Stopped { budget = Round_robin.Decision_limit; _ }) ->
+      Alcotest.failf "%s stopped at the decision budget" label
+  | Ok (Round_robin.Finished _) -> Alcotest.failf "%s unexpectedly finished" label
+  | Error error -> Alcotest.failf "%s failed structurally: %s" label (Runtime_err.to_string error)
+
+let test_task_budget_prefix_strictly_replays () =
+  let store, ctx = Eval_support.make_prelude_ctx () in
+  let spawn =
+    expression store "(let nonrec (pwild) (app (var async.spawn) (lam () (lit 1))) (lit 0))"
+  in
+  let bounds = Round_robin.{ max_tasks = 1; max_decisions = 8 } in
+  let recorded_error, recorded_prefix =
+    Round_robin.run_expr_scheduled_attempt ctx ~bounds ~mode:Round_robin.Record_schedule spawn
+    |> task_stopped "record"
+  in
+  let replayed_error, replayed_prefix =
+    Round_robin.run_expr_scheduled_attempt ctx ~bounds
+      ~mode:(Round_robin.Replay_schedule recorded_prefix) spawn
+    |> task_stopped "strict replay"
+  in
+  Alcotest.(check string)
+    "strict replay reproduces the task-budget diagnostic"
+    (Runtime_err.to_string recorded_error)
+    (Runtime_err.to_string replayed_error);
+  Alcotest.(check string)
+    "strict replay reproduces byte-identical stopped prefix"
+    (Schedule_trace.serialize recorded_prefix)
+    (Schedule_trace.serialize replayed_prefix)
+
 let test_canonical_round_trip_and_identity () =
   let fork = Schedule_trace.{ decision = 2; chosen = root } in
   let trace = valid ~fork valid_events in
@@ -214,4 +258,6 @@ let suite =
     Alcotest.test_case "legacy, unknown, and noncanonical refusal" `Quick
       test_legacy_unknown_and_noncanonical_refused;
     Alcotest.test_case "impossible event refusal" `Quick test_impossible_events_refused;
+    Alcotest.test_case "task-budget prefix strictly replays" `Quick
+      test_task_budget_prefix_strictly_replays;
   ]


### PR DESCRIPTION
## Context

A scheduler run can stop because its task budget is exhausted. Jacquard keeps the decisions reached before that stop as a canonical prefix so exhaustive search can inspect or fork it.

The task-limit prefix was canonical but could not be strictly replayed. Recording observed an `async.spawn` decision, validated the attempted child creation, and then discovered that the task budget was already full. The snapshot kept the decision but dropped that in-flight creation. Replaying the saved prefix therefore reached the same spawn and failed with “unexpected creation after trace EOF” instead of reproducing the task-budget stop.

This is a scheduler correctness repair. It does not change Jacquard source syntax, evaluator results, scheduling choices, trace format, or release identity.

## What changed

- Split task allocation into a budget preflight and a mutation step.
- Apply the same preflight to child spawns and nested-scope root creation.
- Refuse an over-budget creation before recording a `Create` event or mutating task counts.
- Continue validating allowed creations before allocation state changes.
- Make prefix snapshots retain any creations that were already validated during an in-flight decision, in canonical `Decide` then `Create` order.
- Add an end-to-end regression that records a real task-budget stop, strictly replays it with the same bounds, and requires the same diagnostic and byte-identical prefix.
- Update the mechanically checked successor test inventory from 826 to 827 and the schedule-trace group count from 3 to 4.

## Why it was done this way

A trace whose header says `max-tasks=1` cannot legally contain a second task creation. Adding the refused child to the prefix would make the trace fail its own canonical validator.

The scheduler instead checks the same task limit at the same point in record and replay modes. Both runs now observe the spawn, refuse it before creation, and return the same canonical stopped prefix. Allowed creations still keep the stronger replay rule: validate the exact expected creation before mutating allocation state.

The snapshot helper also now preserves genuinely validated in-flight creations, so its partial trace uses the same event order as a completed decision.

## Semantic contract

- An over-budget spawn or nested scope records no creation and allocates nothing.
- An allowed creation is replay-validated before allocation mutation.
- Committed event order remains `Decide -> Create`.
- Strict replay with identical bounds reproduces the same task-limit refusal and byte-identical prefix.
- Existing fork ordering and exhaustive-search behavior remain unchanged.

## Deliberately excluded

- No schedule format or version change.
- No `HASH_V0`, canonical program identity, or cache-key change.
- No scheduler-choice, task-bound, evaluator, kernel, `.jac`, or `.jqd` semantic change.
- No native-runtime behavior change.
- No historical release manifest bytes were rewritten.

## How it was checked

- Regression-first failure reproduced the old drift: `unexpected creation of 0#1 after trace EOF`.
- Focused suites passed: 4 schedule-trace cases, 1 round-robin case, and 8 exhaustive-schedule cases.
- Final forced full suite passed all 827 Alcotest/QCheck cases in 339.790 seconds, plus all cram transcripts and 27 doctest examples.
- Forced GM12B forwarding evidence passed 50,000 exhaustive cases with zero failures, skips, or refusals.
- Full build, documentation build, runtime checks, formatting, whitespace, version smoke, and installer smoke passed.
- The production historical-publication gate verified all 35 registered publications and rejected manifest drift, missing/unregistered entries, coordinated deletion, and checker-policy weakening.
- GPT-5.6 Sol xhigh independently reviewed exact head `123d0694d617b69d2038e2d9dbbc8de36cfbf6cb` against base `3522906a50e2d83bb5783d829a9262f3d159deab` and returned **PASS** with no blocking or nonblocking findings.

## Risks and follow-ups

The regression directly covers the `async.spawn` task-limit path. Nested `async.scope` uses the same preflight implementation and its existing global-bound tests remain green, but it does not yet have a symmetric stopped-prefix replay case. The private controller’s in-flight creation snapshot behavior is straightforward and reviewed, but it does not have a direct controller-level unit test because that module is intentionally outside the public test boundary. These are evidence-depth follow-ups, not known behavior defects.
