### PR TITLE
Accept trailing commas and stabilize multiline formatting

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -304,6 +304,12 @@ Labels document constructor fields but do not create record syntax, labeled
 patterns, or generated accessors. Construct values with `Canary(5)` and match
 positionally with `Canary(percent)`.
 
+Comma-separated surface groups accept an optional final comma. Compact
+formatting removes it, except for singleton tuples such as `(T,)`; when a
+group wraps, Jacquard prints one item per line and a comma after every item.
+The punctuation is erased before kernel validation and never changes hashes
+or `.jqd` behavior.
+
 ### Effects And Deep Mode-Aware Handlers
 
 Effects declare operations. Calling an operation looks like an ordinary call;

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `829`
+- Alcotest/QCheck cases: `832`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 829 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 832 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `829`
+- Alcotest/QCheck cases: `832`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -793,7 +793,7 @@ inventory. GM.17B adds four static effect-attribution cases and one public CLI
 transcript, and GM.17C adds five pure machine review-diff cases, producing the
 then-current `799 / 48 / 27` inventory. Later successor overlays bring the
 inventory to 828 cases; SX.25 adds one formatter-contract case, producing the
-current `829 / 51 / 27` inventory.
+current `832 / 51 / 27` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -115,11 +115,11 @@ type-app      := type-atom type-atom*
 type-atom     := type-name | type-var | "()" | "(" type ")"
 | "(" type "," ")" | "(" types ")"
 row           := "->{" cont effects? [cont "|" cont row-var] cont "}"
-patterns      := pattern ("," pattern)*
-fields        := field ("," field)*
-types         := type ("," type)*
-exprs         := expr ("," expr)*
-effects       := effect-name ("," cont effect-name)*
+patterns      := pattern ("," pattern)* [","]
+fields        := field ("," field)* [","]
+types         := type ("," type)* [","]
+exprs         := expr ("," expr)* [","]
+effects       := effect-name ("," cont effect-name)* [","]
 type-vars     := type-var+
 row-vars      := row-var+
 forall-vars   := type-vars ["|" row-vars] | "|" row-vars
@@ -343,9 +343,21 @@ than four source lines produces W1203 and asks the author to bind it with
 `let`; the formatter never invents that binding or rewrites the AST. This
 preserves L4 and semantic identity.
 
-This contract does not add trailing commas, change accepted grammar, or require
-every comma-separated construct to adopt a new multiline layout. Those broader
-formatter choices remain separate surface-language work.
+Calls, lists, expression and type tuples, function and handler parameter lists,
+arrow parameter lists, labeled constructor fields, operation parameter lists,
+constructor patterns, and effect lists accept one optional final comma. The
+comma is surface punctuation only: lowering erases it, so it cannot change
+kernel forms, evaluation order, hashes, or `.jqd` behavior. A final comma
+before an open row tail is accepted and normalized away because the tail still
+follows the effect list.
+
+Compact groups remain on one line without a final comma, except singleton
+tuples, whose comma carries their arity. When a comma group exceeds the
+selected width, its opening delimiter stays on the preceding line, every item
+gets its own indented line, every item ends in a comma, and the closing
+delimiter gets its own line. This all-or-nothing vertical layout makes an
+appended item a one-line diff. Comments may force the same vertical choice;
+their text, order, and ownership remain governed by L6.
 
 ## 4. Lexical ground rules
 
@@ -562,7 +574,9 @@ while the other kept chains flat, which is the printer's rule now.
 
 `(a, b)` and `()` are kernel tuples. `[1, 2, 3]` is sugar desugaring by name
 to `Cons(1, Cons(2, Cons(3, Nil)))`, resolved like any other names (D32), so
-the sugar carries no hard-coded hashes.
+the sugar carries no hard-coded hashes. An author may write `(a, b,)` or
+`[1, 2, 3,]`; both lower exactly like the compact spelling, and canonical
+formatting removes the comma unless the group wraps.
 
 ### Pipe
 
@@ -631,6 +645,9 @@ below.
 
 Row notation prints tight, with no interior spaces (`->{Net, Clock}`, never
 `-> { Net, Clock }`), and wraps one effect per line past that width.
+Closed multiline rows end every effect with a comma, including the final
+effect. Open rows do not print a comma immediately before `|`, because the row
+tail follows the effect list.
 `()` is the empty tuple type and `(T,)` is the singleton tuple type; the
 trailing comma preserves every legal kernel `TTuple` arity. Quantification
 prints `forall a b | e. T`, with type variables before `|` and row variables

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -531,10 +531,8 @@ and parse_expr_list state =
         | Surface_lex.Comma ->
             ignore (advance state);
             skip_list_space state;
-            if (current state).Surface_lex.token = Surface_lex.RParen then begin
-              report state (current state) "calls do not permit a trailing comma";
+            if (current state).Surface_lex.token = Surface_lex.RParen then
               (List.rev (expression :: acc), advance state)
-            end
             else loop (expression :: acc)
         | Surface_lex.RParen -> (List.rev (expression :: acc), advance state)
         | _ ->
@@ -643,11 +641,8 @@ and parse_list_expr state opening =
                   | Surface_lex.Comma ->
                       ignore (advance state);
                       skip_list_space state;
-                      if (current state).Surface_lex.token = Surface_lex.RBracket then begin
-                        report state (current state) "list literals do not permit a trailing comma";
-                        let hole = expr_hole state (current state) in
-                        (List.rev (hole :: expression :: acc), advance state)
-                      end
+                      if (current state).Surface_lex.token = Surface_lex.RBracket then
+                        (List.rev (expression :: acc), advance state)
                       else loop (expression :: acc)
                   | Surface_lex.RBracket -> (List.rev (expression :: acc), advance state)
                   | _ ->
@@ -805,10 +800,8 @@ and parse_paren_expr state opening =
               | Surface_lex.Comma ->
                   ignore (advance state);
                   skip_list_space state;
-                  if (current state).Surface_lex.token = Surface_lex.RParen then begin
-                    report state (current state) "multi-item tuples do not permit a trailing comma";
+                  if (current state).Surface_lex.token = Surface_lex.RParen then
                     (List.rev (item :: acc), advance state)
-                  end
                   else items (item :: acc)
               | Surface_lex.RParen -> (List.rev (item :: acc), advance state)
               | _ ->
@@ -879,7 +872,6 @@ and parse_pattern_list state _opening =
             ignore (advance state);
             skip_list_space state;
             if (current state).Surface_lex.token = Surface_lex.RParen then begin
-              report state (current state) "pattern lists do not permit a trailing comma";
               let closing = advance state in
               (List.rev (pattern :: acc), closing)
             end
@@ -1688,11 +1680,8 @@ and parse_paren_type state ~allow_newlines:_ opening =
             | Surface_lex.Comma ->
                 ignore (advance state);
                 skip_list_space state;
-                if (current state).Surface_lex.token = Surface_lex.RParen then begin
-                  report state (current state)
-                    "multi-item type tuples do not permit a trailing comma";
+                if (current state).Surface_lex.token = Surface_lex.RParen then
                   (List.rev (item :: acc), advance state)
-                end
                 else items (item :: acc)
             | Surface_lex.RParen -> (List.rev (item :: acc), advance state)
             | _ ->
@@ -1853,8 +1842,7 @@ and parse_row_separator state ~effect_index row_owners =
               !row_owners;
           skip_continuation state;
           match (current state).Surface_lex.token with
-          | Surface_lex.RBrace | Surface_lex.Bar ->
-              report state (current state) "effect rows do not permit a trailing comma"
+          | Surface_lex.RBrace | Surface_lex.Bar -> ()
           | _ -> ())
       | Surface_lex.Bar | Surface_lex.RBrace -> ()
       | Surface_lex.Newline -> (
@@ -2126,9 +2114,7 @@ let parse_constructor_fields state constructor opening =
                 | Surface_lex.Comma ->
                     ignore (advance state);
                     skip_list_space state;
-                    if (current state).Surface_lex.token = Surface_lex.RParen then
-                      report_code state (current state) "E1225"
-                        "constructor field lists do not permit a trailing comma"
+                    ()
                 | Surface_lex.RParen -> ()
                 | _ ->
                     report_code state (current state) "E1225"
@@ -2233,8 +2219,6 @@ let parse_operation_types state =
               ignore (advance state);
               skip_list_space state;
               if (current state).Surface_lex.token = Surface_lex.RParen then begin
-                report_code state (current state) "E1225"
-                  "operation parameter lists do not permit a trailing comma";
                 let closing = advance state in
                 (List.rev (ty :: acc), closing)
               end
@@ -2682,7 +2666,7 @@ module Trivia_ownership = struct
   let row_slots (row : Surface_ast.row) =
     containers [ "row-open"; "row-bar"; "row-tail"; "row-close" ] row.row_meta
     @ indexed_containers "row-effect" (List.length row.effects) row.row_meta
-    @ indexed_containers "row-comma" (max 0 (List.length row.effects - 1)) row.row_meta
+    @ indexed_containers "row-comma" (List.length row.effects) row.row_meta
 
   let rec expr depth (node : Surface_ast.expr) =
     let children =
@@ -3050,7 +3034,7 @@ module Trivia_ownership = struct
     meta
     |> apply_containers additions [ "row-open"; "row-bar"; "row-tail"; "row-close" ]
     |> apply_indexed_containers additions "row-effect" effect_count
-    |> apply_indexed_containers additions "row-comma" (max 0 (effect_count - 1))
+    |> apply_indexed_containers additions "row-comma" effect_count
 
   let apply_owner additions role meta =
     meta |> apply additions role

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -112,6 +112,45 @@ let pp_sep sep pp fmt items =
       pp fmt item)
     items
 
+(* In an [hv] box every break is taken together. The opening break therefore puts the first item
+   on its own line when the group does not fit, the separator breaks put every later item on its
+   own line, and the final custom break adds a comma only in that vertical rendering. When comments
+   follow the final comma, this helper owns their two breaks so the close still returns to the
+   delimiter's column without an empty line. Singleton tuples opt into a comma in both layouts
+   because the comma carries their arity. *)
+let pp_comma_list ?(singleton = false) ?(break_padding = "") ?(inner_metas = []) context pp fmt
+    items =
+  let inner_comments =
+    if context.trivia then List.concat_map (Meta.comment_texts Meta.key_trivia_inner) inner_metas
+    else []
+  in
+  if items <> [] then begin
+    Format.pp_print_custom_break fmt ~fits:("", 0, "") ~breaks:("", 0, break_padding);
+    let last = List.length items - 1 in
+    List.iteri
+      (fun index item ->
+        pp fmt item;
+        if index <> last then
+          Format.pp_print_custom_break fmt ~fits:(",", 1, "") ~breaks:(",", 0, break_padding))
+      items
+  end;
+  match inner_comments with
+  | [] ->
+      if items <> [] then
+        Format.pp_print_custom_break fmt
+          ~fits:((if singleton then "," else ""), 0, "")
+          ~breaks:(",", -2, break_padding)
+  | comments ->
+      if items <> [] then Format.pp_print_char fmt ',';
+      List.iter
+        (fun comment ->
+          Format.pp_print_break fmt 1000 0;
+          Format.pp_print_string fmt break_padding;
+          Format.pp_print_string fmt comment)
+        comments;
+      Format.pp_print_break fmt 1000 (-2);
+      Format.pp_print_string fmt break_padding
+
 let kind_of_refkind = function
   | Kernel.Term -> Surface_name.Term
   | Kernel.Con -> Surface_name.Con
@@ -167,23 +206,28 @@ let rec pp_pat context lookup fmt (pat : Kernel.pat) =
   | Kernel.PVar name -> pp_named Surface_name.Term fmt name
   | Kernel.PLit lit -> pp_lit fmt lit
   | Kernel.PCon (con, args) ->
+      Format.fprintf fmt "@[<hv 2>";
       pp_gref lookup Surface_name.Con pat.meta fmt con;
       if args <> [] then begin
-        Format.fprintf fmt "(@[<hov>%a" (pp_sep "," (pp_pat context lookup)) args;
-        pp_inner context pat.meta fmt;
-        Format.fprintf fmt "@])"
-      end
+        Format.fprintf fmt "(%a"
+          (pp_comma_list ~inner_metas:[ pat.meta ] context (pp_pat context lookup))
+          args;
+        Format.fprintf fmt ")"
+      end;
+      Format.fprintf fmt "@]"
   | Kernel.PTuple items -> (
       match items with
       | [] -> Format.pp_print_string fmt "()"
       | [ item ] ->
-          Format.fprintf fmt "(@[<hov>%a" (pp_pat context lookup) item;
-          pp_inner context pat.meta fmt;
-          Format.fprintf fmt "@])"
+          Format.fprintf fmt "@[<hv 2>(%a"
+            (pp_comma_list ~singleton:true ~inner_metas:[ pat.meta ] context (pp_pat context lookup))
+            [ item ];
+          Format.fprintf fmt ")@]"
       | _ ->
-          Format.fprintf fmt "(@[<hov>%a" (pp_sep "," (pp_pat context lookup)) items;
-          pp_inner context pat.meta fmt;
-          Format.fprintf fmt "@])")
+          Format.fprintf fmt "@[<hv 2>(%a"
+            (pp_comma_list ~inner_metas:[ pat.meta ] context (pp_pat context lookup))
+            items;
+          Format.fprintf fmt ")@]")
   | Kernel.PAs (name, inner) -> (
       match inner.it with
       | Kernel.PAs _ -> raise Bug_unsupported_surface_form
@@ -219,7 +263,16 @@ and pp_row context lookup fmt (row : Kernel.row) =
         if row.effects = [] then opening
         else indexed "row-effect" (List.length row.effects - 1) row.wmeta
       in
-      if row.effects <> [] && not (has_line_trailing context preceding) then Format.fprintf fmt "@ ";
+      if row.effects <> [] then begin
+        let trailing_comma = indexed "row-comma" (List.length row.effects - 1) row.wmeta in
+        if context.trivia && meta_has_comments trailing_comma then begin
+          pp_leading context trailing_comma fmt;
+          pp_inner context trailing_comma fmt;
+          pp_line_trailing context trailing_comma fmt;
+          if not (has_line_trailing context trailing_comma) then Format.fprintf fmt "@ "
+        end
+        else if not (has_line_trailing context preceding) then Format.fprintf fmt "@ "
+      end;
       let bar_meta = owned "row-bar" row.wmeta in
       pp_owned_token context bar_meta "|" fmt;
       if not (has_line_trailing context bar_meta) then Format.pp_print_char fmt ' ';
@@ -234,7 +287,20 @@ and pp_row context lookup fmt (row : Kernel.row) =
     | None when row.effects <> [] -> indexed "row-effect" (List.length row.effects - 1) row.wmeta
     | None -> opening
   in
-  if not (has_line_trailing context preceding) then Format.fprintf fmt "@;<0 -2>";
+  if not (has_line_trailing context preceding) then
+    begin match (row.effects, row.rvar) with
+    | _ :: _, None ->
+        let trailing_comma = indexed "row-comma" (List.length row.effects - 1) row.wmeta in
+        if context.trivia && meta_has_comments trailing_comma then begin
+          pp_leading context trailing_comma fmt;
+          pp_inner context trailing_comma fmt;
+          Format.pp_print_char fmt ',';
+          pp_trailing context trailing_comma fmt;
+          Format.pp_print_break fmt 1000 (-2)
+        end
+        else Format.pp_print_custom_break fmt ~fits:("", 0, "") ~breaks:(",", -2, "")
+    | _, _ -> Format.fprintf fmt "@;<0 -2>"
+    end;
   Format.fprintf fmt "@]";
   pp_owned_token context closing "}" fmt;
   pp_trailing context row.wmeta fmt
@@ -252,9 +318,10 @@ and pp_ty context lookup fmt (ty : Kernel.ty) =
       let params_meta = Meta.surface_container "params" ty.meta in
       Format.fprintf fmt "@[<hov 2>";
       pp_leading context params_meta fmt;
-      Format.fprintf fmt "(%a" (pp_sep "," (pp_ty context lookup)) params;
-      pp_inner context params_meta fmt;
-      Format.fprintf fmt ")";
+      Format.fprintf fmt "(@[<hv 1>%a"
+        (pp_comma_list ~inner_metas:[ params_meta ] context (pp_ty context lookup))
+        params;
+      Format.fprintf fmt "@])";
       pp_trailing context params_meta fmt;
       Format.fprintf fmt " %a" (pp_row context lookup) row;
       if not (has_line_trailing context (owned "row-close" row.wmeta)) then Format.fprintf fmt "@ ";
@@ -266,13 +333,15 @@ and pp_ty context lookup fmt (ty : Kernel.ty) =
           pp_inner context ty.meta fmt;
           Format.pp_print_char fmt ')'
       | [ item ] ->
-          Format.fprintf fmt "(@[<hov>%a," (pp_ty context lookup) item;
-          pp_inner context ty.meta fmt;
-          Format.fprintf fmt "@])"
+          Format.fprintf fmt "@[<hv 2>(%a"
+            (pp_comma_list ~singleton:true ~inner_metas:[ ty.meta ] context (pp_ty context lookup))
+            [ item ];
+          Format.fprintf fmt ")@]"
       | _ ->
-          Format.fprintf fmt "(@[<hov>%a" (pp_sep "," (pp_ty context lookup)) items;
-          pp_inner context ty.meta fmt;
-          Format.fprintf fmt "@])")
+          Format.fprintf fmt "@[<hv 2>(%a"
+            (pp_comma_list ~inner_metas:[ ty.meta ] context (pp_ty context lookup))
+            items;
+          Format.fprintf fmt ")@]")
   | Kernel.TForall (tvars, rvars, body) ->
       let forall_meta = Meta.surface_container "forall" ty.meta in
       pp_leading context forall_meta fmt;
@@ -443,31 +512,34 @@ and pp_kernel_expr context lookup fmt (expr : Kernel.expr) =
       | None -> Format.fprintf fmt "#group[%d]" index)
   | Kernel.Lam (params, body) ->
       let params_meta = Meta.surface_container "params" expr.meta in
-      Format.fprintf fmt "@[<hov 2>fn ";
+      Format.fprintf fmt "@[<hv 2>fn ";
       pp_leading context params_meta fmt;
-      Format.fprintf fmt "(%a" (pp_sep "," (pp_pat context lookup)) params;
-      pp_inner context params_meta fmt;
+      Format.fprintf fmt "(%a"
+        (pp_comma_list ~inner_metas:[ params_meta ] context (pp_pat context lookup))
+        params;
       Format.fprintf fmt ")";
       pp_trailing context params_meta fmt;
       Format.fprintf fmt " ->@ %a@]" (pp_expr context lookup) body
   | Kernel.App (fn, args) ->
-      Format.fprintf fmt "@[<hov 2>%a(@,%a" (pp_expr_atom context lookup) fn
-        (pp_sep "," (pp_expr context lookup))
+      Format.fprintf fmt "@[<hv 2>%a(%a" (pp_expr_atom context lookup) fn
+        (pp_comma_list ~inner_metas:[ expr.meta ] context (pp_expr context lookup))
         args;
-      pp_inner context expr.meta fmt;
       Format.fprintf fmt ")@]"
   | Kernel.Let _ -> pp_block context lookup fmt expr
   | Kernel.Tuple items -> (
       match items with
       | [] -> Format.pp_print_string fmt "()"
       | [ item ] ->
-          Format.fprintf fmt "(@[<hov>%a," (pp_expr context lookup) item;
-          pp_inner context expr.meta fmt;
-          Format.fprintf fmt "@])"
+          Format.fprintf fmt "@[<hv 2>(%a"
+            (pp_comma_list ~singleton:true ~inner_metas:[ expr.meta ] context
+               (pp_expr context lookup))
+            [ item ];
+          Format.fprintf fmt ")@]"
       | _ ->
-          Format.fprintf fmt "(@[<hov>%a" (pp_sep "," (pp_expr context lookup)) items;
-          pp_inner context expr.meta fmt;
-          Format.fprintf fmt "@])")
+          Format.fprintf fmt "@[<hv 2>(%a"
+            (pp_comma_list ~inner_metas:[ expr.meta ] context (pp_expr context lookup))
+            items;
+          Format.fprintf fmt ")@]")
   | Kernel.Ann (subject, ty) ->
       Format.fprintf fmt "@[<hov 2>(%a :@ %a" (pp_expr context lookup) subject
         (pp_ty context lookup) ty;
@@ -549,10 +621,10 @@ and list_items expr =
 and pp_list context lookup meta fmt items =
   let container_meta = Meta.surface_container "list" meta in
   pp_leading context container_meta fmt;
-  Format.fprintf fmt "[@[<hov>%a" (pp_sep "," (pp_expr context lookup)) items;
-  pp_inner context meta fmt;
-  pp_inner context container_meta fmt;
-  Format.fprintf fmt "@]]";
+  Format.fprintf fmt "@[<hv 2>[%a"
+    (pp_comma_list ~inner_metas:[ meta; container_meta ] context (pp_expr context lookup))
+    items;
+  Format.fprintf fmt "]@]";
   pp_trailing context container_meta fmt
 
 and pp_pipe context lookup meta fmt left fn args =
@@ -572,12 +644,10 @@ and pp_pipe context lookup meta fmt left fn args =
       pp_inner context meta fmt;
       Format.fprintf fmt "@]"
   | _ ->
-      Format.fprintf fmt "@[<hov 2>%a@ %a%a(@,%a" (pp_pipe_left context lookup) left pp_operator ()
+      Format.fprintf fmt "@[<hv 2>%a@ %a%a(%a" (pp_pipe_left context lookup) left pp_operator ()
         (pp_expr_atom context lookup) fn
-        (pp_sep "," (pp_expr context lookup))
+        (pp_comma_list ~inner_metas:[ rhs_meta; meta ] context (pp_expr context lookup))
         args;
-      pp_inner context rhs_meta fmt;
-      pp_inner context meta fmt;
       Format.fprintf fmt ")";
       pp_trailing context rhs_meta fmt;
       Format.fprintf fmt "@]"
@@ -632,10 +702,11 @@ and pp_sequence_item context lookup fmt (meta, isrec, binder, value) =
       pp_trailing context meta fmt
   | true, Kernel.PVar name, Kernel.Lam (params, body) ->
       let params_meta = Meta.surface_container "params" value.meta in
-      Format.fprintf fmt "@[<hov 2>let rec %a" (pp_named Surface_name.Term) name;
+      Format.fprintf fmt "@[<hv 2>let rec %a" (pp_named Surface_name.Term) name;
       pp_leading context params_meta fmt;
-      Format.fprintf fmt "(%a" (pp_sep "," (pp_pat context lookup)) params;
-      pp_inner context params_meta fmt;
+      Format.fprintf fmt "(%a"
+        (pp_comma_list ~inner_metas:[ params_meta ] context (pp_pat context lookup))
+        params;
       Format.fprintf fmt ")";
       pp_trailing context params_meta fmt;
       Format.fprintf fmt " =@ %a@]" (pp_expr context lookup) body;
@@ -714,10 +785,11 @@ and pp_handle context lookup meta fmt body ret ops =
   let pp_op fmt (clause : Kernel.opclause) =
     let params_meta = Meta.surface_container "params" clause.ometa in
     pp_leading context clause.ometa fmt;
-    Format.fprintf fmt "@[<hov 2>| %a" (pp_gref lookup Surface_name.Op clause.ometa) clause.op;
+    Format.fprintf fmt "@[<hv 2>| %a" (pp_gref lookup Surface_name.Op clause.ometa) clause.op;
     pp_leading context params_meta fmt;
-    Format.fprintf fmt "(%a" (pp_sep "," (pp_pat context lookup)) clause.params;
-    pp_inner context params_meta fmt;
+    Format.fprintf fmt "(%a"
+      (pp_comma_list ~inner_metas:[ params_meta ] context (pp_pat context lookup))
+      clause.params;
     Format.fprintf fmt ")";
     pp_trailing context params_meta fmt;
     Format.fprintf fmt " resume %a ->@ %a@]" pp_resume clause.resume (pp_arm_body context lookup)
@@ -814,10 +886,11 @@ let pp_binding context lookup fmt (binding : Kernel.binding) =
           if Meta.is_empty params_meta then Meta.surface_container "params" binding.value.meta
           else params_meta
         in
-        Format.fprintf fmt "@[<hov 2>%a" (pp_named Surface_name.Term) binding.bname;
+        Format.fprintf fmt "@[<hv 2>%a" (pp_named Surface_name.Term) binding.bname;
         pp_leading context params_meta fmt;
-        Format.fprintf fmt "(%a" (pp_sep "," (pp_pat context lookup)) params;
-        pp_inner context params_meta fmt;
+        Format.fprintf fmt "(%a"
+          (pp_comma_list ~inner_metas:[ params_meta ] context (pp_pat context lookup))
+          params;
         Format.fprintf fmt ")";
         pp_trailing context params_meta fmt;
         Format.fprintf fmt " =@ %a@]" (pp_expr context lookup) body
@@ -849,15 +922,16 @@ let pp_field context lookup fmt (field : Kernel.field) =
 
 let pp_constructor ?(leading = true) context lookup fmt (constructor : Kernel.conspec) =
   if leading then pp_leading context constructor.kmeta fmt;
-  Format.fprintf fmt "@[<hov>";
+  Format.fprintf fmt "@[<hv 2>";
   pp_named Surface_name.Con fmt constructor.con_name;
   if constructor.fields <> [] then
     if List.exists (fun field -> Option.is_some field.Kernel.label) constructor.fields then begin
       let params_meta = Meta.surface_container "params" constructor.kmeta in
       pp_leading context params_meta fmt;
-      Format.fprintf fmt "(@[<hov>%a" (pp_sep "," (pp_field context lookup)) constructor.fields;
-      pp_inner context params_meta fmt;
-      Format.fprintf fmt "@])"
+      Format.fprintf fmt "(%a"
+        (pp_comma_list ~inner_metas:[ params_meta ] context (pp_field context lookup))
+        constructor.fields;
+      Format.fprintf fmt ")"
     end
     else
       List.iter
@@ -875,10 +949,13 @@ let pp_operation ?inherited_mode context lookup fmt (operation : Kernel.opspec) 
   | Some mode when mode = operation.op_mode -> ()
   | Some _ -> raise Bug_unsupported_surface_form
   | None -> Format.fprintf fmt "%s " (mode_name operation.op_mode));
-  Format.fprintf fmt "@[<hov 2>%a :@ " (pp_named Surface_name.Op) operation.op_name;
+  Format.fprintf fmt "@[<hv 2>%a :@ " (pp_named Surface_name.Op) operation.op_name;
   pp_leading context params_meta fmt;
-  Format.fprintf fmt "(%a" (pp_sep "," (pp_ty context lookup)) operation.op_params;
-  pp_inner context params_meta fmt;
+  (* The signature box may already have broken after [:]. Padding the nested custom breaks keeps
+     parameter types two columns inside [(], while [)] returns to the opening delimiter's column. *)
+  Format.fprintf fmt "(%a"
+    (pp_comma_list ~break_padding:"  " ~inner_metas:[ params_meta ] context (pp_ty context lookup))
+    operation.op_params;
   Format.fprintf fmt ")";
   pp_trailing context params_meta fmt;
   Format.fprintf fmt " ->@ %a@]" (pp_ty context lookup) operation.op_result;
@@ -1049,10 +1126,10 @@ let pp_op_fragment context lookup fmt (clause : Kernel.opclause) =
     if String.equal name "_" then Format.pp_print_string fmt "_"
     else pp_named Surface_name.Term fmt name
   in
-  Format.fprintf fmt "@[<hov 2>| %a(%a) resume %a ->@ %a@]"
+  Format.fprintf fmt "@[<hv 2>| %a(%a) resume %a ->@ %a@]"
     (pp_gref lookup Surface_name.Op clause.ometa)
     clause.op
-    (pp_sep "," (pp_pat context lookup))
+    (pp_comma_list context (pp_pat context lookup))
     clause.params pp_resume clause.resume (pp_arm_body context lookup) clause.obody
 
 let fragment_error form =

--- a/test/test_surface_check.ml
+++ b/test/test_surface_check.ml
@@ -92,9 +92,6 @@ let test_hole_kinds_and_independent_islands () =
       ( "row-missing-tail",
         "broken : () ->{|} Int\nbroken() = 1\nlater = 42\n",
         [ e1220 "row-missing-tail.jac:1:17-18" "expected a lowercase row variable after `|`" ] );
-      ( "row-trailing-comma",
-        "broken : () ->{Net,} Int\nbroken() = 1\nlater = 42\n",
-        [ e1220 "row-trailing-comma.jac:1:20-21" "effect rows do not permit a trailing comma" ] );
     ]
   in
   List.iter
@@ -112,11 +109,11 @@ let test_hole_kinds_and_independent_islands () =
 let test_malformed_row_checks_as_any_row () =
   let report =
     analyze ~file:"row-any.jac"
-      "takes : (() ->{Net,} Int) ->{} Int\ntakes(thunk) = 1\nquiet() = 1\ntakes(quiet)\n"
+      "takes : (() ->{|} Int) ->{} Int\ntakes(thunk) = 1\nquiet() = 1\ntakes(quiet)\n"
   in
   Alcotest.(check (list string))
     "only the primary malformed-row diagnostic"
-    [ e1220 "row-any.jac:1:20-21" "effect rows do not permit a trailing comma" ]
+    [ e1220 "row-any.jac:1:17-18" "expected a lowercase row variable after `|`" ]
     (report_golden report);
   Alcotest.(check (list string))
     "surrounding declarations still check" [ "takes"; "quiet"; "_" ] (signature_names report)

--- a/test/test_surface_control_sugar.ml
+++ b/test/test_surface_control_sugar.ml
@@ -126,6 +126,9 @@ let test_list_shapes_and_hashes () =
       ( "non-empty list",
         "[a, b, x]",
         "(app (var cons) (var a) (app (var cons) (var b) (app (var cons) (var x) (var nil))))" );
+      ( "trailing list comma",
+        "[a, b, x,]",
+        "(app (var cons) (var a) (app (var cons) (var b) (app (var cons) (var x) (var nil))))" );
       ( "nested lists",
         "[[a], [], [b, x]]",
         "(app (var cons) (app (var cons) (var a) (var nil)) (app (var cons) (var nil) (app (var \
@@ -468,7 +471,6 @@ let test_malformed_and_recovery () =
   Alcotest.(check (list string))
     "exact malformed diagnostics"
     [
-      e1220 "bad-ss13.jac:1:4-5" "list literals do not permit a trailing comma";
       e1220 "bad-ss13.jac:2:6-7"
         "unclosed `if`: expected `then` after the condition, found ident(a) The `if` expression \
          opened at bad-ss13.jac:2:1-3.";

--- a/test/test_surface_decls.ml
+++ b/test/test_surface_decls.ml
@@ -223,6 +223,9 @@ let test_type_declarations () =
   let no_initial_bar = only_decl (lower "type Unitish = Unitish\n") in
   let positional = only_decl (lower "type Pair a b = | Pair a b\n") in
   let labeled = only_decl (lower "type Fleet = | MkFleet(inv: SvcMood, pay: SvcMood)\n") in
+  let labeled_trailing =
+    only_decl (lower "type Fleet = | MkFleet(inv: SvcMood, pay: SvcMood,)\n")
+  in
   let mixed = only_decl (lower "type Mixed = | MkMixed(left: SvcMood, SvcMood)\n") in
   let labels declaration =
     match declaration.Kernel.it with
@@ -234,6 +237,8 @@ let test_type_declarations () =
   Alcotest.(check (list (option string))) "positional labels" [ None; None ] (labels positional);
   Alcotest.(check (list (option string)))
     "labeled fields" [ Some "inv"; Some "pay" ] (labels labeled);
+  Alcotest.(check (list (option string)))
+    "labeled fields trailing comma" (labels labeled) (labels labeled_trailing);
   Alcotest.(check (list (option string))) "mixed fields" [ Some "left"; None ] (labels mixed);
   (match
      (only_decl (lower "type Wrapped a = | MkWrapped(value:\n  List\n    a\n)\n")).Kernel.it
@@ -259,12 +264,11 @@ let test_type_declarations () =
       } ->
       ()
   | _ -> Alcotest.fail "valid multiline labeled field type was weakened by recovery lookahead");
-  has_code "E1225" "type Bad a = | Some(a)\n";
-  has_code "E1225" "type Bad = | MkBad(field: Bad,)\n"
+  has_code "E1225" "type Bad a = | Some(a)\n"
 
 let test_effect_declarations () =
   let declaration =
-    only_decl (lower "multi effect Choice a where {\n  choose : (a, Text) -> Bool\n}\n")
+    only_decl (lower "multi effect Choice a where {\n  choose : (a, Text,) -> Bool\n}\n")
   in
   (match declaration.Kernel.it with
   | Kernel.DefEffect

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -57,7 +57,7 @@ let test_one_page_grammar_snapshot () =
   Alcotest.(check bool) "L7 grammar stays within 100 nonblank lines" true (List.length lines <= 100);
   Alcotest.(check string)
     "L7 grammar snapshot (review docs/surface-syntax.md before updating)"
-    "e564dd92d4b632d4cd8b724ba8bf830ba2489527387c74e93e722ac7b808ffc8"
+    "a813f6829812989a1da38508f7ffe0b30c347d021852f9156fedac11da08545b"
     (Hash.to_hex (Hash.of_string grammar))
 
 let format_surface ?width path source =
@@ -149,6 +149,152 @@ let test_plain_text_formatter_contract () =
     "formatting does not change canonical identity"
     (surface_hashes "plain-text.jac" source)
     (surface_hashes "plain-text.jac" once)
+
+let test_multiline_comma_layout_contract () =
+  let source =
+    {|
+("first-long-item", "second-long-item", "third-long-item",)
+(1, -- first item
+ 2,)
+f(first-long-argument, -- after-final-comma
+)
+(first-long-item, -- after-final-tuple-comma
+)
+[first-long-item, -- after-final-list-comma
+]
+|}
+  in
+  let compact = format_surface ~width:100 "comma-layout.jac" source in
+  let wrapped = format_surface ~width:24 "comma-layout.jac" source in
+  Alcotest.(check bool)
+    "compact multi-item tuple has no final comma" true
+    (contains {|("first-long-item", "second-long-item", "third-long-item")|} compact);
+  Alcotest.(check bool)
+    "wrapped tuple is one item per line with a final comma" true
+    (contains {|(
+  "first-long-item",
+  "second-long-item",
+  "third-long-item",
+)|} wrapped);
+  Alcotest.(check bool) "item comment survives" true (contains "-- first item" wrapped);
+  List.iter
+    (fun (label, expected) ->
+      Alcotest.(check bool)
+        (label ^ " keeps the close aligned after final-comma trivia")
+        true (contains expected wrapped))
+    [
+      ("call", {|f(
+  first-long-argument,
+  -- after-final-comma
+)|});
+      ("tuple", {|(
+  first-long-item,
+  -- after-final-tuple-comma
+)|});
+      ("list", {|[
+  first-long-item,
+  -- after-final-list-comma
+]|});
+    ];
+  Alcotest.(check string)
+    "multiline comma layout is idempotent" wrapped
+    (format_surface ~width:24 "comma-layout.jac" wrapped);
+  let identity_source = "(\"first-long-item\", \"second-long-item\", \"third-long-item\",)\n" in
+  let identity_formatted = format_surface ~width:24 "comma-identity.jac" identity_source in
+  Alcotest.(check (list string))
+    "accepted and emitted commas do not change identity"
+    (surface_hashes "comma-identity.jac" identity_source)
+    (surface_hashes "comma-identity.jac" identity_formatted)
+
+let test_multiline_comma_contexts () =
+  let source =
+    {|
+very-long-call-name(first-argument-with-a-very-long-name, second-argument-with-a-very-long-name, third-argument-with-a-very-long-name,)
+
+[first-list-item-with-a-very-long-name, second-list-item-with-a-very-long-name, third-list-item-with-a-very-long-name,]
+
+very-long-function-name(first-parameter-with-a-very-long-name, second-parameter-with-a-very-long-name, third-parameter-with-a-very-long-name, -- final function parameter
+) = first-parameter-with-a-very-long-name
+
+match subject {
+  | VeryLongConstructor(first-pattern-with-a-very-long-name, second-pattern-with-a-very-long-name, third-pattern-with-a-very-long-name, -- final pattern argument
+    ) -> first-pattern-with-a-very-long-name
+}
+
+type LongFields = | MakeLongFields(first-field-with-a-very-long-name: FirstFieldTypeWithAVeryLongName, second-field-with-a-very-long-name: SecondFieldTypeWithAVeryLongName, third-field-with-a-very-long-name: ThirdFieldTypeWithAVeryLongName, -- final labeled field
+)
+
+multi effect LongOperation where {
+  very-long-operation-name : (FirstParameterTypeWithAVeryLongName, SecondParameterTypeWithAVeryLongName, ThirdParameterTypeWithAVeryLongName, -- final operation parameter
+  ) -> ()
+}
+|}
+  in
+  let formatted = format_surface "comma-contexts.jac" source in
+  let expected_contexts =
+    [
+      ( "call arguments",
+        {|very-long-call-name(
+  first-argument-with-a-very-long-name,
+  second-argument-with-a-very-long-name,
+  third-argument-with-a-very-long-name,
+)|}
+      );
+      ( "list items",
+        {|
+[
+  first-list-item-with-a-very-long-name,
+  second-list-item-with-a-very-long-name,
+  third-list-item-with-a-very-long-name,
+]|}
+      );
+      ( "function parameters",
+        {|
+very-long-function-name(
+  first-parameter-with-a-very-long-name,
+  second-parameter-with-a-very-long-name,
+  third-parameter-with-a-very-long-name,
+  -- final function parameter
+) =|}
+      );
+      ( "constructor-pattern arguments",
+        {|
+  | VeryLongConstructor(
+      first-pattern-with-a-very-long-name,
+      second-pattern-with-a-very-long-name,
+      third-pattern-with-a-very-long-name,
+      -- final pattern argument
+    ) ->|}
+      );
+      ( "labeled constructor fields",
+        {|
+  | MakeLongFields(
+      first-field-with-a-very-long-name: FirstFieldTypeWithAVeryLongName,
+      second-field-with-a-very-long-name: SecondFieldTypeWithAVeryLongName,
+      third-field-with-a-very-long-name: ThirdFieldTypeWithAVeryLongName,
+      -- final labeled field
+    )|}
+      );
+      ( "effect-operation parameters",
+        {|
+    (
+      FirstParameterTypeWithAVeryLongName,
+      SecondParameterTypeWithAVeryLongName,
+      ThirdParameterTypeWithAVeryLongName,
+      -- final operation parameter
+    ) ->|}
+      );
+    ]
+  in
+  List.iter
+    (fun (label, expected) ->
+      Alcotest.(check bool)
+        (label ^ " uses vertical final-comma layout")
+        true (contains expected formatted))
+    expected_contexts;
+  Alcotest.(check string)
+    "all comma-list contexts are idempotent" formatted
+    (format_surface "comma-contexts.jac" formatted)
 
 let trim = String.trim
 
@@ -1142,6 +1288,8 @@ let suite =
     Alcotest.test_case "constructor standard width boundary" `Quick
       test_constructor_standard_width_boundary;
     Alcotest.test_case "plain-text formatter contract" `Quick test_plain_text_formatter_contract;
+    Alcotest.test_case "multiline comma layout contract" `Quick test_multiline_comma_layout_contract;
+    Alcotest.test_case "multiline comma contexts" `Quick test_multiline_comma_contexts;
     Alcotest.test_case "release tables stop before later subheadings" `Quick
       test_table_rows_stop_at_later_subheading;
     Alcotest.test_case "structured release decision" `Quick assert_release_valid;

--- a/test/test_surface_parse.ml
+++ b/test/test_surface_parse.ml
@@ -52,12 +52,14 @@ let test_atoms () =
 let test_calls () =
   check_equivalent "zero arguments" "f()" "(app (var f))";
   check_equivalent "multiline arguments" "f(\n  1,\n  2\n)" "(app (var f) (lit 1) (lit 2))";
+  check_equivalent "trailing call comma" "f(1, 2,)" "(app (var f) (lit 1) (lit 2))";
   check_equivalent "postfix left associativity" "f()(1)(2, 3)"
     "(app (app (app (var f)) (lit 1)) (lit 2) (lit 3))"
 
 let test_functions_and_patterns () =
   check_equivalent "function and irrefutable patterns" "fn (_, (x, y)) -> x"
     "(lam ((pwild) (ptuple (pvar x) (pvar y))) (var x))";
+  check_equivalent "trailing parameter comma" "fn (x, y,) -> x" "(lam ((pvar x) (pvar y)) (var x))";
   check_equivalent "zero argument function" "fn () -> ()" "(lam () (tuple))";
   List.iter
     (fun source ->
@@ -80,7 +82,9 @@ let test_parentheses_and_tuples () =
   check_equivalent "grouping" "(1)" "(lit 1)";
   check_equivalent "unit" "()" "(tuple)";
   check_equivalent "singleton" "(1,)" "(tuple (lit 1))";
-  check_equivalent "multi" "(1, 2, f(3))" "(tuple (lit 1) (lit 2) (app (var f) (lit 3)))"
+  check_equivalent "multi" "(1, 2, f(3))" "(tuple (lit 1) (lit 2) (app (var f) (lit 3)))";
+  check_equivalent "multi trailing comma" "(1, 2, f(3),)"
+    "(tuple (lit 1) (lit 2) (app (var f) (lit 3)))"
 
 let test_annotations_and_complete_types () =
   let zeros = String.make 64 '0' in
@@ -102,9 +106,12 @@ let test_annotations_and_complete_types () =
     "(ann (var x) (tforall ((tvar a)) ((rvar e)) (tarrow ((tvar a)) (row (eref console) e) (tvar \
      a))))";
   check_equivalent "grouped type" "(x : (List a))" "(ann (var x) (tapp (tref list) (tvar a)))";
-  Alcotest.(check bool)
-    "row trailing comma rejected" true
-    (List.mem "E1220" (error_codes "(x : () ->{Console,} Unit)"))
+  check_equivalent "row trailing comma" "(x : () ->{Console,} Unit)"
+    "(ann (var x) (tarrow () (row (eref console)) (tref unit)))";
+  check_equivalent "type parameter and tuple trailing commas"
+    "(x : (List a, Text,) ->{} (a, Text,))"
+    "(ann (var x) (tarrow ((tapp (tref list) (tvar a)) (tref text)) (row) (ttuple (tvar a) (tref \
+     text))))"
 
 let test_forall_row_var_requirement () =
   check_equivalent "vacuous forall" "(x : forall . T)" "(ann (var x) (tforall () () (tref t)))";

--- a/test/test_surface_patterns.ml
+++ b/test/test_surface_patterns.ml
@@ -48,9 +48,9 @@ let test_all_pattern_forms_and_literals () =
   | _ -> 0
   | binding -> binding
   | 1 -> 1
-  | Some(value) -> value
-  | (only) -> only
-  | Pair(left, right) as whole -> whole
+  | Some(value,) -> value
+  | (only,) -> only
+  | Pair(left, right,) as whole -> whole
 }|}
     {|(match (var subject)
   (clause (pwild) (lit 0))

--- a/test/test_surface_print.ml
+++ b/test/test_surface_print.ml
@@ -158,7 +158,8 @@ let test_wrapping_is_stable () =
     "very-long-function-name(\n\
     \  \"first-long-argument\",\n\
     \  \"second-long-argument\",\n\
-    \  \"third-long-argument\")"
+    \  \"third-long-argument\",\n\
+     )"
     once
 
 let test_patterns_and_match_arms () =
@@ -175,7 +176,7 @@ let test_patterns_and_match_arms () =
   | x -> x
   | "ok" -> 1
   | Some(value) -> value
-  | (only) -> only
+  | (only,) -> only
   | (left, _) -> left
   | (first, second) as whole -> whole
 }|}

--- a/test/test_surface_types.ml
+++ b/test/test_surface_types.ml
@@ -211,6 +211,17 @@ let test_row_wrapping_threshold () =
     "wraps one effect per line"
     "->{\n  NetworkObservability,\n  FilesystemObservability,\n  DeterministicClock\n  | e\n}"
     (print_fragment ~width:(String.length compact - 1) row);
+  let closed_row =
+    "(row (eref network-observability) (eref filesystem-observability) (eref deterministic-clock))"
+  in
+  let closed_compact = "->{NetworkObservability, FilesystemObservability, DeterministicClock}" in
+  Alcotest.(check string)
+    "closed row fits without a final comma" closed_compact
+    (print_fragment ~width:(String.length closed_compact) closed_row);
+  Alcotest.(check string)
+    "closed row wraps with a final comma"
+    "->{\n  NetworkObservability,\n  FilesystemObservability,\n  DeterministicClock,\n}"
+    (print_fragment ~width:(String.length closed_compact - 2) closed_row);
   let top =
     bootstrap
       "(ann (var f) (tarrow () (row (eref network-observability) (eref filesystem-observability) \
@@ -448,13 +459,46 @@ f = 0
   Alcotest.(check string) "exact canonical placement" expected once;
   Alcotest.(check string) "type trivia idempotence" once (print_recovered once)
 
+let test_trailing_row_comma_trivia () =
+  let cases =
+    [
+      ( "closed",
+        "f : () ->{Net, -- keep closed comma\n} Text\nf = 0\n",
+        "f : () ->{Net} Text\nf = 0\n",
+        "-- keep closed comma",
+        "->{\n         Net, -- keep closed comma\n       }" );
+      ( "open",
+        "f : () ->{Net, -- keep open comma\n| e} Text\nf = 0\n",
+        "f : () ->{Net | e} Text\nf = 0\n",
+        "-- keep open comma",
+        "->{\n         Net -- keep open comma\n         | e\n       }" );
+    ]
+  in
+  List.iter
+    (fun (label, source, twin, comment, expected) ->
+      let formatted = print_recovered source in
+      Alcotest.(check bool) (label ^ " comment survives") true (contains formatted comment);
+      Alcotest.(check bool)
+        (label ^ " comma and closing-row layout is canonical")
+        true (contains formatted expected);
+      Alcotest.(check string)
+        (label ^ " formatting is idempotent")
+        formatted (print_recovered formatted);
+      match (lower source, lower twin) with
+      | [ source_top ], [ twin_top ] ->
+          Alcotest.(check bool)
+            (label ^ " trailing comma and comment are identity inert")
+            true
+            (Form.equal_ignoring_meta (form source_top) (form twin_top))
+      | _ -> Alcotest.failf "%s row fixture changed top count" label)
+    cases
+
 let test_malformed_rows_and_recovery () =
   let zero = String.make 64 '0' in
   let cases =
     [
       ("missing tail", "f : () ->{|} Text\nf = 0\n");
       ("duplicate tail", "f : () ->{Net | e | f} Text\nf = 0\n");
-      ("trailing comma", "f : () ->{Net,} Text\nf = 0\n");
       ("wrong namespace", Printf.sprintf "f : () ->{#%s:type} Text\nf = 0\n" zero);
       ("missing opening brace", "f : () ->Net Text\nf = 0\n");
       ("legacy tail-only", "f : () ->{e} Text\nf = 0\n");
@@ -563,6 +607,7 @@ let suite =
     Alcotest.test_case "resolved reference identity" `Quick test_resolved_reference_identity;
     Alcotest.test_case "checker surface signatures" `Quick test_checker_signatures_are_surface;
     Alcotest.test_case "type trivia ownership" `Quick test_type_trivia_ownership;
+    Alcotest.test_case "trailing row comma trivia" `Quick test_trailing_row_comma_trivia;
     Alcotest.test_case "malformed rows and recovery" `Quick test_malformed_rows_and_recovery;
     Alcotest.test_case "forall newline recovery" `Quick test_forall_newline_recovery_and_owners;
     Alcotest.test_case "raw and bootstrap fallback" `Quick test_raw_and_bootstrap_fallback;


### PR DESCRIPTION
## Context

Jacquard already had a canonical 100-column formatter, but comma-separated surface forms still behaved inconsistently. Calls, lists, rows, labeled fields, and several parameter forms rejected a final comma, while wrapped output did not consistently put one item on each line with a diff-stable final comma. That made ordinary edits noisier and left the documented formatter contract incomplete.

There was also a correctness risk around comments next to a final comma: the formatter must preserve the comment without adding blank lines, losing the comma required by a closed multiline row, or moving the closing delimiter out of alignment.

This PR completes that surface-formatting contract. It changes accepted `.jac` punctuation and canonical `.jac` layout only. It does not change the kernel, evaluation, hashes, `.jqd`, the runtime, or native compilation.

## What changed

- Accepts one optional final comma in calls, lists, expression and type tuples, function and handler parameter lists, arrow parameter lists, constructor patterns, labeled constructor fields, operation parameter lists, and effect lists.
- Uses one canonical comma-list layout:
  - compact groups omit the final comma, except singleton tuples where the comma carries arity;
  - wrapped groups put one item on each indented line, end every item with a comma, and put the closing delimiter on its own aligned line.
- Makes closed multiline effect rows end with a comma. Open rows omit the comma before `|` because the row tail continues the list.
- Preserves comments attached to a final comma across every supported context. The printer owns the comment breaks and closing alignment, so formatting does not insert an empty line or indent the closing delimiter incorrectly.
- Extends row trivia ownership to include the possible final comma, allowing comment-bearing commas to survive parsing and printing without affecting semantic identity.
- Updates the surface grammar, formatter documentation, and agent onboarding guidance.
- Replaces obsolete trailing-comma rejection assertions with acceptance, recovery, idempotence, comment-ownership, layout, and hash-inertia coverage.
- Updates the live successor test inventories from 829 to 832. Frozen 0.1 counts and historical manifests are unchanged.

## Why it was done this way

A trailing comma is useful editing punctuation, but it should not become a new semantic distinction. The parser therefore accepts it as surface metadata and lowering produces the same existing kernel forms as the spelling without it. Canonical hashes, evaluation order, and `.jqd` behavior remain identical.

The printer uses an all-or-nothing vertical layout after wrapping. That keeps appended arguments, fields, effects, or parameters to a one-line diff and gives reviewers a predictable shape in plain text. The same helper handles final-comma comments so layout and trivia ownership cannot drift apart between calls, tuples, lists, patterns, fields, and parameter forms.

Rows need one deliberate distinction: a closed multiline row has a true final item and prints its final comma; an open row continues into `| e`, so it erases the optional source comma while retaining any attached comment.

The existing flat `else if` behavior and W1203 manual match-scrutinee hoisting remain unchanged. The formatter still does not invent a `let` or rewrite the AST.

## Semantic contract

- Final commas are surface-only punctuation and are erased before kernel validation.
- Adding or removing an accepted final comma does not change canonical identity, hashes, evaluation, or name resolution.
- Compact multi-item groups have no final comma.
- Singleton tuple commas remain mandatory because they encode tuple arity.
- Wrapped comma groups are one item per line, with a comma after every item and an aligned own-line close.
- Closed multiline rows end with a comma; open rows do not print a comma immediately before the row tail.
- Comments retain their text, order, ownership, and idempotent placement.

## Deliberately excluded

- No new kernel forms or lowering semantics.
- No change to HASH_V0, stores, manifests, goldens, or `.jqd` syntax.
- No evaluator, effect, capability, runtime, native, or CLI-command change.
- No automatic match-scrutinee hoisting or AST rewrite.
- No readability benchmark outcome claim.
- No rewrite of frozen 0.1 or SS.22 historical evidence.

## How it was checked

- Forced full suite: all 832 compiled/QCheck tests passed in 340.803 seconds; all cram, documentation-example, native/runtime, and readability-protocol lanes passed.
- `dune build @all @doc` passed.
- `dune fmt` passed.
- Immutable SS.22 manifest verification passed at boundary `52f36133b95349ae481f091e0043e71bc1452bc3`.
- Standard whitespace and clean-worktree checks passed.
- Focused parser, declaration, pattern, control-sugar, type, printer, trivia, checker, and surface-law cases passed.
- Exact comment-adjacent probes cover calls, tuples, lists, function parameters, constructor patterns, labeled fields, operation parameters, and open/closed rows.
- Formatting-twice and canonical-identity tests passed.

## Independent review

GPT-5.6 Sol xhigh reviewed exact final commit `2e28b7496f573ba8c54fecdad631374714c2f1d4` against base `ccfbc238e284eb79d4188004ca6264fd7292a8e0`.

The first review found two valid trivia/layout blockers. Both were fixed in one batch and covered by expanded regressions. The permitted follow-up review returned **PASS** with no blockers, nonblocking findings, disputed evidence gaps, debt, or architecture conflicts.
