### PR TITLE
docs: reconcile effect taxonomy successor status

### DIFF
--- a/docs/effect-linearity.md
+++ b/docs/effect-linearity.md
@@ -166,17 +166,25 @@ each `DefEffect` declaration. The shipped assignments are:
 
 | mode | blessed operations |
 |------|--------------------|
-| `once` | `Eval.eval-code`; `Abort.abort`; `Throw.throw`; `Emit.emit`; `Console.print`, `Console.read-line`; `Clock.now`, `Clock.sleep`; `Net.fetch`; `Fs.read`, `Fs.write`, `Fs.list-dir`; `Infer.complete` |
+| `once` | `Eval.eval-code`; `Abort.abort`; `Throw.throw`; `Emit.emit`; `Console.print`, `Console.read-line`; `Clock.now`, `Clock.sleep`; `Net.fetch`; `Fs.read`, `Fs.write`, `Fs.list-dir`; `Infer.complete`; `Async.async.spawn`, `Async.async.await`, `Async.async.cancel`, `Async.async.yield`; `Channel.channel.open`, `Channel.channel.send`, `Channel.channel.recv`, `Channel.channel.close`; `Audit.record`; `Approval.ask`; `GovernanceApprovalV1.governance-approval.ask`; `Secret.read`, `Secret.expose`; `Judge.assess`; `Workspace.read-file`, `Workspace.write-file`, `Workspace.fetch` |
 | `multi` | `State.get`, `State.put`; `Dist.sample`, `Dist.observe`; `Check.check`, `Check.fail`; `Fault.flaky` |
 
 State and Check are deliberate Multi exceptions. Their shipped handlers use
 pure continuation capture: State implements its function-of-state transformer,
 and Check composes reporting across generated worlds. This does not grant world
 authority. `Fault` remains multi because its handlers deliberately explore
-alternate failure worlds. Choose and other search effects are likewise multi when added. Pg,
-Blob, Serve, Crypto, Log, Approval, Audit, Secret, and future Async and Channel
-operations must be once. No such effect is currently shipped in the bootstrap
-prelude, so they are a review rule rather than invented manifest rows.
+alternate failure worlds. Choose and other search effects are likewise multi
+when added.
+
+`Approval`, `Audit`, `Secret`, `Judge`, and `Channel` are shipped `once`
+effects. `Async` keeps its reserved taxonomy status while its interpreted
+scheduler is shipped; its four operations are also `once`. The declarations
+and the reviewed manifest agree on all of these modes.
+
+`Choose`, `Env`, `Pg`, `Blob`, `Serve`, `Crypto`, and `Log` remain reserved and
+unimplemented. Their taxonomy modes are compatibility promises for a future
+implementation, not invented executable prelude rows: `Choose` is `multi`,
+while the other six are `once`.
 
 Almost everything is `once`. Multi-shot is the rare, deliberate search
 mechanism, and the type system records that distinction.

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `827`
+- Alcotest/QCheck cases: `828`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 

--- a/docs/release/effect-taxonomy/ET8-EVIDENCE.md
+++ b/docs/release/effect-taxonomy/ET8-EVIDENCE.md
@@ -1,16 +1,27 @@
 # Effect Taxonomy ET.8 Evidence
 
-Status: pre-commit ET.8 candidate overlay on integration commit `3591bc0`.
-The manifest makes the overlay reconstructible, but the final release
-reproduction is intentionally pending until the overlay has its own commit
-identity.
+Status: historical ET.8 publication record. Its retained manifest is immutable
+and is verified at the publication commit registered in
+`scripts/release/historical-publications.tsv`.
 
 ET.8 closes the taxonomy slice without changing a prelude declaration,
-operation schema, canonical interface hash, or runtime behavior. The frozen
-inventory contains 25 blessed names: 15 released identities and 10
-reserved/unimplemented schemas. The exact released hashes are recorded in
-`docs/effect-review.md` and checked against the taxonomy TSV, Markdown table,
-effect registry, and loaded prelude.
+operation schema, canonical interface hash, or runtime behavior. At the ET.8
+publication point, the inventory contained 25 blessed names: 15 released
+identities and 10 reserved/unimplemented schemas. The exact released hashes
+were recorded in `docs/effect-review.md` and checked against the taxonomy TSV,
+Markdown table, effect registry, and loaded prelude.
+
+## Current successor status
+
+The current v1 successor has 18 implemented effects. In particular,
+`Workspace`, `Judge`, and `Channel` are implemented. `Async` remains
+taxonomy-reserved with a published identity and interpreted scheduler. The
+seven remaining reserved names—`Choose`, `Env`, `Pg`, `Blob`, `Serve`,
+`Crypto`, and `Log`—are unimplemented.
+
+This successor status does not rewrite what ET.8 published. The historical
+manifest continues to attest the original bytes at its registered publication
+commit, while this prose tells readers what is true in the current tree.
 
 ## Review contract
 
@@ -23,22 +34,24 @@ effect registry, and loaded prelude.
   can provide the consent represented by that protocol.
 - Secret opacity is not taint tracking. `secret.expose` returns ordinary
   `Text`, which can subsequently be copied or leaked.
-- `Choose`, `Env`, `Pg`, `Blob`, `Serve`, `Crypto`, `Log`, `Judge`, `Async`,
-  and `Channel` are reserved and unimplemented. They have no released hash,
-  handler, root grant, product-availability claim, or roadmap commitment.
+- At the ET.8 publication point, `Choose`, `Env`, `Pg`, `Blob`, `Serve`,
+  `Crypto`, `Log`, `Judge`, `Async`, and `Channel` formed the ten-item
+  reserved/unimplemented set. That historical status made no handler, root
+  grant, product-availability claim, or roadmap commitment.
 
-The canonical handler inventory covers all 15 released effects. Executable
-checks require every named Jacquard handler to resolve in the loaded prelude
-and require the eight documented root boundaries to equal
+The ET.8 canonical handler inventory covered all 15 effects released at that
+publication point. Its executable checks required every named Jacquard handler
+to resolve in the loaded prelude and required the eight documented root
+boundaries to equal
 `Prelude.grantable_names`: Clock, Console, Dist, Eval, Fs, Infer, Net, and
 Secret. Approval, Audit, and Secret retain their separately evidenced boundary
 contracts; ET.8 does not add a membrane, object-capability sandbox, continuous
 distribution support, verified model truth, or automatic consent.
 
-## Machine and CLI evidence
+## Historical machine and CLI evidence
 
-The existing `effect-taxonomy` suite now fails if any of these projections
-drift:
+At ET.8, the `effect-taxonomy` suite failed if any of these projections
+drifted:
 
 - the TSV and Markdown name, tier, parameters, mode, risk, ring, status,
   operation, meaning, and exact released-hash fields;
@@ -48,7 +61,7 @@ drift:
   identities and requiring their deterministic canonical prelude names;
 - released declaration identities, type-parameter lists, operation names and
   modes, and rings;
-- the exact 15-item handler/boundary inventory and 10-item reserved set;
+- the then-exact 15-item handler/boundary inventory and 10-item reserved set;
 - the exact hash ledger and required risk, uncertainty, Secret, and non-goal
   wording in the review, taxonomy, stdlib, and tutorial documentation.
 
@@ -64,33 +77,25 @@ The focused stale-hash regression changes Net's TSV parameter schema from
 schema comparison rejects it. Coordinated TSV/Markdown drift can therefore no
 longer pass merely because it leaves a stale hash field untouched.
 
-ET.8 adds that regression to the existing `effect-taxonomy` suite without
-adding a cram file. The candidate inventory is 631 compiled Alcotest/QCheck
+ET.8 added that regression to the existing `effect-taxonomy` suite without
+adding a cram file. Its candidate inventory was 631 compiled Alcotest/QCheck
 cases and 35 cram transcript files.
 
 ## Reproduction
 
+From a current successor checkout, verify ET.8 and the other retained
+publication manifests with the historical-publication gate:
+
 ```sh
-eval "$(opam env)"
-mkdir -p "$PWD/.scratch/tmp"
-export TMPDIR="$PWD/.scratch/tmp"
-opam exec -- dune build @all
-opam exec -- dune runtest --force
-opam exec -- dune fmt
-opam exec -- dune build @doc
-ET8_COMMIT=$(git rev-parse HEAD)
-JACQUARD_RELEASE_REF="$ET8_COMMIT" \
-  JACQUARD_RELEASE_OUT="$PWD/.scratch/release/et8" \
-  scripts/release/reproduce-0.1.sh
-test "$(cat .scratch/release/et8/commit.txt)" = \
-  "$(git rev-parse --short "$ET8_COMMIT")"
-sha256sum -c docs/release/effect-taxonomy/ET8-MANIFEST.sha256
+scripts/release/check-historical-manifests.sh \
+  --commit "$(git rev-parse HEAD)" \
+  --require-history
 ```
 
-Run the release script only after committing the complete ET.8 overlay. A run
-whose `commit.txt` still records the base `3591bc0` validates the base plus a
-dirty working tree, not a release-addressable ET.8 artifact, and is not final
-ET.8 reproduction evidence.
+That gate reconstructs the registered publication tree before checking
+`ET8-MANIFEST.sha256`. Do not regenerate the retained manifest from current
+successor files: a direct `sha256sum -c` in today's checkout would compare
+different publication states.
 
 The ET.2 through ET.7 evidence packs remain historical and unchanged. The ET.8
-manifest attests only this documentation-and-checking overlay on `3591bc0`.
+manifest attests only its registered historical publication.

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 827 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 828 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `827`
+- Alcotest/QCheck cases: `828`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled

--- a/test/dune
+++ b/test/dune
@@ -120,6 +120,7 @@
   ../README.md
   ../docs/errors.md
   ../docs/effect-review.md
+  ../docs/effect-linearity.md
   ../docs/effect-membranes.md
   ../docs/client-playground.md
   ../docs/effect-taxonomy.md
@@ -132,6 +133,7 @@
   ../docs/release/structured-concurrency/EVIDENCE.md
   ../docs/release/structured-concurrency/LIMITS.md
   ../docs/release/structured-concurrency/MANIFEST.sha256
+  ../docs/release/effect-taxonomy/ET8-EVIDENCE.md
   ../demos/README.md
   (source_tree ../demos/concurrency)
   ../docs/release/dx-jac-export/EVIDENCE.md

--- a/test/test_effect_taxonomy.ml
+++ b/test/test_effect_taxonomy.ml
@@ -8,6 +8,8 @@ let review_doc = "../docs/effect-review.md"
 let stdlib_doc = "../docs/stdlib.md"
 let tutorial_doc = "../docs/tutorial.md"
 let concurrency_doc = "../docs/concurrency.md"
+let linearity_doc = "../docs/effect-linearity.md"
+let et8_evidence_doc = "../docs/release/effect-taxonomy/ET8-EVIDENCE.md"
 let schema_fixture = "docs-doctest/fixtures/effect-taxonomy-schemas.jac"
 let approval_fixture = "docs-doctest/fixtures/stdlib-handler-policy.jac"
 let channel_effect_hash = "bf9a334188ac13495eeb070fdc215d51763d9761b4775c98c61f44ebb1b03756"
@@ -2237,6 +2239,63 @@ let test_governance_contracts () =
   test_governance_and_links ();
   test_governed_membrane_charter ()
 
+let test_successor_status_docs () =
+  let linearity = Corpus_support.read_file linearity_doc |> normalize_whitespace in
+  let et8 = Corpus_support.read_file et8_evidence_doc |> normalize_whitespace in
+  List.iter
+    (fun phrase ->
+      Alcotest.(check bool)
+        ("effect-linearity successor status: " ^ phrase)
+        true
+        (contains_string linearity phrase))
+    [
+      "`Approval`, `Audit`, `Secret`, `Judge`, and `Channel` are shipped `once` effects";
+      "`Async` keeps its reserved taxonomy status while its interpreted scheduler is shipped";
+      "`Choose`, `Env`, `Pg`, `Blob`, `Serve`, `Crypto`, and `Log` remain reserved and \
+       unimplemented";
+      "`Audit.record`; `Approval.ask`";
+      "`Secret.read`, `Secret.expose`; `Judge.assess`";
+      "`Workspace.read-file`, `Workspace.write-file`, `Workspace.fetch`";
+    ];
+  Alcotest.(check bool)
+    "effect-linearity no longer claims every listed effect is unshipped" false
+    (contains_string linearity "No such effect is currently shipped in the bootstrap prelude");
+  List.iter
+    (fun stale ->
+      Alcotest.(check bool)
+        ("effect-linearity rejects double-qualified operation " ^ stale)
+        false (contains_string linearity stale))
+    [
+      "Audit.audit.record";
+      "Approval.approval.ask";
+      "Secret.secret.read";
+      "Secret.secret.expose";
+      "Judge.judge.assess";
+      "Workspace.workspace.read-file";
+      "Workspace.workspace.write-file";
+      "Workspace.workspace.fetch";
+    ];
+  List.iter
+    (fun phrase ->
+      Alcotest.(check bool) ("ET.8 successor status: " ^ phrase) true (contains_string et8 phrase))
+    [
+      "At the ET.8 publication point, the inventory contained 25 blessed names: 15 released \
+       identities and 10 reserved/unimplemented schemas";
+      "The current v1 successor has 18 implemented effects";
+      "`Workspace`, `Judge`, and `Channel` are implemented";
+      "`Async` remains taxonomy-reserved with a published identity and interpreted scheduler";
+      "The seven remaining reserved names—`Choose`, `Env`, `Pg`, `Blob`, `Serve`, `Crypto`, and \
+       `Log`—are unimplemented";
+      "At ET.8, the `effect-taxonomy` suite failed if any of these projections drifted";
+      "scripts/release/check-historical-manifests.sh \\ --commit \"$(git rev-parse HEAD)\" \\ \
+       --require-history";
+    ];
+  Alcotest.(check bool)
+    "ET.8 no longer presents its historical reserved set as current" false
+    (contains_string et8
+       "`Choose`, `Env`, `Pg`, `Blob`, `Serve`, `Crypto`, `Log`, `Judge`, `Async`, and `Channel` \
+        are reserved and unimplemented")
+
 let suite =
   [
     Alcotest.test_case "complete machine contract" `Quick test_complete_contract;
@@ -2255,4 +2314,5 @@ let suite =
       test_unknown_identity_is_uncolored_and_unblessed;
     Alcotest.test_case "registry ordering stable" `Quick test_registry_order_is_stable;
     Alcotest.test_case "taxonomy v2 is additive" `Quick test_taxonomy_v2_is_additive;
+    Alcotest.test_case "successor status docs" `Quick test_successor_status_docs;
   ]


### PR DESCRIPTION
## Context

The current documentation described two different effect taxonomies.
`docs/effect-linearity.md` said that Approval, Audit, and Secret were not
shipped, even though those effects—and Judge and Channel—are implemented in the
current prelude. The ET.8 evidence page also presented its old
15-released/10-reserved inventory as if it were still current.

That contradiction could make a reviewer miss real outside-world or governance
effects in a function signature. It also made the ET.8 reproduction directions
misleading: retained manifests describe a historical publication tree, so they
must not be regenerated or checked directly against today's successor files.

This PR corrects documentation and regression coverage only. It does not change
the language, runtime, prelude, taxonomy rows, effect modes, hashes, command
line, or release contract.

## What changed

- Updated the effect-linearity operation table to include the shipped
  governance, concurrency, Workspace, and additive governance operations with
  their exact declaration names.
- Stated the current status directly: 18 implemented effects, seven
  reserved/unimplemented schemas, and Async as taxonomy-reserved with a
  published identity and interpreted scheduler.
- Reframed ET.8's 15-released/10-reserved inventory as its historical
  publication snapshot, while adding a separate current-successor section.
- Replaced the obsolete current-tree checksum procedure with the exact
  history-backed reconstruction command, including its required commit and
  full-history arguments.
- Added a mutation-sensitive taxonomy regression that pins the corrected
  statuses, exact operation spellings, historical tense, and runnable
  reconstruction command while rejecting the stale claims.
- Updated the two mechanically checked current test inventories from 827 to
  828 after adding that regression.

## Why it was done this way

Historical evidence and current documentation have different jobs. The
retained ET.8 manifest must continue to attest the exact bytes published at its
registered commit. Current successor prose must continue to tell readers what
the repository implements today.

The history gate already models that distinction by reconstructing the
publication commit before verifying its manifest. This PR documents and tests
that model instead of rewriting old manifest bytes or pretending today's files
still match an earlier snapshot.

## Semantic and evidence contract

- The current v1 taxonomy contains 18 implemented effects.
- Choose, Env, Pg, Blob, Serve, Crypto, and Log are the seven
  reserved/unimplemented schemas.
- Async remains taxonomy-reserved, with its exact published identity and
  interpreted scheduler.
- Approval, Audit, Secret, Judge, Channel, and Workspace are implemented; their
  documented operation names and modes match the current declarations.
- ET.8's historical publication state remains 15 released identities and 10
  reserved/unimplemented schemas.
- Every retained manifest and the historical-publication registry remain
  byte-identical.

## Deliberately excluded

- No effect declaration, operation mode, handler, scheduler, or runtime change.
- No HASH_V0 identity, taxonomy TSV, kernel form, public syntax, or diagnostic
  change.
- No manifest regeneration and no reinterpretation of historical evidence as a
  current-tree checksum.

## How it was checked

- Regression-first successor-status test failed against the old prose, then
  passed after the correction.
- All 12 focused effect-taxonomy cases passed.
- Full exact-head Dune gate passed all 828 Alcotest/QCheck cases, every cram
  transcript, native/runtime parity, 27 documentation examples across 8
  documents, and the readability protocol.
- Historical reconstruction passed for every registered publication; the
  mutation battery rejected manifest drift, missing/unregistered evidence,
  coordinated row deletion, and checker-policy weakening.
- Forced GM12B evidence passed all 50,000 exhaustive cases with zero failures,
  skips, or refusals.
- `dune build @all @doc`, formatting cleanliness, temporary-storage policy,
  version smoke, release-file presence, Linux installer/package, packaged
  demos, and the no-Dune native build all passed.
- GPT-5.6 Sol xhigh reviewed the exact final commit
  `bc22c2efc83c5cdfdf671b5631fdd94a7140bdbc` and returned PASS with no
  remaining findings.

## Risks and follow-ups

The change is documentation/test-only. The main maintenance risk is future
status drift; the new regression intentionally requires taxonomy, prelude,
current prose, and test inventory to move together. There is no deferred
current-scope debt.
