### PR TITLE
UX.1: pin deterministic study schedules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ project shape from file names alone.
 - `research/readability-benchmark/PROTOCOL.md`: preregistered reviewer tasks,
   paired-carrier fixtures, scoring, privacy, and synthetic reproduction evidence
   for future syntax decisions.
+- `research/readability-benchmark/EXECUTION.md`: fail-closed UX.1 authority
+  boundary and deterministic human/model schedule commands.
 - `ci-cd.md`: GitHub gates, branch protection, and release evidence workflow.
 
 ## Core Design

--- a/docs/research/readability-benchmark/EXECUTION.md
+++ b/docs/research/readability-benchmark/EXECUTION.md
@@ -41,10 +41,11 @@ python3 test/readability/readability_benchmark.py human-schedule \
 ```
 
 The command emits 480 zero-based enrollment ordinals. Each row contains only
-the frozen carrier and three-job presentation order; it contains no identity,
-contact, consent, compensation, or outcome data. The confirmatory seed assigns
-exactly 160 enrollments to each carrier. Every complete block of 18 ordinals
-contains all carrier and job-order cells once.
+assignment-planning metadata: the ordinal, block and position, carrier,
+three-job presentation order, schema and protocol versions, and seed digest.
+It contains no identity, contact, consent, compensation, or outcome data. The
+confirmatory seed assigns exactly 160 enrollments to each carrier. Every
+complete block of 18 ordinals contains all carrier and job-order cells once.
 
 The reviewed JSONL SHA-256 is
 `c6421e9fff78b5fd7397e8c2aaeadee434c58c01c1d1d85aec224c4e2ec1a9be`.

--- a/docs/research/readability-benchmark/EXECUTION.md
+++ b/docs/research/readability-benchmark/EXECUTION.md
@@ -1,0 +1,106 @@
+# Readability benchmark execution gate
+
+Status: planning tools are implemented; collection is not authorized and no
+human or model outcomes have been collected.
+
+The frozen [protocol](PROTOCOL.md) defines what the study measures. This
+document defines the boundary between making a deterministic plan and starting
+the study. A generated schedule is evidence that the planned conditions are
+complete and balanced. It is not consent, ethics or privacy approval, a model
+attestation, or permission to collect data.
+
+## Authority required before collection
+
+The study operator must record all of the following outside the result rows
+before enrolling a person or starting a model session:
+
+1. the accountable study owner and operator;
+2. the applicable ethics and privacy route, decision, and decision date;
+3. approved information-sheet and consent-form versions;
+4. recruitment source, eligibility wording, and the no-tools agreement;
+5. compensation terms, funded budget, payment process, and withdrawal window;
+6. the data controller, access list, storage location, deletion date, and
+   incident contact;
+7. the de-identified publication license agreed to by participants;
+8. the accessible plain-text study host and a completed presentation check;
+9. for confirmatory model rows, an attestation from the provider or deployment
+   owner that the pinned model's training cutoff predates fixture publication.
+
+A required change to the protocol, fixtures, schema, answer key, exclusions,
+or consent/data terms must be versioned and reviewed before collection. Missing
+authority fails closed. Synthetic dry runs and generated schedules cannot fill
+in an approval or attestation.
+
+## Human assignment plan
+
+Generate the complete plan before recruitment:
+
+```text
+python3 test/readability/readability_benchmark.py human-schedule \
+  > .scratch/readability/human-schedule.jsonl
+```
+
+The command emits 480 zero-based enrollment ordinals. Each row contains only
+the frozen carrier and three-job presentation order; it contains no identity,
+contact, consent, compensation, or outcome data. The confirmatory seed assigns
+exactly 160 enrollments to each carrier. Every complete block of 18 ordinals
+contains all carrier and job-order cells once.
+
+The reviewed JSONL SHA-256 is
+`c6421e9fff78b5fd7397e8c2aaeadee434c58c01c1d1d85aec224c4e2ec1a9be`.
+
+The operator allocates the next ordinal only after eligibility and consent.
+The operator may not skip an assignment after seeing it. Private enrollment,
+consent, contact, and compensation records must not be added to this schedule
+or to the published result rows.
+
+## Model dispatch plan
+
+Generate the complete plan without calling a model:
+
+```text
+python3 test/readability/readability_benchmark.py model-schedule \
+  --manifest test/readability/fixture-manifest.json \
+  > .scratch/readability/model-schedule.jsonl
+```
+
+The command emits 270 trials: three carriers by three jobs by 30 repetitions.
+Every trial requires a fresh session with tools and session memory disabled.
+Each row pins the reviewed model, client, temperature, prompt digest, fixture
+digest, confirmatory seed digest, and isolation settings.
+
+Dispatch order is ascending SHA-256 of this exact UTF-8 byte sequence:
+
+```text
+jacquard-readability-v0\0carrier=<carrier>\0job=<job>\0repetition=<1..30>
+```
+
+Here `\0` means one NUL byte, not the two printed characters backslash and
+zero. The schedule records that digest as `dispatch_key_sha256`. A dispatcher
+must use the rows in ordinal order and must not retry parse failures. Model or
+client drift, prompt drift, tool use, memory use, and missing training-cutoff
+attestation remain exclusions under the protocol.
+
+The reviewed JSONL SHA-256 is
+`ba972dfcd0738a7f3360f54179c95dc02140e84d21320474a9e410380f8071b5`.
+
+The repository deliberately does not include a command that contacts a model.
+That prevents a local verification command from silently spending quota,
+changing external state, or creating results without the required attestation.
+
+## What the checked gate proves
+
+`dune build @readability-protocol` verifies:
+
+- all 480 human ordinals are present, contiguous, and balanced 160 per carrier;
+- every human row exactly matches the frozen seeded assignment function;
+- all 270 model carrier/job/repetition cells occur exactly once;
+- model dispatch keys are unique and in SHA-256 order;
+- every model row retains the reviewed fixture, prompt, model, client,
+  temperature, tool, memory, and fresh-session pins;
+- repeated schedule generation is byte-identical JSON Lines.
+
+It does not prove that approvals exist, presentation was accessible in the live
+host, subjects followed instructions, the pinned model was uncontaminated, or
+the study results support a readability claim. Those require the separately
+reviewed execution and publication evidence required by Task UX.1.

--- a/docs/research/readability-benchmark/PROTOCOL.md
+++ b/docs/research/readability-benchmark/PROTOCOL.md
@@ -202,3 +202,8 @@ and makes no performance claim. Disposable assignments, renderings, logs, and
 execution stores remain under `.scratch/`. Protocol, fixture bytes, answer key,
 schema, model pin, exclusions, scoring, or threshold changes require a new
 version and review before further collection.
+
+The [execution gate](EXECUTION.md) records the authority required before UX.1
+collection and the deterministic commands for generating the frozen human and
+model schedules. Generating either schedule remains a planning operation, not
+consent or permission to collect outcomes.

--- a/test/readability/dune
+++ b/test/readability/dune
@@ -7,12 +7,22 @@
   model-prompt.txt
   (source_tree fixtures)
   ../../docs/research/readability-benchmark/PROTOCOL.md
+  ../../docs/research/readability-benchmark/EXECUTION.md
   (source_tree ../../prelude))
  (action
   (setenv TMPDIR .
-   (run %{bin:python3} readability_benchmark.py verify
-    --manifest fixture-manifest.json
-    --schema result.schema.json
-    --protocol ../../docs/research/readability-benchmark/PROTOCOL.md
-    --jacquard %{bin:jacquard}
-    --prelude ../../prelude))))
+   (progn
+    (run %{bin:python3} readability_benchmark.py verify
+     --manifest fixture-manifest.json
+     --schema result.schema.json
+     --protocol ../../docs/research/readability-benchmark/PROTOCOL.md
+     --jacquard %{bin:jacquard}
+     --prelude ../../prelude)
+    (with-stdout-to human-schedule.jsonl
+     (run %{bin:python3} readability_benchmark.py human-schedule))
+    (with-stdout-to model-schedule.jsonl
+     (run %{bin:python3} readability_benchmark.py model-schedule
+      --manifest fixture-manifest.json))
+    (run %{bin:python3} readability_benchmark.py verify-schedules
+     --human human-schedule.jsonl
+     --model model-schedule.jsonl)))))

--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Deterministic UX.0 fixture verifier, assignment tool, scorer, and dry runner.
+"""Deterministic readability fixture verifier, planner, scorer, and dry runner.
 
 The tool uses only the Python standard library.  It never collects participants
-or calls a model; real-study orchestration belongs to the separately reviewed
-execution phase.  Invalid manifests, result rows, or fixture evidence fail with
-a concise message and a nonzero exit status.
+or calls a model.  Its UX.1 schedule commands emit de-identified execution
+plans, not consent or study authority.  Invalid manifests, result rows, or
+fixture evidence fail with a concise message and a nonzero exit status.
 """
 
 from __future__ import annotations
@@ -29,6 +29,11 @@ JOBS = ("seeded-bug", "predict-output", "authority-escalation")
 JOB_ORDERS = tuple(itertools.permutations(JOBS))
 FIXED_DRY_RUN_TIME = "2000-01-01T00:00:00Z"
 CONFIRMATORY_SEED = "jacquard-readability-v0"
+HUMAN_ENROLLMENT_COUNT = 480
+HUMAN_SCHEDULE_VERSION = "readability-human-schedule-v0"
+MODEL_SCHEDULE_VERSION = "readability-model-schedule-v0"
+HUMAN_SCHEDULE_SHA256 = "c6421e9fff78b5fd7397e8c2aaeadee434c58c01c1d1d85aec224c4e2ec1a9be"
+MODEL_SCHEDULE_SHA256 = "ba972dfcd0738a7f3360f54179c95dc02140e84d21320474a9e410380f8071b5"
 
 
 class ProtocolError(RuntimeError):
@@ -259,6 +264,84 @@ def assignment(seed: str, ordinal: int) -> dict[str, Any]:
         "job_order": list(order),
         "assignment_seed_sha256": digest_text(seed),
     }
+
+
+def human_schedule() -> list[dict[str, Any]]:
+    """Return the frozen de-identified 480-enrollment assignment plan.
+
+    The rows contain enrollment ordinals and presentation assignments only.
+    They never contain participant, consent, contact, or compensation data.
+    """
+
+    rows: list[dict[str, Any]] = []
+    for ordinal in range(HUMAN_ENROLLMENT_COUNT):
+        row = assignment(CONFIRMATORY_SEED, ordinal)
+        rows.append(
+            {
+                "schedule_schema_version": HUMAN_SCHEDULE_VERSION,
+                "protocol_version": PROTOCOL_VERSION,
+                **row,
+            }
+        )
+    return rows
+
+
+def model_schedule(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the frozen model trial plan without starting model sessions.
+
+    Every carrier/job/repetition appears exactly once.  Dispatch order is the
+    lexicographic order of SHA-256 over the documented UTF-8/NUL-separated key.
+    Each row carries the reviewed fixture, prompt, and runtime pins needed to
+    detect drift before a result can enter confirmatory evidence.
+    """
+
+    pinned = manifest["model_condition"]
+    repetitions = pinned["repetitions_per_condition"]
+    fixtures = fixture_index(manifest)
+    trials: list[tuple[str, str, int, str]] = []
+    for carrier in CARRIERS:
+        for job in JOBS:
+            for repetition in range(1, repetitions + 1):
+                key = (
+                    f"{CONFIRMATORY_SEED}\0carrier={carrier}"
+                    f"\0job={job}\0repetition={repetition}"
+                )
+                trials.append((carrier, job, repetition, digest_text(key)))
+    trials.sort(key=lambda trial: trial[3])
+
+    seed_digest = digest_text(CONFIRMATORY_SEED)
+    return [
+        {
+            "schedule_schema_version": MODEL_SCHEDULE_VERSION,
+            "protocol_version": PROTOCOL_VERSION,
+            "ordinal": ordinal,
+            "condition_id": f"{carrier}/{job}",
+            "carrier": carrier,
+            "job": job,
+            "repetition": repetition,
+            "dispatch_key_sha256": dispatch_key,
+            "assignment_seed_sha256": seed_digest,
+            "fixture_sha256": fixtures[job]["sources"][carrier]["sha256"],
+            "provider": pinned["provider"],
+            "model": pinned["model"],
+            "client": pinned["client"],
+            "prompt_sha256": pinned["prompt_sha256"],
+            "temperature": pinned["temperature"],
+            "tools": pinned["tools"],
+            "session_memory": pinned["session_memory"],
+            "fresh_session_required": True,
+        }
+        for ordinal, (carrier, job, repetition, dispatch_key) in enumerate(trials)
+    ]
+
+
+def encode_jsonl(rows: Iterable[dict[str, Any]]) -> str:
+    """Encode evidence rows as stable UTF-8-compatible JSON Lines."""
+
+    return "".join(
+        json.dumps(row, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+        for row in rows
+    )
 
 
 def score_answer(fixture: dict[str, Any], answer_id: str) -> tuple[bool, str | None]:
@@ -546,6 +629,61 @@ def self_test(
         if set(orders) != set(JOB_ORDERS):
             raise ProtocolError(f"assignment block does not counterbalance all job orders for {carrier}")
 
+    humans = human_schedule()
+    if len(humans) != HUMAN_ENROLLMENT_COUNT:
+        raise ProtocolError("human schedule must contain exactly 480 enrollment ordinals")
+    if [row["ordinal"] for row in humans] != list(range(HUMAN_ENROLLMENT_COUNT)):
+        raise ProtocolError("human schedule ordinals must be contiguous and zero-based")
+    human_carrier_counts = {
+        carrier: sum(row["carrier"] == carrier for row in humans) for carrier in CARRIERS
+    }
+    if human_carrier_counts != {carrier: 160 for carrier in CARRIERS}:
+        raise ProtocolError("human schedule must assign exactly 160 enrollments per carrier")
+    for row in humans:
+        expected = assignment(CONFIRMATORY_SEED, row["ordinal"])
+        if any(row[key] != value for key, value in expected.items()):
+            raise ProtocolError("human schedule drifted from frozen seeded assignment")
+
+    pinned = manifest["model_condition"]
+    models = model_schedule(manifest)
+    expected_model_count = len(CARRIERS) * len(JOBS) * pinned["repetitions_per_condition"]
+    if len(models) != expected_model_count:
+        raise ProtocolError("model schedule must contain exactly 270 fresh trials")
+    if models != model_schedule(manifest):
+        raise ProtocolError("model schedule generation is not deterministic")
+    if [row["ordinal"] for row in models] != list(range(expected_model_count)):
+        raise ProtocolError("model schedule ordinals must be contiguous and zero-based")
+    if [row["dispatch_key_sha256"] for row in models] != sorted(
+        row["dispatch_key_sha256"] for row in models
+    ):
+        raise ProtocolError("model schedule is not ordered by its SHA-256 dispatch key")
+    if len({row["dispatch_key_sha256"] for row in models}) != expected_model_count:
+        raise ProtocolError("model schedule dispatch keys must be unique")
+    for carrier in CARRIERS:
+        for job in JOBS:
+            repetitions = {
+                row["repetition"]
+                for row in models
+                if row["carrier"] == carrier and row["job"] == job
+            }
+            if repetitions != set(range(1, pinned["repetitions_per_condition"] + 1)):
+                raise ProtocolError(f"model schedule is incomplete for {carrier}/{job}")
+    for row in models:
+        if (
+            not row["fresh_session_required"]
+            or row["tools"] != "disabled"
+            or row["session_memory"] != "disabled"
+        ):
+            raise ProtocolError("model schedule weakened fresh-session isolation")
+    if encode_jsonl(humans) != encode_jsonl(human_schedule()):
+        raise ProtocolError("human schedule JSONL is not byte-deterministic")
+    if encode_jsonl(models) != encode_jsonl(model_schedule(manifest)):
+        raise ProtocolError("model schedule JSONL is not byte-deterministic")
+    if digest_text(encode_jsonl(humans)) != HUMAN_SCHEDULE_SHA256:
+        raise ProtocolError("human schedule bytes drifted from the reviewed plan")
+    if digest_text(encode_jsonl(models)) != MODEL_SCHEDULE_SHA256:
+        raise ProtocolError("model schedule bytes drifted from the reviewed plan")
+
     for fixture in fixture_index(manifest).values():
         if score_answer(fixture, fixture["correct_answer"]) != (True, None):
             raise ProtocolError(f"correct scoring failed for {fixture['id']}")
@@ -727,6 +865,17 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     assign.add_argument("--seed", required=True)
     assign.add_argument("--ordinal", type=int, required=True)
 
+    commands.add_parser(
+        "human-schedule",
+        help="emit the frozen 480-enrollment de-identified assignment plan",
+    )
+
+    model_plan = commands.add_parser(
+        "model-schedule",
+        help="emit the frozen 270-trial model plan without calling a model",
+    )
+    model_plan.add_argument("--manifest", type=Path, required=True)
+
     present = commands.add_parser("present", help="render one accessible plain-text trial")
     present.add_argument("--manifest", type=Path, required=True)
     present.add_argument("--carrier", choices=CARRIERS, required=True)
@@ -740,9 +889,15 @@ def main(argv: Iterable[str]) -> int:
         if args.command == "assign":
             print(json.dumps(assignment(args.seed, args.ordinal), sort_keys=True))
             return 0
+        if args.command == "human-schedule":
+            sys.stdout.write(encode_jsonl(human_schedule()))
+            return 0
 
         manifest = load_json(args.manifest)
         verify_manifest(manifest, args.manifest)
+        if args.command == "model-schedule":
+            sys.stdout.write(encode_jsonl(model_schedule(manifest)))
+            return 0
         if args.command == "present":
             sys.stdout.write(render_trial(manifest, args.manifest, args.carrier, args.job))
             return 0

--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -344,6 +344,24 @@ def encode_jsonl(rows: Iterable[dict[str, Any]]) -> str:
     )
 
 
+def verify_schedule_files(human_path: Path, model_path: Path) -> None:
+    """Fail unless CLI-generated schedule files match the reviewed byte plans."""
+
+    expected = (
+        ("human", human_path, HUMAN_SCHEDULE_SHA256),
+        ("model", model_path, MODEL_SCHEDULE_SHA256),
+    )
+    for label, path, expected_digest in expected:
+        try:
+            actual_digest = digest_bytes(path.read_bytes())
+        except OSError as error:
+            raise ProtocolError(f"cannot read {label} schedule {path}: {error}") from error
+        if actual_digest != expected_digest:
+            raise ProtocolError(
+                f"{label} schedule digest drift: expected {expected_digest}, got {actual_digest}"
+            )
+
+
 def score_answer(fixture: dict[str, Any], answer_id: str) -> tuple[bool, str | None]:
     options = {option["id"] for option in fixture["options"]}
     if answer_id == "__timeout__":
@@ -876,6 +894,13 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     )
     model_plan.add_argument("--manifest", type=Path, required=True)
 
+    verify_plans = commands.add_parser(
+        "verify-schedules",
+        help="verify CLI-generated human and model schedule bytes",
+    )
+    verify_plans.add_argument("--human", type=Path, required=True)
+    verify_plans.add_argument("--model", type=Path, required=True)
+
     present = commands.add_parser("present", help="render one accessible plain-text trial")
     present.add_argument("--manifest", type=Path, required=True)
     present.add_argument("--carrier", choices=CARRIERS, required=True)
@@ -891,6 +916,10 @@ def main(argv: Iterable[str]) -> int:
             return 0
         if args.command == "human-schedule":
             sys.stdout.write(encode_jsonl(human_schedule()))
+            return 0
+        if args.command == "verify-schedules":
+            verify_schedule_files(args.human, args.model)
+            print("readability schedules: PASS (480 human assignments, 270 model trials)")
             return 0
 
         manifest = load_json(args.manifest)


### PR DESCRIPTION
## Context

Jacquard’s UX.0 work froze a readability study before any outcomes existed. It
defined 480 human enrollments and 270 isolated model trials, but deliberately
left the execution schedules for UX.1. Without checked schedules, an operator
could accidentally omit a condition, alter dispatch order, reuse a model
session, or make assignment choices after seeing results.

This change makes those plans deterministic and reviewable before collection.
It does not collect study data or claim that the study has been authorized or
run.

## What changed

- Added `human-schedule`, which emits all 480 enrollment ordinals from the
  frozen confirmatory seed. The plan assigns exactly 160 people to each carrier
  and contains presentation order only—no identity, contact, consent,
  compensation, or outcome data.
- Added `model-schedule`, which emits all 270 carrier/job/repetition trials.
  Every row pins the fixture, prompt, model, client, temperature, tool and
  memory settings, and the requirement for a fresh session.
- Defined the model dispatch order as ascending SHA-256 over one documented
  UTF-8/NUL-separated key.
- Pinned the complete human and model JSONL outputs by SHA-256 and added
  checked invariants for counts, balance, uniqueness, ordering, isolation, and
  byte-identical regeneration.
- Added an execution-gate document listing the owner, ethics/privacy, consent,
  recruitment, compensation, retention, licensing, accessibility, and model
  cutoff authority required before real collection.

## Why it was done this way

The study plan should be fixed before any result can influence it. Generating
the schedules from reviewed constants makes omissions and ordering drift
visible in the repository, while whole-file hashes make the exact plan easy to
reproduce and compare.

The tool emits plans but has no command that contacts a model or enrolls a
person. That keeps ordinary verification offline and prevents a build or test
from spending quota, changing external state, or being mistaken for consent.

## Contract and invariants

- The human output is exactly 480 contiguous ordinals and 160 assignments per
  carrier; every row is the existing frozen assignment for that ordinal.
- The model output is exactly 3 carriers × 3 jobs × 30 repetitions, with each
  trial present once and ordered by its unique dispatch hash.
- Schedule rows retain the frozen protocol, confirmatory seed, fixture and
  prompt digests, and model execution pins.
- Repeated generation is byte-identical:
  - human schedule:
    `c6421e9fff78b5fd7397e8c2aaeadee434c58c01c1d1d85aec224c4e2ec1a9be`
  - model schedule:
    `ba972dfcd0738a7f3360f54179c95dc02140e84d21320474a9e410380f8071b5`
- A schedule is planning evidence only. It cannot stand in for consent,
  external approval, accessibility evidence, or the Fable training-cutoff
  attestation.
- No Jacquard kernel, syntax, lowering, HASH_V0 identity, runtime, diagnostic,
  fixture, answer key, result schema, or release manifest changes.

## Deliberately excluded

This PR does not recruit participants, store identifiers, call a model, accept
live results, choose compensation or data-governance terms, assert a training
cutoff, implement the study host, calculate outcome statistics, or make a
readability claim. Task UX.1 remains open until the approved study is executed
and reproducible evidence is published.

## Validation

- `dune build @readability-protocol` — passed, including CLI-generated schedule
  verification
- Human schedule — 480 rows; repeated output byte-identical; pinned hash passed
- Model schedule — 270 rows; repeated output byte-identical; pinned hash passed
- `dune build @all @doc` — passed
- `dune runtest --force` — all 829 compiled/property tests passed in 337.014
  seconds, plus every cram/native/runtime/readability lane
- Documentation examples — all 27 passed
- `dune fmt` — clean
- Standard trailing-whitespace and space-before-tab checks — passed

## Risks and follow-up

The pinned hashes intentionally make schedule-format or ordering changes
review-visible. A legitimate protocol change must update the relevant version
and evidence rather than silently regenerating the hashes.

The repository can verify that every plan row requires a fresh isolated model
session, but only the later external execution record can prove that the
dispatcher actually provided one. The same boundary applies to human consent,
live presentation accessibility, and the model training-cutoff attestation.
