### PR TITLE
Make channel deadlock diagnostics describe the real trigger

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -968,11 +968,12 @@ results, or deadlock detection. Jacquard scopes select fail-fast:
 - Collect does not cancel siblings or implicitly close a channel when one child
   fails. Other children may continue to communicate and their results remain in
   creation order;
-- under either policy, if every remaining live task is channel-blocked and no
-  channel transition is possible, the scheduler reports deadlock E0908. In
-  particular, fail-fast has no failure to prefer in this state; Collect cannot
-  return a partial aggregate. Deadlock never implies an implicit close. Cleanup
-  removes waiters and destroys continuations;
+- under either policy, if every remaining live task is suspended and at least
+  one is channel-blocked, the scheduler reports deadlock E0908. The other
+  suspended tasks may be waiting for tasks or nested scopes. In particular,
+  fail-fast has no failure to prefer in this state; Collect cannot return a
+  partial aggregate. Deadlock never implies an implicit close. Cleanup removes
+  waiters and destroys continuations;
 - explicit close while the scope is active uses §8.3 regardless of policy;
 - final scope destruction closes owned channels in creation order, removes any
   waiter before destroying its Once continuation, and drops undrained buffered
@@ -999,8 +1000,9 @@ SC.14 is conforming only if all of the following remain true:
   double continuation consumption;
 - [x] exact run/scope ownership, recursive escape scans, hostile callback
   revalidation, and deterministic ChannelId creation;
-- [x] fail-fast cancellation, OCaml Collect non-interference, policy-independent
-  all-channel-blocked E0908 refusal, and exception-safe teardown;
+- [x] fail-fast cancellation, OCaml Collect non-interference, the
+  policy-independent all-suspended/at-least-one-channel-blocked E0908 refusal,
+  and exception-safe teardown;
 - [x] rendezvous and buffered contract traces plus positive/negative checker
   fixtures.
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -698,8 +698,9 @@ idempotent drain-on-close. Cancellation is delivered before channel mutation
 and removes a blocked waiter without reordering survivors. Handles are exact
 run/scope capabilities and escape or parent/descendant use is E0907.
 Fail-fast removes channel-blocked siblings through cancellation; collect does
-not cancel or auto-close. Under either policy, an all-channel-blocked live set
-with no possible transition is E0908; fail-fast has no failure to prefer.
+not cancel or auto-close. Under either policy, if every live task is suspended
+and at least one is channel-blocked, the state is E0908; fail-fast has no
+failure to prefer.
 
 `corpus/channel/rendezvous-v1.trace` and
 `corpus/channel/buffered-v1.trace` pin exact abstract states, results, and wake

--- a/src/round_robin.ml
+++ b/src/round_robin.ml
@@ -932,7 +932,8 @@ let run_state_global ctx ~policy ~bounds ~program ~schedule_mode ~allow_routed i
           Error
             [
               scheduler_diagnostic
-                "async deadlock: all remaining live tasks are blocked on channels";
+                "async deadlock: all remaining live tasks are suspended and at least one is \
+                 blocked on a channel";
             ]
       | [] -> Ok ()
       | _ when !sequence >= bounds.max_decisions ->

--- a/test/test_effect_taxonomy.ml
+++ b/test/test_effect_taxonomy.ml
@@ -1173,7 +1173,7 @@ let test_channel_interface_hash_contract () =
       "blocked-receiver cancellation and close";
       "blocked-sender cancellation, survivor order";
       "exact run/scope ownership";
-      "policy-independent all-channel-blocked E0908 refusal";
+      "policy-independent all-suspended/at-least-one-channel-blocked E0908 refusal";
       "actors, mailboxes, links, monitors, supervision";
     ]
 

--- a/test/test_round_robin.ml
+++ b/test/test_round_robin.ml
@@ -714,8 +714,10 @@ let test_scoped_channels_run_end_to_end_without_world_allowance () =
   (match Round_robin.run_expr ctx blocked with
   | Error (Runtime_err.Scheduler_error message) ->
       Alcotest.(check string)
-        "all-channel-blocked deadlock"
-        "async deadlock: all remaining live tasks are blocked on channels" message
+        "channel-including suspended deadlock"
+        "async deadlock: all remaining live tasks are suspended and at least one is blocked on a \
+         channel"
+        message
   | Error error -> Alcotest.failf "wrong channel deadlock error: %s" (Runtime_err.to_string error)
   | Ok value -> Alcotest.failf "channel deadlock returned %s" (Value.show value));
   let fail_fast_source =

--- a/test/test_structured_scope.ml
+++ b/test/test_structured_scope.ml
@@ -355,6 +355,31 @@ let opened_channel scope capacity =
   | Structured_scope.Channel_invalid_capacity rejected ->
       Alcotest.failf "capacity %d unexpectedly rejected" rejected
 
+let test_channel_deadlock_accepts_mixed_suspensions () =
+  let scope, receiver = Structured_scope.create ~body_resume:10 |> ok in
+  let channel = opened_channel scope 0 in
+  (match
+     Structured_scope.with_checkout scope receiver (fun resume ->
+         Structured_scope.channel_recv scope ~task:receiver ~channel ~resume
+           ~map_resume:map_channel_resume)
+     |> ok
+   with
+  | Structured_scope.Channel_suspended -> ()
+  | Structured_scope.Channel_continues _ -> Alcotest.fail "rendezvous receiver did not suspend");
+  let yielded = Structured_scope.spawn scope ~resume:20 |> ok in
+  Structured_scope.with_checkout scope yielded (fun resume ->
+      Structured_scope.suspend_yield scope yielded ~resume)
+  |> ok;
+  Alcotest.(check bool)
+    "one channel wait plus another suspension is deadlocked" true
+    (Structured_scope.channel_deadlocked scope);
+  Structured_scope.wake_yielded scope yielded |> ok;
+  Alcotest.(check bool)
+    "a runnable task prevents deadlock" false
+    (Structured_scope.channel_deadlocked scope);
+  Structured_scope.close scope ~reason:Structured_scope.Normal ~escaping:[] ~drop:ignore |> ok;
+  check_zero_metrics "mixed channel deadlock close" scope
+
 let test_scoped_channel_ownership_and_cancellation () =
   let scope, body = Structured_scope.create ~body_resume:10 |> ok in
   (match Structured_scope.channel_open scope ~capacity:(-1) |> ok with
@@ -683,6 +708,7 @@ let run () =
   test_cleanup_exception_precedence ();
   test_checkout_bracket_restores_error_and_exception ();
   test_dynamic_escape_graph_scan ();
+  test_channel_deadlock_accepts_mixed_suspensions ();
   test_scoped_channel_ownership_and_cancellation ();
   test_closed_channel_remains_live_until_scope_teardown ();
   test_channel_transition_preflight_is_atomic ();


### PR DESCRIPTION
## Context

Jacquard reports E0908 when the deterministic scheduler has no runnable task
and the scope cannot make progress because channel work is involved. The old
message said every remaining task was blocked on a channel.

That was narrower than the real rule. The scheduler also reports this state
when one task is waiting on a channel and the other live tasks are suspended
for another reason, such as waiting for a task or a nested scope. The behavior
was correct, but the diagnostic and current documentation could mislead
someone debugging a mixed wait.

## What changed

- Reworded the E0908 message to say: `all remaining live tasks are suspended
  and at least one is blocked on a channel`.
- Updated the normative concurrency guide and current successor evidence to
  state the same condition.
- Updated the exact-message regression.
- Added a direct regression with one channel receiver and one yielded task. It
  proves that the mixed suspended state is deadlocked and that making the
  yielded task runnable clears the predicate.
- Updated the documentation assertion that keeps the release checklist in
  sync.

## Why it was done this way

The runtime predicate already matched the intended scheduler contract, so this
change corrects the explanation instead of changing scheduling behavior. The
new wording tells a reader both facts the runtime actually knows: every live
task is suspended, and at least one suspension is a channel wait.

The mixed-state regression is at the structured-scope boundary where the
predicate is observable. The existing end-to-end scheduler regression still
pins the exact public E0908 message.

## Semantic contract

- E0908 is reported at an empty runnable queue only when the scope is open,
  at least one live task remains, every live task is suspended, and at least
  one task is waiting to send or receive on a channel.
- Other suspended tasks may be waiting for tasks, yielded for a nested scope,
  or waiting for host readiness.
- The diagnostic code, domain, span behavior, cleanup, task ordering, scope
  policy, and deadlock predicate are unchanged.

## Deliberately excluded

- No scheduler, channel, cleanup, or policy behavior change.
- No kernel, surface syntax, prelude, native runtime, trace, cache, or hash
  change.
- No rewrite of historical release manifests or historical evidence bytes.
- No new corpus program because the only public behavior change is stable
  diagnostic text, pinned directly by unit coverage.

## How it was checked

- The exact-message regression failed first against the old runtime text.
- Focused `round-robin`, `structured-scope`, and `effect-taxonomy` suites
  passed after the correction.
- Fresh GPT-5.6 Sol xhigh independent review passed exact commit
  `52f9c154de7ea4eb4f256239222d9ff7e551a093` with no blockers or architecture
  conflict.
- `dune build @all @doc` passed.
- The forced full suite passed all 827 compiled/property tests in 344.342
  seconds, plus every command-line transcript and all 27 documentation
  examples.
- Temporary-storage policy, installer smoke, formatting cleanliness, version
  `0.1.0`, release-file presence, and whitespace checks passed.
- All 35 historical publications and the complete manifest mutation battery
  passed.
- The forced GM12B forwarding proof passed all 50,000 cases with zero
  failures, skips, or refusals.

## Risks and follow-ups

The changed diagnostic text is intentional and may affect consumers that
match the full message instead of the stable E0908 code. The exact public
message is now pinned.

Additional direct cases for every suspension variant would add evidence, but
the unchanged predicate is already covered by the mixed-yield regression and
was independently reviewed. No correctness follow-up is required for this
slice.
