### PR TITLE
ci: schedule parser depth performance evidence

### DIFF
--- a/.github/workflows/parser-depth-performance.yml
+++ b/.github/workflows/parser-depth-performance.yml
@@ -1,0 +1,87 @@
+name: Parser depth performance
+
+on:
+  schedule:
+    - cron: "37 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: parser-depth-perf-${{ github.event_name == 'schedule' && 'scheduled' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'schedule' }}
+
+env:
+  OCAML_COMPILER: 5.1.1
+  JACQUARD_PRELUDE: ${{ github.workspace }}/prelude
+  TMPDIR: ${{ github.workspace }}/.scratch/tmp
+
+jobs:
+  dx6-parser-depth:
+    name: DX.6 parser-depth performance guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+
+      - name: Prepare temporary storage
+        run: |
+          mkdir -p "$TMPDIR"
+          scripts/check-temp-policy.sh
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3.6.1
+        with:
+          ocaml-compiler: ${{ env.OCAML_COMPILER }}
+
+      - name: Install dependencies
+        run: opam install --deps-only . --with-test -y
+
+      - name: Build
+        run: opam exec -- dune build @all
+
+      - name: Run parser-depth performance guard
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p .scratch/evidence/parser-depth-perf
+          scripts/parser-depth-perf.sh 2>&1 |
+            tee .scratch/evidence/parser-depth-perf/result.txt
+
+      - name: Summarize attestation
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## DX.6 parser-depth performance guard"
+            echo
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Canonical depth: \`100000\`"
+            echo "- Per-carrier deadline: \`10 seconds\`"
+            echo
+            if [[ -s .scratch/evidence/parser-depth-perf/result.txt ]]; then
+              while IFS= read -r line; do
+                printf -- '- `%s`\n' "$line"
+              done < .scratch/evidence/parser-depth-perf/result.txt
+            else
+              echo "- Guard produced no result transcript; inspect the failed setup or build step."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload parser-depth evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: parser-depth-performance-${{ github.run_number }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 30
+          include-hidden-files: true
+          path: |
+            .scratch/evidence/parser-depth-perf/result.txt
+            .scratch/parser-depth-perf/surface.stdout
+            .scratch/parser-depth-perf/surface.stderr
+            .scratch/parser-depth-perf/bootstrap.stdout
+            .scratch/parser-depth-perf/bootstrap.stderr

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -161,6 +161,44 @@ export TMPDIR="$PWD/.scratch/tmp"
 opam exec -- dune build @test/gm12b/gm12b-evidence --force
 ```
 
+## Parser Depth Performance Evidence
+
+Workflow: `.github/workflows/parser-depth-performance.yml`
+
+The `Parser depth performance / DX.6 parser-depth performance guard` job runs
+every day at 06:37 UTC and can also be started manually for a branch or tag. It
+is recurring performance evidence, not a required merge check or a portable
+benchmark, so it does not run on pull requests or pushes.
+
+The job builds Jacquard and runs `scripts/parser-depth-perf.sh` with its
+canonical defaults. At depth 100,000, each carrier has a 10-second deadline:
+
+- surface `.jac` input must exit with exactly one E1227 diagnostic;
+- bootstrap `.jqd` input must exit with exactly one E0115 diagnostic;
+- a timeout, E0003, `Stack_overflow`, internal error, extra diagnostic, or
+  unexpected exit status fails the job.
+
+Scheduled runs cancel an older scheduled run if they overlap. Manual runs have
+unique concurrency groups so one attestation cannot replace another. Each run
+records the exact commit and results in its job summary and retains the small
+result/stdout/stderr evidence files for 30 days.
+
+Run the workflow manually after parser, trivia ownership, structural-depth
+guard, or OCaml toolchain changes, and before a release candidate. A timing
+failure on a shared runner may be rerun manually once to distinguish host
+noise. Do not increase the canonical deadline merely to restore a green run;
+investigate the parser or runner evidence first.
+
+Local equivalent:
+
+```sh
+eval "$(opam env)"
+mkdir -p "$PWD/.scratch/tmp"
+export TMPDIR="$PWD/.scratch/tmp"
+opam exec -- dune build @all
+scripts/parser-depth-perf.sh
+```
+
 ## Release Evidence
 
 Workflow: `.github/workflows/release-evidence.yml`

--- a/docs/release/dx-parser-performance/EVIDENCE.md
+++ b/docs/release/dx-parser-performance/EVIDENCE.md
@@ -1,6 +1,7 @@
 # DX.6 Parser-depth performance evidence
 
-Status: opt-in release-hardening evidence based on merged DX.5/DX.7 main commit
+Status: scheduled/manual CI release-hardening evidence, opt-in locally. The
+historical measurements below are based on merged DX.5/DX.7 main commit
 `b75b7a951289745bc3c26633e5da4f6e139199a0`, which includes the SC.16 C0-C3
 stack.
 
@@ -59,7 +60,10 @@ The script generates both hostile sources under `.scratch/parser-depth-perf/`,
 runs `jacquard check` under a wall-clock deadline, and requires carrier-specific
 diagnostics. It rejects timeouts, the E0003 host-stack backstop, `Stack_overflow`,
 or an internal error. It is intentionally not part of `dune runtest`: wall-clock
-checks are opt-in performance evidence, not deterministic semantic tests.
+checks are recurring scheduled/manual performance evidence, not deterministic
+per-change semantic tests. `.github/workflows/parser-depth-performance.yml`
+runs the canonical check daily and on manual dispatch without adding pull
+request latency.
 
 Useful overrides:
 

--- a/scripts/parser-depth-perf.sh
+++ b/scripts/parser-depth-perf.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eu
 
-# DX.6 opt-in performance guard. This is deliberately outside Dune's default
-# test aliases because wall-clock assertions are unsuitable for shared CI hosts.
+# DX.6 scheduled/manual CI performance guard, opt-in for local runs. This is
+# deliberately outside Dune's default test aliases because wall-clock
+# assertions are unsuitable as per-change merge gates.
 
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 depth=${JACQUARD_PARSER_DEPTH:-100000}


### PR DESCRIPTION
## Context

Jacquard already has a hostile-input performance guard for the two parser
front ends. It generates source nested 100,000 levels deep and proves that the
surface parser reports E1227 and the bootstrap reader reports E0115 within ten
seconds, without falling through to a host stack overflow or internal error.

That guard was only run by hand. It deliberately stayed out of `dune runtest`
because wall-clock limits on shared machines are a poor pull-request gate, but
the repository also had no recurring automation for it. A superlinear parser
regression could therefore remain unnoticed until someone remembered to run
the script.

This PR turns the existing guard into recurring release-hardening evidence. It
does not change the parser, its limits, or its diagnostics.

## What changed

- Added a dedicated `Parser depth performance` workflow.
- Runs the guard daily at 06:37 UTC and supports explicit manual dispatch.
- Keeps the workflow off pull requests, pushes, and required branch checks, so
  it adds no merge latency.
- Gives the job a 45-minute setup/build timeout while retaining the script's
  existing ten-second deadline for each parser carrier.
- Cancels only an older scheduled run; manual attestations use unique
  concurrency groups and are never replaced by another run.
- Records the exact commit and guard results in the job summary.
- Retains the small result, stdout, and stderr evidence files for 30 days.
- Documents when to run the lane manually, how to triage shared-runner timing
  noise, and the local equivalent.
- Clarifies that the script is scheduled/manual CI evidence and remains
  opt-in locally.

## Why it was done this way

Parser depth is both a correctness boundary and a performance risk. The normal
tests already pin the structural limits and diagnostic codes; this lane checks
the separate wall-clock promise against intentionally hostile inputs.

A daily lane limits how long a regression can hide without making every
contributor wait on timing-sensitive evidence. Manual dispatch is preserved
for parser, trivia, depth-guard, toolchain, and release-candidate work. The
workflow has no custom ref or budget inputs: GitHub records the selected
branch or tag as the run's exact SHA, while the canonical depth and deadline
remain owned by the checked-in guard.

## Operational contract

- Depth remains 100,000.
- Each carrier keeps a ten-second deadline.
- Surface `.jac` must exit with exactly one E1227.
- Bootstrap `.jqd` must exit with exactly one E0115.
- Timeout, E0003, `Stack_overflow`, internal error, an extra diagnostic, or an
  unexpected exit status fails the lane.
- Scheduled runs may replace only stale scheduled runs.
- Manual runs are preserved independently.
- The lane is recurring evidence, not a portable benchmark or merge gate.

## Deliberately excluded

This PR does not change parser or lowering behavior, structural limits,
diagnostic identities, CLI behavior, the 27-form kernel, runtime/native
behavior, HASH_V0, retained manifests, release formats, ordinary Dune aliases,
or branch-protection requirements.

## How it was checked

- `actionlint` 1.7.7 and an independent YAML parse passed.
- The repository temporary-storage policy passed.
- The history-backed checker reconstructed and verified every registered
  historical publication; retained manifests are unchanged.
- `dune build @all @doc` passed.
- The forced full suite passed all 828 compiled/property tests in 350.157
  seconds, every cram transcript, native/runtime checks, all 27 documentation
  examples, and the readability jobs.
- Formatting and clean-diff checks passed.
- The canonical guard passed with exact E1227 and E0115 results at depth
  100,000 within ten seconds.
- A negative control with a 0.001-second deadline failed closed with exit 1
  and an exceeded-deadline report.
- A fresh GPT-5.6 Sol xhigh reviewer returned PASS on exact head
  `60dbcc6903f2bb36b4eef25920fd96224b6dbaeb` with no findings.

## Risks and follow-up

Wall-clock evidence can be affected by a noisy hosted runner. The documented
policy allows one manual rerun to distinguish host noise, but does not allow
raising the deadline merely to make the lane green.

GitHub cannot dispatch a new workflow until it exists on the default branch.
After merge, the first manual run will be required against the exact merge
commit and checked for its summary and 30-day artifact before this work is
considered operationally complete.
