### PR TITLE
Pin the canonical formatter width and plain-text contract

### DIFF
--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `828`
+- Alcotest/QCheck cases: `829`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 
@@ -34,7 +34,8 @@ transcript; its native differential twin is closed and deterministic.
 GM.16 adds three canonical Workspace source-verification cases and one public
 governance-check transcript. GM.17A adds four governance-explanation cases and
 one public explanation transcript. GM.17B adds four static effect-attribution
-cases and one public why-effect transcript.
+cases and one public why-effect transcript. SX.25 adds one formatter-contract
+case for the canonical width, plain UTF-8 output, idempotence, and hash inertia.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 828 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 829 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `828`
+- Alcotest/QCheck cases: `829`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -791,7 +791,9 @@ cases and one public CLI transcript, producing the then-current
 one public CLI transcript, producing the then-current `790 / 47 / 27`
 inventory. GM.17B adds four static effect-attribution cases and one public CLI
 transcript, and GM.17C adds five pure machine review-diff cases, producing the
-current `799 / 48 / 27` inventory.
+then-current `799 / 48 / 27` inventory. Later successor overlays bring the
+inventory to 828 cases; SX.25 adds one formatter-contract case, producing the
+current `829 / 51 / 27` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -323,6 +323,30 @@ Each is a CI property, not a goal.
   aspiration because grammar growth is the failure mode of every syntax
   project, and L7 is the tripwire.
 
+### Canonical formatter contract
+
+The canonical `.jac` formatter uses a 100-column margin. Omitting the printer's
+`width` argument is exactly the same as passing `width = 100`; the `jac fmt`
+command uses that default. The margin is where breakable groups choose between
+one line and multiple lines, not a promise to split an indivisible identifier,
+string, comment, or other UTF-8 token.
+
+Formatting emits deterministic plain UTF-8 text with no ANSI color or other
+terminal styling. It preserves comment and documentation text but normalizes
+layout as L6 describes. Formatting the result again is byte-identical, and
+formatting cannot change canonical hashes because layout and trivia remain
+metadata.
+
+Two existing readability choices are part of this bounded contract. Chained
+conditionals keep `else if` continuations flat. A match scrutinee spanning more
+than four source lines produces W1203 and asks the author to bind it with
+`let`; the formatter never invents that binding or rewrites the AST. This
+preserves L4 and semantic identity.
+
+This contract does not add trailing commas, change accepted grammar, or require
+every comma-separated construct to adopt a new multiline layout. Those broader
+formatter choices remain separate surface-language work.
+
 ## 4. Lexical ground rules
 
 Identifiers are kebab-case with optional `?` and `!` suffixes, matching the

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -6,6 +6,10 @@
 
 type lookup = Surface_name.kind -> Hash.t -> string option
 
+(** The canonical formatter margin. A caller may request another rendering width for an editor or
+    diagnostic view, but the command-line formatter and calls that omit [width] use exactly 100
+    columns. The margin is a layout target rather than a promise to split indivisible UTF-8 tokens.
+*)
 let default_width = 100
 
 exception Bug_unsupported_surface_form

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -60,9 +60,9 @@ let test_one_page_grammar_snapshot () =
     "e564dd92d4b632d4cd8b724ba8bf830ba2489527387c74e93e722ac7b808ffc8"
     (Hash.to_hex (Hash.of_string grammar))
 
-let format_surface path source =
+let format_surface ?width path source =
   let recovered = Surface_parse.recover_string ~file:path source in
-  match Surface_print.print_recovered recovered with
+  match Surface_print.print_recovered ?width recovered with
   | Ok text -> text
   | Error diagnostics -> Eval_support.fail_diags (path ^ " format") diagnostics
 
@@ -101,12 +101,14 @@ let test_surface_formatter_corpus_stability () =
     files
 
 let test_constructor_standard_width_boundary () =
-  let render constructor_length =
+  let render ?width constructor_length =
     let constructor = "A" ^ String.make (constructor_length - 1) 'a' in
-    format_surface "constructors.jac" (Printf.sprintf "type T = | %s | B\n" constructor)
+    format_surface ?width "constructors.jac" (Printf.sprintf "type T = | %s | B\n" constructor)
   in
   let fits = render 85 in
   let breaks = render 86 in
+  Alcotest.(check int) "canonical formatter width" 100 Surface_print.default_width;
+  Alcotest.(check string) "omitted width is explicit width 100" fits (render ~width:100 85);
   Alcotest.(check int)
     "100-column declaration stays on one line" 100
     (String.length (String.trim fits));
@@ -118,6 +120,35 @@ let test_constructor_standard_width_boundary () =
     "one constructor per line after boundary" 2
     (String.split_on_char '\n' (String.trim breaks) |> List.tl |> List.length);
   Alcotest.(check bool) "second constructor has its own line" true (contains "\n  | B\n" breaks)
+
+let lowered_surface path source =
+  let recovered = Surface_parse.recover_string ~file:path source in
+  match Surface_parse.strict_file recovered with
+  | Error diagnostics -> Eval_support.fail_diags (path ^ " strict parse") diagnostics
+  | Ok parsed -> (
+      match Surface_lower.lower_file parsed with
+      | Ok lowered -> lowered.tops
+      | Error diagnostics -> Eval_support.fail_diags (path ^ " lower") diagnostics)
+
+let surface_hashes path source =
+  lowered_surface path source
+  |> List.map (fun top ->
+      match Canon.hash_top top with
+      | Ok hashes -> Hash.to_hex hashes.Canon.decl_hash
+      | Error diagnostics -> Eval_support.fail_diags (path ^ " hash") diagnostics)
+
+let test_plain_text_formatter_contract () =
+  let source = "-- café stays readable\n\"naïve 🚀\"\n" in
+  let once = format_surface "plain-text.jac" source in
+  let twice = format_surface "plain-text.jac" once in
+  Alcotest.(check string) "formatting twice is byte-identical" once twice;
+  Alcotest.(check bool) "UTF-8 comment survives" true (contains "-- café stays readable" once);
+  Alcotest.(check bool) "UTF-8 literal survives" true (contains "\"naïve 🚀\"" once);
+  Alcotest.(check bool) "canonical output has no ANSI escapes" false (contains "\027[" once);
+  Alcotest.(check (list string))
+    "formatting does not change canonical identity"
+    (surface_hashes "plain-text.jac" source)
+    (surface_hashes "plain-text.jac" once)
 
 let trim = String.trim
 
@@ -1110,6 +1141,7 @@ let suite =
       test_surface_formatter_corpus_stability;
     Alcotest.test_case "constructor standard width boundary" `Quick
       test_constructor_standard_width_boundary;
+    Alcotest.test_case "plain-text formatter contract" `Quick test_plain_text_formatter_contract;
     Alcotest.test_case "release tables stop before later subheadings" `Quick
       test_table_rows_stop_at_later_subheading;
     Alcotest.test_case "structured release decision" `Quick assert_release_valid;


### PR DESCRIPTION
## Context

Jacquard already formatted `.jac` files with a 100-column default, kept `else if` chains flat, warned authors to hoist large match scrutinees by hand, and preserved semantic identity across formatting. Those behaviors were spread across implementation details, prose, and separate tests rather than stated as one reviewable contract.

That ambiguity matters during release hardening. An editor, CLI caller, or future formatter change should not have to guess whether 100 is merely today's implementation value, whether omitted width differs from explicit width 100, whether formatting may inject terminal styling, or whether readability cleanup may rewrite the AST and therefore change a program's identity.

This PR turns the existing behavior into an explicit, tested contract. It does not redesign the formatter or change accepted Jacquard programs.

## What changed

- Documented `Surface_print.default_width` as the canonical 100-column margin and clarified that the margin is a layout target, not a requirement to split indivisible UTF-8 tokens.
- Added a canonical formatter contract to the surface-syntax documentation.
- Pinned omitted width as byte-identical to explicit width 100.
- Kept the existing exact boundary evidence: a 100-column constructor declaration stays inline and the 101-column form wraps one constructor per line.
- Added a plain-text fixture proving UTF-8 comments and literals survive, no ANSI CSI styling is introduced, formatting twice is byte-identical, and canonical hashes do not change.
- Updated current successor evidence from 828 to 829 compiled test cases. Frozen 0.1 and SS.22 inventories and every historical manifest remain unchanged.

## Why it was done this way

The safest hardening change is to pin behavior users already depend on without silently choosing new surface-language semantics. A public constant contract plus an end-to-end formatter test makes the default observable at both the API and source-text boundaries.

The AST and hash checks are included because readability work must not become a hidden program rewrite. Flat `else if` output remains a rendering choice. W1203 continues to ask the author to introduce a `let` for a large match scrutinee; the formatter does not invent that binding.

## Operational and semantic contract

- Canonical/default formatter margin: exactly 100 columns.
- Omitting `width` is equivalent to passing `width = 100`.
- Breakable layout crosses the existing constructor boundary at 100/101 columns.
- Output is deterministic plain UTF-8 and contains no formatter-injected ANSI CSI styling.
- Formatting canonical output again is byte-identical.
- Formatting and trivia do not change canonical identity because metadata remains excluded from `HASH_V0`.
- `else if` continuations remain flat.
- Match scrutinees longer than four source lines produce W1203; hoisting remains a manual source edit, never an automatic AST transform.

## Deliberately excluded

- No trailing-comma syntax or parser changes.
- No new general reflow or one-item-per-line policy.
- No kernel, lowering, `HASH_V0`, store, evaluator, runtime, or native changes.
- No benchmark result or production-maturity claim.
- No change to frozen historical evidence or manifests.

Those broader formatter and syntax choices need their own evidence and language decisions.

## How it was checked

- `opam exec -- dune build @all` passed.
- `opam exec -- dune fmt` passed; `git diff --check` is clean.
- All 41 `surface-laws` cases passed.
- Independent review also ran 74 adjacent `surface-print`, `surface-control-sugar`, `surface-check`, and `surface-trivia` cases; all passed.
- The full gate passed all 829 compiled Alcotest/QCheck cases in 348.742 seconds.
- All 51 cram transcripts passed.
- All 27 documentation examples across 8 documents passed.
- The readability protocol's 3 jobs, 3 carriers, and 9 dry-run conditions passed.
- Live inventories were independently confirmed as 829 compiled cases, 51 crams, and 27 doctests.

## Risks and deferred follow-ups

The no-ANSI regression checks the actual CSI styling prefix (`ESC [`), not every theoretical terminal-control byte. The formatter has no styling path, so the independent reviewer accepted this as proportionate coverage.

This is a bounded hardening slice. Trailing commas, broader multiline layout rules, and benchmark-backed formatter changes remain deferred and are not implied by this PR.
