### PR TITLE
Check scope liveness before channel capacity

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -851,8 +851,9 @@ this order before the transition table below:
 1. deliver a pending cancellation for the chosen task before inspecting
    capacity or handle state; the task becomes `Cancelled`, no Channel result is
    produced, and no Channel continuation or state is mutated;
-2. for `open`, reject negative capacity with the typed result above, then check
-   the native ChannelId bounds before allocation (E0908 on exhaustion);
+2. for `open`, require that the OCaml scope seam is still open (E0907 if it is
+   closed), reject negative capacity with the typed result above, then check the
+   native ChannelId bounds before allocation (E0908 on exhaustion);
 3. for `send`, `recv`, and `close`, validate the opaque carrier's evaluator run,
    exact current open scope, and live channel ownership recursively; failure is
    E0907 before consuming the Once continuation or inspecting closed/buffered

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -691,16 +691,17 @@ visible in the outward row until scheduler admission or an ordinary language
 handler intercepts it.
 
 Capacity zero is rendezvous; a positive capacity is bounded FIFO; a negative
-capacity returns typed `InvalidCapacity` before allocation. The contract fixes
-oldest-waiter pairing, bounded backpressure, buffer-first receive with sender
-promotion, counterpart-before-current wake order, deterministic fan-in, and
-idempotent drain-on-close. Cancellation is delivered before channel mutation
-and removes a blocked waiter without reordering survivors. Handles are exact
-run/scope capabilities and escape or parent/descendant use is E0907.
-Fail-fast removes channel-blocked siblings through cancellation; collect does
-not cancel or auto-close. Under either policy, if every live task is suspended
-and at least one is channel-blocked, the state is E0908; fail-fast has no
-failure to prefer.
+capacity returns typed `InvalidCapacity` before allocation while the scope is
+live. A direct OCaml-library call after scope teardown returns E0907 before
+capacity validation. The contract fixes oldest-waiter pairing, bounded
+backpressure, buffer-first receive with sender promotion,
+counterpart-before-current wake order, deterministic fan-in, and idempotent
+drain-on-close. Cancellation is delivered before channel mutation and removes
+a blocked waiter without reordering survivors. Handles are exact run/scope
+capabilities and escape or parent/descendant use is E0907. Fail-fast removes
+channel-blocked siblings through cancellation; collect does not cancel or
+auto-close. Under either policy, if every live task is suspended and at least
+one is channel-blocked, the state is E0908; fail-fast has no failure to prefer.
 
 `corpus/channel/rendezvous-v1.trace` and
 `corpus/channel/buffered-v1.trace` pin exact abstract states, results, and wake

--- a/src/structured_scope.ml
+++ b/src/structured_scope.ml
@@ -96,9 +96,9 @@ let task_handle capability scope value =
 let channel_run scope = Scheduler_core.task_run Task_capability.runtime scope.scheduler
 
 let channel_open scope ~capacity =
-  if capacity < 0 then Ok (Channel_invalid_capacity capacity)
-  else
-    ensure_open scope (fun () ->
+  ensure_open scope (fun () ->
+      if capacity < 0 then Ok (Channel_invalid_capacity capacity)
+      else
         let open_index = scope.next_channel in
         match
           Channel_contract.open_channel ~scope_path:(scope_path scope) ~open_index ~capacity

--- a/src/structured_scope.mli
+++ b/src/structured_scope.mli
@@ -95,10 +95,10 @@ val task_handle :
 
 val channel_open : ('resume, 'value) t -> capacity:int -> (channel_open_outcome, Diag.t list) result
 (** [channel_open] allocates the next zero-based successful-open identity in this exact open scope.
-    A negative capacity returns [Channel_invalid_capacity] before identity allocation. A closed
-    scope returns E0907 and native ChannelId exhaustion returns E0908 without allocation. Trusted
-    scheduler code must establish the routed cancellation boundary before calling this lower seam.
-*)
+    A closed scope returns E0907 before capacity validation. In an open scope, a negative capacity
+    returns [Channel_invalid_capacity] before identity allocation. Native ChannelId exhaustion
+    returns E0908 without allocation. Trusted scheduler code must establish the routed cancellation
+    boundary before calling this lower seam. *)
 
 val channel_value :
   Task_capability.t -> ('resume, 'value) t -> channel_handle -> (Value.t, Diag.t list) result

--- a/test/test_structured_scope.ml
+++ b/test/test_structured_scope.ml
@@ -638,7 +638,10 @@ let test_channel_open_refusal_domains () =
   Structured_scope.close exhausted ~reason:Structured_scope.Normal ~escaping:[] ~drop:ignore |> ok;
   Alcotest.(check string)
     "closed scope is not invalid capacity" "E0907"
-    (Structured_scope.channel_open exhausted ~capacity:1 |> error_code)
+    (Structured_scope.channel_open exhausted ~capacity:1 |> error_code);
+  Alcotest.(check string)
+    "closed scope liveness precedes negative capacity" "E0907"
+    (Structured_scope.channel_open exhausted ~capacity:(-1) |> error_code)
 
 let test_channel_closer_mapper_and_live_registry_preflight () =
   let scope, body = Structured_scope.create ~body_resume:1 |> ok in


### PR DESCRIPTION
## Context

Jacquard's structured-concurrency library promises that operations on a scope
after teardown fail with E0907. `Structured_scope.channel_open` checked a
negative capacity before it checked whether the scope was still open, though.
As a result, a direct OCaml caller could ask a closed scope to open a
negative-capacity channel and receive the ordinary typed `InvalidCapacity`
result instead of the stale-scope diagnostic.

Scheduler-routed Jacquard code cannot reach this state because tasks do not run
after their scope closes. The mismatch still mattered for the public OCaml
library contract: an invalid lifetime should not be mistaken for a valid
operation with a bad argument.

## What changed

- Moved the open-scope guard around the complete capacity and channel-identity
  path in `Structured_scope.channel_open`.
- Added a regression proving that closed scope plus negative capacity returns
  E0907.
- Kept the existing live-scope negative-capacity result and all 12 channel
  contract cases unchanged.
- Clarified the ordering in the public module contract, normative concurrency
  documentation, and current structured-concurrency successor evidence.

## Why it was done this way

The smallest correction is to enforce ownership/lifetime validity at the
library boundary before inspecting an operation argument. That makes
`channel_open` consistent with the other closed-scope operations and with the
published E0907 promise, without adding a second error type or changing the
language-level Channel interface.

The regression extends the existing refusal-domain test so E0907, typed
`InvalidCapacity`, and E0908 remain visibly separate outcomes.

## Semantic contract

The ordering is:

1. A pending cancellation wins at the scheduler routing boundary.
2. The OCaml scope must still be open; otherwise the operation returns E0907.
3. A live scope maps negative capacity to typed `InvalidCapacity` without
   consuming a channel identity.
4. ChannelId exhaustion returns E0908 without allocation.
5. Only then may a successful channel be allocated and registered.

Successful opens, ChannelId order, FIFO/backpressure, close, cancellation,
scope ownership, and channel state transitions are unchanged.

## Deliberately excluded

This PR does not change scheduler selection or routing, public Jacquard syntax,
the four Channel operations or their hashes, the 27-form kernel, HASH_V0,
trace/cache identity, native Channel execution, or frozen historical manifest
bytes.

## How it was checked

- Regression-first focused run failed on the old ordering and passed after the
  correction.
- Focused structured-scope suite passed.
- All 12 channel-contract cases passed.
- Independent GPT-5.6 Sol xhigh review passed on exact commit
  `15afe2b31795a1740c244902634e5ea8ccb0ee81` with no findings or architecture
  conflicts.
- The exact committed-head historical gate verified all 35 registered
  publications and rejected the full manifest mutation battery.
- `dune build @all @doc` passed.
- The forced full Dune suite passed all 827 compiled/property tests in
  348.554 seconds, every cram transcript, and all 27 documentation examples.
- Formatting, whitespace, version, release-file, temporary-storage, and
  Linux installer/package smoke checks passed.
- The forced 50,000-case GM12B proof passed with zero failures, skips, or
  refusals.

## Risks and follow-ups

The only compatibility change affects direct OCaml callers performing an
already-invalid open on a closed scope with a negative capacity. They now see
the documented E0907 lifetime failure instead of an ordinary typed argument
error. No follow-up debt is known.
