### PR TITLE
Pin formatter width boundaries and readable continuations

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -234,6 +234,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 | W1201 | lowercase binding pattern shadows an in-scope constructor differing only in case | `match Up { | up -> ... }` |
 | W1202 | positional constructor pattern has more than four fields | `Snapshot(_, _, _, _, _)` |
 | W1203 | match scrutinee spans more than four source lines | manually bind the expression with `let`, then match on its name |
+| W1204 | shortest legal type/effect declaration header exceeds the canonical formatter width | shorten the declaration name or type-variable list |
 
 ## Explicit bootstrap export (E13xx)
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -235,6 +235,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 | W1202 | positional constructor pattern has more than four fields | `Snapshot(_, _, _, _, _)` |
 | W1203 | match scrutinee spans more than four source lines | manually bind the expression with `let`, then match on its name |
 | W1204 | shortest legal type/effect declaration header exceeds the canonical formatter width | shorten the declaration name or type-variable list |
+| W1205 | shortest legal `forall` prefix exceeds the canonical formatter width | split the declaration or reduce its quantified variables |
 
 ## Explicit bootstrap export (E13xx)
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `832`
+- Alcotest/QCheck cases: `835`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `837`
+- Alcotest/QCheck cases: `838`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `835`
+- Alcotest/QCheck cases: `837`
 - Cram transcript files: `51`
 - Doctest examples: `27` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 837 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 838 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `837`
+- Alcotest/QCheck cases: `838`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -793,8 +793,9 @@ inventory. GM.17B adds four static effect-attribution cases and one public CLI
 transcript, and GM.17C adds five pure machine review-diff cases, producing the
 then-current `799 / 48 / 27` inventory. Later successor overlays bring the
 inventory to 828 cases; SX.25 adds one formatter-contract case. The Task 173
-formatter-width work adds two boundary cases, producing the current
-`837 / 51 / 27` inventory.
+formatter-width work adds two boundary cases, and SX.25a adds one
+colon-continuation contract case, producing the current `838 / 51 / 27`
+inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 832 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 835 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `832`
+- Alcotest/QCheck cases: `835`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -793,7 +793,7 @@ inventory. GM.17B adds four static effect-attribution cases and one public CLI
 transcript, and GM.17C adds five pure machine review-diff cases, producing the
 then-current `799 / 48 / 27` inventory. Later successor overlays bring the
 inventory to 828 cases; SX.25 adds one formatter-contract case, producing the
-current `832 / 51 / 27` inventory.
+current `835 / 51 / 27` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 835 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 837 compiled Alcotest/QCheck cases, 51 recursive
 cram transcript files, and 27 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `835`
+- Alcotest/QCheck cases: `837`
 - Cram transcript files: `51`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -792,8 +792,9 @@ one public CLI transcript, producing the then-current `790 / 47 / 27`
 inventory. GM.17B adds four static effect-attribution cases and one public CLI
 transcript, and GM.17C adds five pure machine review-diff cases, producing the
 then-current `799 / 48 / 27` inventory. Later successor overlays bring the
-inventory to 828 cases; SX.25 adds one formatter-contract case, producing the
-current `835 / 51 / 27` inventory.
+inventory to 828 cases; SX.25 adds one formatter-contract case. The Task 173
+formatter-width work adds two boundary cases, producing the current
+`837 / 51 / 27` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -327,9 +327,10 @@ Each is a CI property, not a goal.
 
 The canonical `.jac` formatter uses a 100-column margin. Omitting the printer's
 `width` argument is exactly the same as passing `width = 100`; the `jac fmt`
-command uses that default. The margin is where breakable groups choose between
-one line and multiple lines, not a promise to split an indivisible identifier,
-string, comment, or other UTF-8 token.
+command uses that default. Breakable structure never exceeds the selected
+margin, and a complete group that fits exactly remains compact. The formatter
+does not split an indivisible identifier, string, comment, or other UTF-8
+token, so one of those tokens may exceed the margin.
 
 Formatting emits deterministic plain UTF-8 text with no ANSI color or other
 terminal styling. It preserves comment and documentation text but normalizes

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -327,8 +327,10 @@ Each is a CI property, not a goal.
 
 The canonical `.jac` formatter uses a 100-column margin. Omitting the printer's
 `width` argument is exactly the same as passing `width = 100`; the `jac fmt`
-command uses that default. Breakable structure never exceeds the selected
-margin, and a complete group that fits exactly remains compact. Three forms may
+command uses that default. Width is measured in UTF-8 bytes, matching source
+columns and the formatter's layout accounting. Breakable structure never
+exceeds the selected margin, and a complete group that fits exactly remains
+compact. Three forms may
 exceed it:
 
 - a residual indivisible identifier, string, comment, or other UTF-8 token is
@@ -342,12 +344,15 @@ exceed it:
   quantified variables or before `.`.
 
 The surface checker reports W1204 on a declaration name when its shortest
-canonical header exceeds the default 100-column width. Formatting remains
+canonical header exceeds the default 100-byte width. Formatting remains
 total; the warning recommends shortening the declaration name or type-variable
-list rather than changing valid source into a different carrier. W1205 reports
-the same condition for a `forall` prefix and recommends splitting the
-declaration or reducing its quantified variables. Multiline declaration headers
-and quantified binders are one post-0.1 grammar-design question.
+list rather than changing valid source into a different carrier. W1205 selects
+each offending `forall` prefix, including prefixes in nested expression
+annotations, and recommends splitting the declaration or reducing its
+quantified variables. These diagnostics fire only when a construct cannot fit
+at any indentation; they are necessary rather than exhaustive descriptions of
+over-wide physical lines. Multiline declaration headers and quantified binders
+are one post-0.1 grammar-design question.
 
 Top-level signatures and labeled constructor fields use their existing legal
 continuation immediately after `:`. The name and colon stay together. When the

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -325,13 +325,19 @@ Each is a CI property, not a goal.
 
 ### Canonical formatter contract
 
-The canonical `.jac` formatter uses a 100-column margin. Omitting the printer's
-`width` argument is exactly the same as passing `width = 100`; the `jac fmt`
-command uses that default. Width is measured in UTF-8 bytes, matching source
-columns and the formatter's layout accounting. Breakable structure never
-exceeds the selected margin, and a complete group that fits exactly remains
-compact. Three forms may
-exceed it:
+The canonical `.jac` formatter uses a 100-byte layout target. Omitting the
+printer's `width` argument is exactly the same as passing `width = 100`; the
+`jac fmt` command uses that default. Width is measured in UTF-8 bytes, matching
+source columns and the formatter's layout accounting.
+
+The target is not a global physical-line postcondition. The formatter lays out
+each top-level unit as a whole. It first uses one extra internal byte so a group
+ending exactly at the target can remain compact, and keeps that rendering only
+when every line still fits. Otherwise it lays out the whole unit at the
+requested target. An exact-fit subgroup can therefore break when another line
+in the same unit forces that fallback.
+
+Known overflow cases include, but are not limited to:
 
 - a residual indivisible identifier, string, comment, or other UTF-8 token is
   never split after the formatter takes every legal break;
@@ -341,7 +347,11 @@ exceed it:
   margin by exactly the shortest-header length minus the margin;
 - a `forall` prefix whose shortest legal rendering exceeds the margin remains
   on one logical line because `.jac` has no continuation point between its
-  quantified variables or before `.`.
+  quantified variables or before `.`;
+- syntax emitted next to a measured breakable group can push the physical line
+  past the target, such as the arrow after a match-clause pattern;
+- an unsupported kernel form may use the raw `jqd { ... }` inversion escape,
+  whose preserved bootstrap form can be wider than the target.
 
 The surface checker reports W1204 on a declaration name when its shortest
 canonical header exceeds the default 100-byte width. Formatting remains

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -328,20 +328,32 @@ Each is a CI property, not a goal.
 The canonical `.jac` formatter uses a 100-column margin. Omitting the printer's
 `width` argument is exactly the same as passing `width = 100`; the `jac fmt`
 command uses that default. Breakable structure never exceeds the selected
-margin, and a complete group that fits exactly remains compact. Two forms may
+margin, and a complete group that fits exactly remains compact. Three forms may
 exceed it:
 
-- an indivisible identifier, string, comment, or other UTF-8 token is never
-  split;
+- a residual indivisible identifier, string, comment, or other UTF-8 token is
+  never split after the formatter takes every legal break;
 - a type or effect declaration header whose shortest legal rendering exceeds
   the margin remains on one logical line, because `.jac` requires the name and
   `=` or `where` together. That line contains only the header and exceeds the
-  margin by exactly the shortest-header length minus the margin.
+  margin by exactly the shortest-header length minus the margin;
+- a `forall` prefix whose shortest legal rendering exceeds the margin remains
+  on one logical line because `.jac` has no continuation point between its
+  quantified variables or before `.`.
 
 The surface checker reports W1204 on a declaration name when its shortest
 canonical header exceeds the default 100-column width. Formatting remains
 total; the warning recommends shortening the declaration name or type-variable
-list rather than changing valid source into a different carrier.
+list rather than changing valid source into a different carrier. W1205 reports
+the same condition for a `forall` prefix and recommends splitting the
+declaration or reducing its quantified variables. Multiline declaration headers
+and quantified binders are one post-0.1 grammar-design question.
+
+Top-level signatures and labeled constructor fields use their existing legal
+continuation immediately after `:`. The name and colon stay together. When the
+flat group does not fit, the type starts on the next line two spaces inside the
+owning item; nested type layout continues from there. A labeled-field comma
+stays attached to the final line of its type.
 
 Formatting emits deterministic plain UTF-8 text with no ANSI color or other
 terminal styling. It preserves comment and documentation text but normalizes

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -328,9 +328,20 @@ Each is a CI property, not a goal.
 The canonical `.jac` formatter uses a 100-column margin. Omitting the printer's
 `width` argument is exactly the same as passing `width = 100`; the `jac fmt`
 command uses that default. Breakable structure never exceeds the selected
-margin, and a complete group that fits exactly remains compact. The formatter
-does not split an indivisible identifier, string, comment, or other UTF-8
-token, so one of those tokens may exceed the margin.
+margin, and a complete group that fits exactly remains compact. Two forms may
+exceed it:
+
+- an indivisible identifier, string, comment, or other UTF-8 token is never
+  split;
+- a type or effect declaration header whose shortest legal rendering exceeds
+  the margin remains on one logical line, because `.jac` requires the name and
+  `=` or `where` together. That line contains only the header and exceeds the
+  margin by exactly the shortest-header length minus the margin.
+
+The surface checker reports W1204 on a declaration name when its shortest
+canonical header exceeds the default 100-column width. Formatting remains
+total; the warning recommends shortening the declaration name or type-variable
+list rather than changing valid source into a different carrier.
 
 Formatting emits deterministic plain UTF-8 text with no ANSI color or other
 terminal styling. It preserves comment and documentation text but normalizes

--- a/src/surface_check.ml
+++ b/src/surface_check.ml
@@ -200,6 +200,58 @@ let warning_large_scrutinee (subject : Surface_ast.expr) lines =
          lines large_match_scrutinee_lines)
     ~next_step:"Bind the expression with `let`, then match on that name." ~contrast:None ()
 
+let declaration_header_name_meta (top : Surface_ast.top) =
+  let name_meta = Meta.surface_container "declaration-name" top.meta in
+  if Meta.is_empty name_meta then top.meta else name_meta
+
+let rendered_names_length kind names =
+  List.fold_left
+    (fun length name -> length + 1 + String.length (Surface_name.render kind name))
+    0 names
+
+let type_header_length name vars =
+  String.length "type "
+  + String.length (Surface_name.render Surface_name.Type name)
+  + rendered_names_length Surface_name.Tvar vars
+  + String.length " ="
+
+let uniform_effect_mode (operations : Surface_ast.operation list) =
+  match operations with
+  | { Surface_ast.mode = Some mode; _ } :: rest
+    when List.for_all (fun operation -> operation.Surface_ast.mode = Some mode) rest ->
+      Some mode
+  | _ -> None
+
+let effect_header_length name vars operations =
+  let prefix =
+    match uniform_effect_mode operations with
+    | Some Kernel.Once -> "once effect "
+    | Some Kernel.Multi -> "multi effect "
+    | None -> "effect "
+  in
+  String.length prefix
+  + String.length (Surface_name.render Surface_name.Effect name)
+  + rendered_names_length Surface_name.Tvar vars
+  + String.length " where {"
+
+let warning_long_declaration_header (top : Surface_ast.top) kind name length =
+  let rendered_name = Surface_name.render kind name in
+  Diag.warning
+    ?span:(Meta.span (declaration_header_name_meta top))
+    ~domain:Surface ~code:"W1204"
+    ~summary:"Declaration header exceeds the canonical formatter width"
+    ~cause:
+      (Printf.sprintf
+         "The shortest legal header for `%s` is %d columns, but the canonical formatter width is \
+          %d; `.jac` requires this header to remain on one logical line."
+         rendered_name length Surface_print.default_width)
+    ~next_step:"Shorten the declaration name or its type-variable list." ~contrast:None ()
+
+let long_declaration_header_warning top kind name length =
+  if length > Surface_print.default_width then
+    [ warning_long_declaration_header top kind name length ]
+  else []
+
 let span_line_count meta =
   Option.map (fun span -> span.Span.end_pos.line - span.Span.start_pos.line + 1) (Meta.span meta)
 
@@ -278,9 +330,12 @@ let lint_top names constructors (top : Surface_ast.top) =
   | Surface_ast.Definition { params; value; _ } ->
       List.concat_map (lint_pat names constructors) params @ lint_expr names constructors value
   | Surface_ast.TopExpr expression -> lint_expr names constructors expression
-  | Surface_ast.Signature _ | Surface_ast.TypeDecl _ | Surface_ast.EffectDecl _
-  | Surface_ast.RawTop _ | Surface_ast.TopHole _ ->
-      []
+  | Surface_ast.TypeDecl { name; vars; _ } ->
+      long_declaration_header_warning top Surface_name.Type name (type_header_length name vars)
+  | Surface_ast.EffectDecl { name; vars; operations } ->
+      long_declaration_header_warning top Surface_name.Effect name
+        (effect_header_length name vars operations)
+  | Surface_ast.Signature _ | Surface_ast.RawTop _ | Surface_ast.TopHole _ -> []
 
 let lint_file names tops =
   let rec loop constructors diagnostics = function

--- a/src/surface_check.ml
+++ b/src/surface_check.ml
@@ -252,6 +252,50 @@ let long_declaration_header_warning top kind name length =
     [ warning_long_declaration_header top kind name length ]
   else []
 
+let quantifier_prefix_length type_vars row_vars =
+  String.length "forall"
+  + rendered_names_length Surface_name.Tvar type_vars
+  + (if row_vars = [] then 0 else String.length " |")
+  + rendered_names_length Surface_name.Rvar row_vars
+  + String.length "."
+
+let rec longest_quantifier_prefix (annotation : Surface_ast.ty) =
+  let longest annotations =
+    List.fold_left
+      (fun found annotation -> max found (longest_quantifier_prefix annotation))
+      0 annotations
+  in
+  match annotation.it with
+  | Surface_ast.TyForall (type_vars, row_vars, body) ->
+      max (quantifier_prefix_length type_vars row_vars) (longest_quantifier_prefix body)
+  | Surface_ast.TyApp (head, args) -> max (longest_quantifier_prefix head) (longest args)
+  | Surface_ast.TyArrow (params, _, result) ->
+      max (longest params) (longest_quantifier_prefix result)
+  | Surface_ast.TyTuple items -> longest items
+  | Surface_ast.TyName _ | Surface_ast.TyVar _ | Surface_ast.TyHash _ | Surface_ast.TyHole _ -> 0
+
+let warning_long_quantifier_prefix (top : Surface_ast.top) kind name length =
+  Diag.warning
+    ?span:(Meta.span (declaration_header_name_meta top))
+    ~domain:Surface ~code:"W1205" ~summary:"Quantifier prefix exceeds line width"
+    ~cause:
+      (Printf.sprintf
+         "The shortest legal `forall` prefix in `%s` is %d columns, but the canonical formatter \
+          width is %d; `.jac` requires the quantified variables and `.` to remain on one logical \
+          line."
+         (Surface_name.render kind name) length Surface_print.default_width)
+    ~next_step:"Split the declaration or reduce its quantified variables." ~contrast:None ()
+
+let long_quantifier_prefix_warning top kind name annotations =
+  let length =
+    List.fold_left
+      (fun found annotation -> max found (longest_quantifier_prefix annotation))
+      0 annotations
+  in
+  if length > Surface_print.default_width then
+    [ warning_long_quantifier_prefix top kind name length ]
+  else []
+
 let span_line_count meta =
   Option.map (fun span -> span.Span.end_pos.line - span.Span.start_pos.line + 1) (Meta.span meta)
 
@@ -330,12 +374,23 @@ let lint_top names constructors (top : Surface_ast.top) =
   | Surface_ast.Definition { params; value; _ } ->
       List.concat_map (lint_pat names constructors) params @ lint_expr names constructors value
   | Surface_ast.TopExpr expression -> lint_expr names constructors expression
-  | Surface_ast.TypeDecl { name; vars; _ } ->
+  | Surface_ast.Signature (name, annotation) ->
+      long_quantifier_prefix_warning top Surface_name.Term name [ annotation ]
+  | Surface_ast.TypeDecl { name; vars; constructors } ->
       long_declaration_header_warning top Surface_name.Type name (type_header_length name vars)
+      @ long_quantifier_prefix_warning top Surface_name.Type name
+          (List.concat_map
+             (fun (constructor : Surface_ast.constructor) ->
+               List.map (fun (field : Surface_ast.field) -> field.ty) constructor.fields)
+             constructors)
   | Surface_ast.EffectDecl { name; vars; operations } ->
       long_declaration_header_warning top Surface_name.Effect name
         (effect_header_length name vars operations)
-  | Surface_ast.Signature _ | Surface_ast.RawTop _ | Surface_ast.TopHole _ -> []
+      @ long_quantifier_prefix_warning top Surface_name.Effect name
+          (List.concat_map
+             (fun (operation : Surface_ast.operation) -> operation.result :: operation.params)
+             operations)
+  | Surface_ast.RawTop _ | Surface_ast.TopHole _ -> []
 
 let lint_file names tops =
   let rec loop constructors diagnostics = function

--- a/src/surface_check.ml
+++ b/src/surface_check.ml
@@ -242,8 +242,8 @@ let warning_long_declaration_header (top : Surface_ast.top) kind name length =
     ~summary:"Declaration header exceeds the canonical formatter width"
     ~cause:
       (Printf.sprintf
-         "The shortest legal header for `%s` is %d columns, but the canonical formatter width is \
-          %d; `.jac` requires this header to remain on one logical line."
+         "The shortest legal header for `%s` is %d bytes, but the canonical formatter width is %d \
+          bytes; `.jac` requires this header to remain on one logical line."
          rendered_name length Surface_print.default_width)
     ~next_step:"Shorten the declaration name or its type-variable list." ~contrast:None ()
 
@@ -259,42 +259,37 @@ let quantifier_prefix_length type_vars row_vars =
   + rendered_names_length Surface_name.Rvar row_vars
   + String.length "."
 
-let rec longest_quantifier_prefix (annotation : Surface_ast.ty) =
-  let longest annotations =
-    List.fold_left
-      (fun found annotation -> max found (longest_quantifier_prefix annotation))
-      0 annotations
-  in
-  match annotation.it with
-  | Surface_ast.TyForall (type_vars, row_vars, body) ->
-      max (quantifier_prefix_length type_vars row_vars) (longest_quantifier_prefix body)
-  | Surface_ast.TyApp (head, args) -> max (longest_quantifier_prefix head) (longest args)
-  | Surface_ast.TyArrow (params, _, result) ->
-      max (longest params) (longest_quantifier_prefix result)
-  | Surface_ast.TyTuple items -> longest items
-  | Surface_ast.TyName _ | Surface_ast.TyVar _ | Surface_ast.TyHash _ | Surface_ast.TyHole _ -> 0
+let quantifier_prefix_meta (annotation : Surface_ast.ty) =
+  let prefix = Meta.surface_container "forall" annotation.meta in
+  if Meta.is_empty prefix then annotation.meta else prefix
 
-let warning_long_quantifier_prefix (top : Surface_ast.top) kind name length =
+let warning_long_quantifier_prefix (annotation : Surface_ast.ty) length =
   Diag.warning
-    ?span:(Meta.span (declaration_header_name_meta top))
+    ?span:(Meta.span (quantifier_prefix_meta annotation))
     ~domain:Surface ~code:"W1205" ~summary:"Quantifier prefix exceeds line width"
     ~cause:
       (Printf.sprintf
-         "The shortest legal `forall` prefix in `%s` is %d columns, but the canonical formatter \
-          width is %d; `.jac` requires the quantified variables and `.` to remain on one logical \
-          line."
-         (Surface_name.render kind name) length Surface_print.default_width)
+         "The shortest legal `forall` prefix is %d bytes, but the canonical formatter width is %d \
+          bytes; `.jac` requires the quantified variables and `.` to remain on one logical line."
+         length Surface_print.default_width)
     ~next_step:"Split the declaration or reduce its quantified variables." ~contrast:None ()
 
-let long_quantifier_prefix_warning top kind name annotations =
-  let length =
-    List.fold_left
-      (fun found annotation -> max found (longest_quantifier_prefix annotation))
-      0 annotations
-  in
-  if length > Surface_print.default_width then
-    [ warning_long_quantifier_prefix top kind name length ]
-  else []
+let rec long_quantifier_prefix_warnings (annotation : Surface_ast.ty) =
+  let annotations values = List.concat_map long_quantifier_prefix_warnings values in
+  match annotation.it with
+  | Surface_ast.TyForall (type_vars, row_vars, body) ->
+      let length = quantifier_prefix_length type_vars row_vars in
+      let here =
+        if length > Surface_print.default_width then
+          [ warning_long_quantifier_prefix annotation length ]
+        else []
+      in
+      here @ long_quantifier_prefix_warnings body
+  | Surface_ast.TyApp (head, args) -> long_quantifier_prefix_warnings head @ annotations args
+  | Surface_ast.TyArrow (params, _, result) ->
+      annotations params @ long_quantifier_prefix_warnings result
+  | Surface_ast.TyTuple items -> annotations items
+  | Surface_ast.TyName _ | Surface_ast.TyVar _ | Surface_ast.TyHash _ | Surface_ast.TyHole _ -> []
 
 let span_line_count meta =
   Option.map (fun span -> span.Span.end_pos.line - span.Span.start_pos.line + 1) (Meta.span meta)
@@ -360,7 +355,8 @@ let rec lint_expr names constructors (expression : Surface_ast.expr) =
   | Surface_ast.Quote (Surface_ast.Surface body) -> lint_expr names constructors body
   | Surface_ast.Quote (Surface_ast.Raw _) -> []
   | Surface_ast.Unquote body -> lint_expr names constructors body
-  | Surface_ast.Ann (subject, _) -> lint_expr names constructors subject
+  | Surface_ast.Ann (subject, annotation) ->
+      lint_expr names constructors subject @ long_quantifier_prefix_warnings annotation
 
 and lint_block_item names constructors = function
   | Surface_ast.Expr expression -> lint_expr names constructors expression
@@ -374,11 +370,10 @@ let lint_top names constructors (top : Surface_ast.top) =
   | Surface_ast.Definition { params; value; _ } ->
       List.concat_map (lint_pat names constructors) params @ lint_expr names constructors value
   | Surface_ast.TopExpr expression -> lint_expr names constructors expression
-  | Surface_ast.Signature (name, annotation) ->
-      long_quantifier_prefix_warning top Surface_name.Term name [ annotation ]
+  | Surface_ast.Signature (_, annotation) -> long_quantifier_prefix_warnings annotation
   | Surface_ast.TypeDecl { name; vars; constructors } ->
       long_declaration_header_warning top Surface_name.Type name (type_header_length name vars)
-      @ long_quantifier_prefix_warning top Surface_name.Type name
+      @ List.concat_map long_quantifier_prefix_warnings
           (List.concat_map
              (fun (constructor : Surface_ast.constructor) ->
                List.map (fun (field : Surface_ast.field) -> field.ty) constructor.fields)
@@ -386,9 +381,9 @@ let lint_top names constructors (top : Surface_ast.top) =
   | Surface_ast.EffectDecl { name; vars; operations } ->
       long_declaration_header_warning top Surface_name.Effect name
         (effect_header_length name vars operations)
-      @ long_quantifier_prefix_warning top Surface_name.Effect name
+      @ List.concat_map long_quantifier_prefix_warnings
           (List.concat_map
-             (fun (operation : Surface_ast.operation) -> operation.result :: operation.params)
+             (fun (operation : Surface_ast.operation) -> operation.params @ [ operation.result ])
              operations)
   | Surface_ast.RawTop _ | Surface_ast.TopHole _ -> []
 

--- a/src/surface_check.mli
+++ b/src/surface_check.mli
@@ -11,7 +11,9 @@ val large_match_scrutinee_lines : int
 
 val lint : names:Resolve.names -> Surface_ast.top list -> Diag.t list
 (** [lint ~names tops] returns source-ordered surface review warnings without lowering, rewriting,
-    resolving, or typechecking. [names] is consulted only for namespace-aware pattern warnings. *)
+    resolving, or typechecking. [names] is consulted only for namespace-aware pattern warnings.
+    Declaration-header warnings use the canonical formatter width and the parser-retained
+    declaration-name span. *)
 
 val analyze : names:Resolve.names -> Check.ctx -> Surface_ast.recovered -> report
 (** [analyze ~names ctx recovered] checks a recovered surface tree for editor feedback. Parser holes

--- a/src/surface_check.mli
+++ b/src/surface_check.mli
@@ -12,8 +12,9 @@ val large_match_scrutinee_lines : int
 val lint : names:Resolve.names -> Surface_ast.top list -> Diag.t list
 (** [lint ~names tops] returns source-ordered surface review warnings without lowering, rewriting,
     resolving, or typechecking. [names] is consulted only for namespace-aware pattern warnings.
-    Declaration-header and quantifier-prefix warnings use the canonical formatter width and the
-    parser-retained declaration-name span. *)
+    Declaration-header and quantifier-prefix warnings use the canonical formatter width. Quantifier
+    warnings recursively cover every annotation and select the offending [forall] prefix;
+    declaration-header warnings select the parser-retained declaration name. *)
 
 val analyze : names:Resolve.names -> Check.ctx -> Surface_ast.recovered -> report
 (** [analyze ~names ctx recovered] checks a recovered surface tree for editor feedback. Parser holes

--- a/src/surface_check.mli
+++ b/src/surface_check.mli
@@ -12,8 +12,8 @@ val large_match_scrutinee_lines : int
 val lint : names:Resolve.names -> Surface_ast.top list -> Diag.t list
 (** [lint ~names tops] returns source-ordered surface review warnings without lowering, rewriting,
     resolving, or typechecking. [names] is consulted only for namespace-aware pattern warnings.
-    Declaration-header warnings use the canonical formatter width and the parser-retained
-    declaration-name span. *)
+    Declaration-header and quantifier-prefix warnings use the canonical formatter width and the
+    parser-retained declaration-name span. *)
 
 val analyze : names:Resolve.names -> Check.ctx -> Surface_ast.recovered -> report
 (** [analyze ~names ctx recovered] checks a recovered surface tree for editor feedback. Parser holes

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -1994,7 +1994,9 @@ let parse_signature state name_token name =
   ignore (expect state Surface_lex.Colon "`:` in the signature");
   skip_continuation state;
   let ty = parse_type state ~allow_newlines:false in
-  Surface_ast.{ it = Signature (name, ty); meta = meta_from_token_to_meta name_token ty.meta }
+  let meta = meta_from_token_to_meta name_token ty.meta in
+  let meta = Meta.with_surface_container "declaration-name" (meta_with_span name_token.span) meta in
+  Surface_ast.{ it = Signature (name, ty); meta }
 
 let parse_definition state name_token name equation =
   ignore (advance state);

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -2159,7 +2159,7 @@ let next_bar state =
   if (token_at state index).Surface_lex.token = Surface_lex.Bar then Some index else None
 
 let parse_type_decl state keyword =
-  let name, _ = parse_decl_name state "a type name" type_decl_name in
+  let name, name_token = parse_decl_name state "a type name" type_decl_name in
   let vars = parse_type_vars state (fun token -> token = Surface_lex.Equal) in
   ignore (expect state Surface_lex.Equal "`=` in the type declaration");
   let interrupted = ref false in
@@ -2199,6 +2199,7 @@ let parse_type_decl state keyword =
     | constructor :: _ -> meta_from_token_to_meta keyword constructor.Surface_ast.meta
     | [] -> meta_with_span keyword.Surface_lex.span
   in
+  let meta = Meta.with_surface_container "declaration-name" (meta_with_span name_token.span) meta in
   Surface_ast.{ it = TypeDecl { name; vars; constructors }; meta }
 
 let parse_operation_types state =
@@ -2322,7 +2323,7 @@ let operation_ahead state index =
       (token_at state next).Surface_lex.token = Surface_lex.Colon
 
 let parse_effect_decl state ~start ~effect_mode keyword =
-  let name, _ = parse_decl_name state "an effect name" effect_decl_name in
+  let name, name_token = parse_decl_name state "an effect name" effect_decl_name in
   let vars = parse_type_vars state (fun token -> token = Surface_lex.Keyword "where") in
   ignore (expect state (Surface_lex.Keyword "where") "`where` in the effect declaration");
   let opening = expect state Surface_lex.LBrace "`{` immediately after `where`" in
@@ -2394,7 +2395,9 @@ let parse_effect_decl state ~start ~effect_mode keyword =
   Surface_ast.
     {
       it = EffectDecl { name; vars; operations };
-      meta = meta_with_span (Span.merge start.Surface_lex.span end_span);
+      meta =
+        meta_with_span (Span.merge start.Surface_lex.span end_span)
+        |> Meta.with_surface_container "declaration-name" (meta_with_span name_token.span);
     }
 
 let parse_mode_effect_decl state first =

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -1995,7 +1995,6 @@ let parse_signature state name_token name =
   skip_continuation state;
   let ty = parse_type state ~allow_newlines:false in
   let meta = meta_from_token_to_meta name_token ty.meta in
-  let meta = Meta.with_surface_container "declaration-name" (meta_with_span name_token.span) meta in
   Surface_ast.{ it = Signature (name, ty); meta }
 
 let parse_definition state name_token name equation =

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -8,8 +8,8 @@ type lookup = Surface_name.kind -> Hash.t -> string option
 
 (** The canonical formatter margin. A caller may request another rendering width for an editor or
     diagnostic view, but the command-line formatter and calls that omit [width] use exactly 100
-    columns. The margin is a layout target rather than a promise to split indivisible UTF-8 tokens.
-*)
+    columns. Breakable structure stays within the margin and a group that fits exactly remains
+    compact. An indivisible UTF-8 token or preserved comment may exceed it. *)
 let default_width = 100
 
 exception Bug_unsupported_surface_form
@@ -595,7 +595,7 @@ and pp_if context lookup fmt condition yes no =
         | None -> Format.fprintf fmt "else %a" (pp_expr context lookup) expression)
     | _ -> Format.fprintf fmt "else %a" (pp_expr context lookup) expression
   in
-  Format.fprintf fmt "@[<hov 0>@[<hov 2>if %a" (pp_expr context lookup) condition;
+  Format.fprintf fmt "@[<hv 0>@[<hov 2>if %a" (pp_expr context lookup) condition;
   pp_following_keyword context fmt condition "then";
   Format.fprintf fmt "@ %a@]" (pp_expr context lookup) yes;
   if context.trivia && expression_has_trailing_comments yes then Format.pp_force_newline fmt ();
@@ -1099,13 +1099,45 @@ let has_decoded_surface_ref_top = function
 let is_raw_top top =
   match Meta.surface_form (top_meta top) with Some "raw-top" -> true | Some _ | None -> false
 
-let render ~width pp value =
+let render_at_margin ~margin pp value =
   let buffer = Buffer.create 128 in
   let fmt = Format.formatter_of_buffer buffer in
-  Format.pp_set_margin fmt width;
+  Format.pp_set_margin fmt margin;
   pp fmt value;
   Format.pp_print_flush fmt ();
   Buffer.contents buffer
+
+let max_line_length text =
+  String.split_on_char '\n' text
+  |> List.fold_left (fun longest line -> max longest (String.length line)) 0
+
+(* [Format] treats the end of an [hv] box conservatively: a flat box whose final visible column is
+   exactly the configured margin can break, while a nested [hov] box can retain a flat child that
+   pushes its complete line past the margin. Render the complete syntactic unit first, then select
+   the widest internal margin whose visible output honors the caller's width. The initial extra
+   column lets an exactly fitting flat candidate remain flat. If even the maximally broken rendering
+   exceeds the width, retain the requested-margin rendering: the remaining excess is an indivisible
+   token or preserved comment, which the formatter contract explicitly permits, and shrinking the
+   internal margin further would only discard useful indentation. *)
+let render ~width pp value =
+  let upper_margin = max 2 (width + 1) in
+  let upper = render_at_margin ~margin:upper_margin pp value in
+  let upper_length = max_line_length upper in
+  if upper_length <= width then upper
+  else
+    (* Box layout is not monotone at extremely narrow margins: once indentation itself no longer
+       fits, [Format] may keep an inner box flat. Descend from the widest candidate so the first
+       compliant rendering is the least aggressive layout. *)
+    let requested_margin = max 2 width in
+    let requested = render_at_margin ~margin:requested_margin pp value in
+    let rec widest_fitting margin =
+      if margin < 2 then requested
+      else
+        let rendered = render_at_margin ~margin pp value in
+        let length = max_line_length rendered in
+        if length <= width then rendered else widest_fitting (margin - 1)
+    in
+    if max_line_length requested <= width then requested else widest_fitting (requested_margin - 1)
 
 let pp_clause_fragment context lookup fmt (clause : Kernel.clause) =
   match clause.cbody.it with

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -9,8 +9,8 @@ type lookup = Surface_name.kind -> Hash.t -> string option
 (** The canonical formatter margin. A caller may request another rendering width for an editor or
     diagnostic view, but the command-line formatter and calls that omit [width] use exactly 100
     columns. Breakable structure stays within the margin and a group that fits exactly remains
-    compact. An indivisible UTF-8 token, preserved comment, or syntactically indivisible type/effect
-    declaration header may exceed it. *)
+    compact. An indivisible UTF-8 token, preserved comment, type/effect declaration header, or
+    [forall] prefix may exceed it only when its shortest legal rendering cannot fit. *)
 let default_width = 100
 
 exception Bug_unsupported_surface_form
@@ -906,7 +906,7 @@ let pp_binding context lookup fmt (binding : Kernel.binding) =
   | Some ty ->
       let signature_meta = Meta.signature binding.bmeta in
       pp_leading context signature_meta fmt;
-      Format.fprintf fmt "@[<v>%a : %a" (pp_named Surface_name.Term) binding.bname
+      Format.fprintf fmt "@[<v>@[<hov 2>%a :@ %a@]" (pp_named Surface_name.Term) binding.bname
         (pp_ty context lookup) ty;
       pp_trailing context signature_meta fmt;
       Format.fprintf fmt "@,%a@]" pp_definition ();
@@ -917,8 +917,8 @@ let pp_field context lookup fmt (field : Kernel.field) =
   (match field.label with
   | None -> pp_ty context lookup fmt field.fty
   | Some label ->
-      Format.fprintf fmt "%a: %a" (pp_named Surface_name.Term) label (pp_ty context lookup)
-        field.fty);
+      Format.fprintf fmt "@[<hov 2>%a:@ %a@]" (pp_named Surface_name.Term) label
+        (pp_ty context lookup) field.fty);
   pp_trailing context field.fmeta fmt
 
 let pp_constructor ?(leading = true) context lookup fmt (constructor : Kernel.conspec) =

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -6,11 +6,12 @@
 
 type lookup = Surface_name.kind -> Hash.t -> string option
 
-(** The canonical formatter margin. A caller may request another rendering width for an editor or
-    diagnostic view, but the command-line formatter and calls that omit [width] use exactly 100
-    columns. Breakable structure stays within the margin and a group that fits exactly remains
-    compact. An indivisible UTF-8 token, preserved comment, type/effect declaration header, or
-    [forall] prefix may exceed it only when its shortest legal rendering cannot fit. *)
+(** The canonical formatter's byte-width target. A caller may request another width for an editor or
+    diagnostic view, but the command-line formatter and calls that omit [width] use exactly 100.
+    This is a layout target rather than a global physical-line postcondition: adjacent syntax
+    outside a measured group, preserved source text, or a raw [jqd] inversion may still exceed it. A
+    group that ends exactly at the target remains compact when the containing top-level unit's
+    preflight also fits; otherwise the whole unit is rendered at the requested target. *)
 let default_width = 100
 
 exception Bug_unsupported_surface_form

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -9,7 +9,8 @@ type lookup = Surface_name.kind -> Hash.t -> string option
 (** The canonical formatter margin. A caller may request another rendering width for an editor or
     diagnostic view, but the command-line formatter and calls that omit [width] use exactly 100
     columns. Breakable structure stays within the margin and a group that fits exactly remains
-    compact. An indivisible UTF-8 token or preserved comment may exceed it. *)
+    compact. An indivisible UTF-8 token, preserved comment, or syntactically indivisible type/effect
+    declaration header may exceed it. *)
 let default_width = 100
 
 exception Bug_unsupported_surface_form

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -1112,33 +1112,17 @@ let max_line_length text =
   String.split_on_char '\n' text
   |> List.fold_left (fun longest line -> max longest (String.length line)) 0
 
-(* [Format] treats the end of an [hv] box conservatively: a flat box whose final visible column is
-   exactly the configured margin can break, while a nested [hov] box can retain a flat child that
-   pushes its complete line past the margin. Render the complete syntactic unit first, then select
-   the widest internal margin whose visible output honors the caller's width. The initial extra
-   column lets an exactly fitting flat candidate remain flat. If even the maximally broken rendering
-   exceeds the width, retain the requested-margin rendering: the remaining excess is an indivisible
-   token or preserved comment, which the formatter contract explicitly permits, and shrinking the
-   internal margin further would only discard useful indentation. *)
+(* [Format] conservatively breaks a complete group whose last byte lands exactly at the margin, so
+   first try one internal byte beyond the requested width and retain that rendering only when its
+   physical lines still fit. Otherwise render at the requested margin. Never search narrower
+   margins: [Format] may satisfy them by clamping structural indentation, making a one-byte edit
+   move a type continuation back to column zero. Indivisible tokens, comments, declaration headers,
+   and quantified prefixes therefore retain their shortest valid rendering when they cannot fit. *)
 let render ~width pp value =
-  let upper_margin = max 2 (width + 1) in
-  let upper = render_at_margin ~margin:upper_margin pp value in
-  let upper_length = max_line_length upper in
-  if upper_length <= width then upper
-  else
-    (* Box layout is not monotone at extremely narrow margins: once indentation itself no longer
-       fits, [Format] may keep an inner box flat. Descend from the widest candidate so the first
-       compliant rendering is the least aggressive layout. *)
-    let requested_margin = max 2 width in
-    let requested = render_at_margin ~margin:requested_margin pp value in
-    let rec widest_fitting margin =
-      if margin < 2 then requested
-      else
-        let rendered = render_at_margin ~margin pp value in
-        let length = max_line_length rendered in
-        if length <= width then rendered else widest_fitting (margin - 1)
-    in
-    if max_line_length requested <= width then requested else widest_fitting (requested_margin - 1)
+  let requested_margin = max 2 width in
+  let upper = render_at_margin ~margin:(requested_margin + 1) pp value in
+  if max_line_length upper <= width then upper
+  else render_at_margin ~margin:requested_margin pp value
 
 let pp_clause_fragment context lookup fmt (clause : Kernel.clause) =
   match clause.cbody.it with

--- a/test/cli/surface.t
+++ b/test/cli/surface.t
@@ -98,6 +98,18 @@ must exceed the canonical width.
   101
   $ jac fmt wide-declaration-formatted.jac 2> /dev/null | cmp wide-declaration-formatted.jac -
 
+Quantified-variable prefixes have no legal continuation point in 0.1. W1205 makes a pathological
+prefix visible without rejecting or rewriting a valid program.
+
+  $ cat > wide-forall.jac <<'EOF'
+  > f : forall a0 b0 c0 d0 e0 f0 g0 h0 v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 v15 v16 v17 v18 v19 v20 v21 v22 v23 v24 v25 v26 v27 v28 v29 v30 v31. a0
+  > f = 0
+  > EOF
+  $ jac fmt wide-forall.jac > wide-forall-formatted.jac 2> wide-forall.err
+  $ grep 'warning\[W1205\]' wide-forall.err
+  wide-forall.jac:1:1-2: warning[W1205]: Quantifier prefix exceeds line width
+  $ jac fmt wide-forall-formatted.jac 2> /dev/null | cmp wide-forall-formatted.jac -
+
 DX.3 keeps realistic nested quotes, matches, handlers, conditionals, and blocks stable under
 formatting and canonical identity. Explicit operation namespace intent survives the formatter.
 

--- a/test/cli/surface.t
+++ b/test/cli/surface.t
@@ -107,7 +107,7 @@ prefix visible without rejecting or rewriting a valid program.
   > EOF
   $ jac fmt wide-forall.jac > wide-forall-formatted.jac 2> wide-forall.err
   $ grep 'warning\[W1205\]' wide-forall.err
-  wide-forall.jac:1:1-2: warning[W1205]: Quantifier prefix exceeds line width
+  wide-forall.jac:1:5-164: warning[W1205]: Quantifier prefix exceeds line width
   $ jac fmt wide-forall-formatted.jac 2> /dev/null | cmp wide-forall-formatted.jac -
 
 DX.3 keeps realistic nested quotes, matches, handlers, conditionals, and blocks stable under

--- a/test/cli/surface.t
+++ b/test/cli/surface.t
@@ -85,6 +85,19 @@ manual hoist. The warning is emitted on stderr and formatting remains successful
   $ head -1 large-formatted.jac
   match add(1, 2, 3) {
 
+Declaration headers have no legal continuation point before `=` or `where {`. The formatter keeps
+that grammar-valid line intact, and W1204 points at the declaration name when the shortest header
+must exceed the canonical width.
+
+  $ long_type_name=$(printf 'T%093d' 0 | tr '0' a)
+  $ printf 'type %s = | Make\n' "$long_type_name" > wide-declaration.jac
+  $ jac fmt wide-declaration.jac > wide-declaration-formatted.jac 2> wide-declaration.err
+  $ grep 'warning\[W1204\]' wide-declaration.err
+  wide-declaration.jac:1:6-100: warning[W1204]: Declaration header exceeds the canonical formatter width
+  $ head -1 wide-declaration-formatted.jac | awk '{ print length }'
+  101
+  $ jac fmt wide-declaration-formatted.jac 2> /dev/null | cmp wide-declaration-formatted.jac -
+
 DX.3 keeps realistic nested quotes, matches, handlers, conditionals, and blocks stable under
 formatting and canonical identity. Explicit operation namespace intent survives the formatter.
 

--- a/test/test_surface_check.ml
+++ b/test/test_surface_check.ml
@@ -547,8 +547,8 @@ let test_declaration_header_width_lint_boundary () =
       Alcotest.(check string)
         "type overflow reports exact length"
         (Printf.sprintf
-           "The shortest legal header for `%s` is 101 columns, but the canonical formatter width \
-            is 100; `.jac` requires this header to remain on one logical line."
+           "The shortest legal header for `%s` is 101 bytes, but the canonical formatter width is \
+            100 bytes; `.jac` requires this header to remain on one logical line."
            type_name_over_boundary)
         (Diag.cause warning);
       Alcotest.(check (option string))
@@ -589,26 +589,52 @@ let test_declaration_header_width_lint_boundary () =
     "100-column quantifier prefix is allowed" 0
     (List.length
        (quantifier_warnings (Printf.sprintf "f : forall %s. %s\nf = 0\n" exact_var exact_var)));
+  List.iter
+    (fun prefix_width ->
+      let variable = "a" ^ String.make (prefix_width - 9) 'a' in
+      Alcotest.(check int)
+        (Printf.sprintf "%d-byte quantifier warning boundary" prefix_width)
+        (if prefix_width > Surface_print.default_width then 1 else 0)
+        (List.length (quantifier_warnings (Printf.sprintf "f : forall %s. a\nf = 0\n" variable))))
+    [ 98; 99; 100; 101 ];
   let short_vars =
     List.init 8 (fun index -> Printf.sprintf "%c0" (Char.chr (Char.code 'a' + index)))
     @ List.init 32 (fun index -> Printf.sprintf "v%02d" index)
   in
   let quantified = String.concat " " short_vars in
-  match quantifier_warnings (Printf.sprintf "f : forall %s. a0\nf = 0\n" quantified) with
+  (match quantifier_warnings (Printf.sprintf "f : forall %s. a0\nf = 0\n" quantified) with
   | [ warning ] ->
       Alcotest.(check string)
         "quantifier warning reports exact prefix width"
-        "The shortest legal `forall` prefix in `f` is 159 columns, but the canonical formatter \
-         width is 100; `.jac` requires the quantified variables and `.` to remain on one logical \
-         line."
+        "The shortest legal `forall` prefix is 159 bytes, but the canonical formatter width is 100 \
+         bytes; `.jac` requires the quantified variables and `.` to remain on one logical line."
         (Diag.cause warning);
       Alcotest.(check (option string))
-        "quantifier warning selects the declaration name" (Some "declaration-width.jac:1:1-2")
+        "quantifier warning selects the forall prefix" (Some "declaration-width.jac:1:5-164")
         (Option.map Span.to_string (Diag.span warning));
       Alcotest.(check string)
         "quantifier warning gives an actionable repair"
         "Split the declaration or reduce its quantified variables." (Diag.next_step warning)
-  | found -> Alcotest.failf "expected one quantifier warning, got %d" (List.length found)
+  | found -> Alcotest.failf "expected one quantifier warning, got %d" (List.length found));
+  let annotated = Printf.sprintf "f = (fn (x) -> x : forall %s. (a0) ->{} a0)\n" quantified in
+  (match quantifier_warnings annotated with
+  | [ warning ] ->
+      Alcotest.(check bool)
+        "expression annotation warning selects its forall prefix" true
+        (match Diag.span warning with Some span -> span.Span.start_pos.col > 1 | None -> false)
+  | found -> Alcotest.failf "expected one expression-annotation warning, got %d" (List.length found));
+  let two_annotations =
+    Printf.sprintf "f = ((0 : forall %s. a0), (0 : forall %s. a0))\n" quantified quantified
+  in
+  match quantifier_warnings two_annotations with
+  | [ first; second ] ->
+      Alcotest.(check bool)
+        "multiple quantifier warnings retain source order" true
+        (match (Diag.span first, Diag.span second) with
+        | Some left, Some right -> left.Span.start_pos.offset < right.Span.start_pos.offset
+        | _ -> false)
+  | found ->
+      Alcotest.failf "expected two expression-annotation warnings, got %d" (List.length found)
 
 let test_warning_exact_order_nested_raw_and_redundancy () =
   let source =

--- a/test/test_surface_check.ml
+++ b/test/test_surface_check.ml
@@ -574,13 +574,41 @@ let test_declaration_header_width_lint_boundary () =
         (Option.map Span.to_string (Diag.span warning))
   | found -> Alcotest.failf "expected one effect-header warning, got %d" (List.length found));
   let long_var = "a" ^ String.make 91 'a' in
-  match warnings (Printf.sprintf "type T %s = | Make\n" long_var) with
+  (match warnings (Printf.sprintf "type T %s = | Make\n" long_var) with
   | [ warning ] ->
       Alcotest.(check (option string))
         "type-variable overflow still selects the declaration name"
         (Some "declaration-width.jac:1:6-7")
         (Option.map Span.to_string (Diag.span warning))
-  | found -> Alcotest.failf "expected one type-variable warning, got %d" (List.length found)
+  | found -> Alcotest.failf "expected one type-variable warning, got %d" (List.length found));
+  let quantifier_warnings source =
+    List.filter (fun d -> Diag.code_or_uncoded d = "W1205") (lint source)
+  in
+  let exact_var = "a" ^ String.make 91 'a' in
+  Alcotest.(check int)
+    "100-column quantifier prefix is allowed" 0
+    (List.length
+       (quantifier_warnings (Printf.sprintf "f : forall %s. %s\nf = 0\n" exact_var exact_var)));
+  let short_vars =
+    List.init 8 (fun index -> Printf.sprintf "%c0" (Char.chr (Char.code 'a' + index)))
+    @ List.init 32 (fun index -> Printf.sprintf "v%02d" index)
+  in
+  let quantified = String.concat " " short_vars in
+  match quantifier_warnings (Printf.sprintf "f : forall %s. a0\nf = 0\n" quantified) with
+  | [ warning ] ->
+      Alcotest.(check string)
+        "quantifier warning reports exact prefix width"
+        "The shortest legal `forall` prefix in `f` is 159 columns, but the canonical formatter \
+         width is 100; `.jac` requires the quantified variables and `.` to remain on one logical \
+         line."
+        (Diag.cause warning);
+      Alcotest.(check (option string))
+        "quantifier warning selects the declaration name" (Some "declaration-width.jac:1:1-2")
+        (Option.map Span.to_string (Diag.span warning));
+      Alcotest.(check string)
+        "quantifier warning gives an actionable repair"
+        "Split the declaration or reduce its quantified variables." (Diag.next_step warning)
+  | found -> Alcotest.failf "expected one quantifier warning, got %d" (List.length found)
 
 let test_warning_exact_order_nested_raw_and_redundancy () =
   let source =

--- a/test/test_surface_check.ml
+++ b/test/test_surface_check.ml
@@ -528,6 +528,60 @@ let test_large_match_scrutinee_lint_boundary () =
         (contains "Bind the expression with `let`" (Diag.next_step warning))
   | found -> Alcotest.failf "expected one scrutinee warning, got %d" (List.length found)
 
+let test_declaration_header_width_lint_boundary () =
+  let lint source =
+    let recovered = Surface_parse.recover_string ~file:"declaration-width.jac" source in
+    match Surface_parse.strict recovered with
+    | Error diagnostics -> fail_diags "declaration width lint parse" diagnostics
+    | Ok tops -> Surface_check.lint ~names:Resolve.empty_names tops
+  in
+  let warnings source = List.filter (fun d -> Diag.code_or_uncoded d = "W1204") (lint source) in
+  let type_name_at_boundary = "T" ^ String.make 92 'a' in
+  let type_name_over_boundary = "T" ^ String.make 93 'a' in
+  Alcotest.(check int)
+    "100-column type header is allowed" 0
+    (List.length (warnings (Printf.sprintf "type %s = | Make\n" type_name_at_boundary)));
+  (match warnings (Printf.sprintf "type %s = | Make\n" type_name_over_boundary) with
+  | [ warning ] ->
+      Alcotest.(check bool) "type overflow is warning" true (Diag.severity warning = Diag.Warning);
+      Alcotest.(check string)
+        "type overflow reports exact length"
+        (Printf.sprintf
+           "The shortest legal header for `%s` is 101 columns, but the canonical formatter width \
+            is 100; `.jac` requires this header to remain on one logical line."
+           type_name_over_boundary)
+        (Diag.cause warning);
+      Alcotest.(check (option string))
+        "type warning selects only the declaration name" (Some "declaration-width.jac:1:6-100")
+        (Option.map Span.to_string (Diag.span warning));
+      Alcotest.(check string)
+        "type overflow gives an actionable repair"
+        "Shorten the declaration name or its type-variable list." (Diag.next_step warning)
+  | found -> Alcotest.failf "expected one type-header warning, got %d" (List.length found));
+  let effect_name_at_boundary = "E" ^ String.make 78 'a' in
+  let effect_name_over_boundary = "E" ^ String.make 79 'a' in
+  let effect_source name =
+    Printf.sprintf "multi effect %s where {\n  operation : () -> ()\n}\n" name
+  in
+  Alcotest.(check int)
+    "100-column effect header is allowed" 0
+    (List.length (warnings (effect_source effect_name_at_boundary)));
+  (match warnings (effect_source effect_name_over_boundary) with
+  | [ warning ] ->
+      Alcotest.(check bool) "effect overflow is warning" true (Diag.severity warning = Diag.Warning);
+      Alcotest.(check (option string))
+        "effect warning selects only the declaration name" (Some "declaration-width.jac:1:14-94")
+        (Option.map Span.to_string (Diag.span warning))
+  | found -> Alcotest.failf "expected one effect-header warning, got %d" (List.length found));
+  let long_var = "a" ^ String.make 91 'a' in
+  match warnings (Printf.sprintf "type T %s = | Make\n" long_var) with
+  | [ warning ] ->
+      Alcotest.(check (option string))
+        "type-variable overflow still selects the declaration name"
+        (Some "declaration-width.jac:1:6-7")
+        (Option.map Span.to_string (Diag.span warning))
+  | found -> Alcotest.failf "expected one type-variable warning, got %d" (List.length found)
+
 let test_warning_exact_order_nested_raw_and_redundancy () =
   let source =
     "match True { | _ -> 0 | _ -> 1 }\n\
@@ -711,6 +765,8 @@ let suite =
       test_wide_pattern_boundary_and_coexistence;
     Alcotest.test_case "large match scrutinee lint boundary" `Quick
       test_large_match_scrutinee_lint_boundary;
+    Alcotest.test_case "declaration header width lint boundary" `Quick
+      test_declaration_header_width_lint_boundary;
     Alcotest.test_case "warning exact order nested raw and redundancy" `Quick
       test_warning_exact_order_nested_raw_and_redundancy;
     Alcotest.test_case "cross-island terms" `Quick test_cross_island_terms;

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -392,6 +392,14 @@ let test_colon_continuation_width_contract () =
     (format_surface "wide-field.jac" field);
   Alcotest.(check bool)
     "broken labeled field preserves its lowered form" true (same_lowered field_source field);
+  let long_field_type = "Type" ^ String.make 88 'a' in
+  let indented_field =
+    format_surface "indented-field.jac"
+      (Printf.sprintf "type Container = | Make(field: %s)\n" long_field_type)
+  in
+  Alcotest.(check bool)
+    "labeled-field fallback preserves nested continuation indentation" true
+    (contains (Printf.sprintf "\n        %s,\n" long_field_type) indented_field);
   let hashable_field_source =
     Printf.sprintf "type Container %s = | Make(%s: %s)\n" type_var field_label type_var
   in
@@ -416,7 +424,17 @@ let test_colon_continuation_width_contract () =
     [
       ("signature group", "function-name : ResultType\nfunction-name = 0\n");
       ("labeled-field group", "type T = | Make(field-name: ResultType)\n");
-    ]
+    ];
+  List.iter
+    (fun prefix_width ->
+      let variable = "a" ^ String.make (prefix_width - 9) 'a' in
+      let source = Printf.sprintf "f : forall %s. a\nf = 0\n" variable in
+      let formatted = format_surface "quantifier-indent.jac" source in
+      Alcotest.(check bool)
+        (Printf.sprintf "%d-byte forall prefix keeps its two-space continuation" prefix_width)
+        true
+        (contains (Printf.sprintf "f :\n  forall %s.\n" variable) formatted))
+    [ 98; 99; 100; 101 ]
 
 let test_comma_list_exact_width_boundaries () =
   let cases =

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -345,6 +345,79 @@ let test_declaration_header_width_exception () =
     (surface_hashes "wide-effect-header.jac" effect_source)
     (surface_hashes "wide-effect-header.jac" formatted_effect)
 
+let same_lowered source formatted =
+  List.for_all2
+    (fun before after -> Form.equal_ignoring_meta (Kernel.to_form before) (Kernel.to_form after))
+    (lowered_surface "colon-continuation.jac" source)
+    (lowered_surface "colon-continuation.jac" formatted)
+
+let test_colon_continuation_width_contract () =
+  let term_name = "f" ^ String.make 59 'a' in
+  let type_name = "T" ^ String.make 59 'a' in
+  let signature_source = Printf.sprintf "%s : %s\n%s = 0\n" term_name type_name term_name in
+  let signature = format_surface "wide-signature.jac" signature_source in
+  Alcotest.(check bool)
+    "123-column signature breaks after its colon" true
+    (contains (Printf.sprintf "%s :\n  %s\n" term_name type_name) signature);
+  Alcotest.(check bool)
+    "broken signature lines fit the canonical width" true
+    (max_line_length signature <= Surface_print.default_width);
+  Alcotest.(check string)
+    "broken signature is idempotent" signature
+    (format_surface "wide-signature.jac" signature);
+  Alcotest.(check bool)
+    "broken signature preserves its lowered form" true
+    (same_lowered signature_source signature);
+  let type_var = "a" ^ String.make 59 'a' in
+  let hashable_signature_source =
+    Printf.sprintf "%s : forall %s. %s\n%s = 0\n" term_name type_var type_var term_name
+  in
+  let hashable_signature = format_surface "hashable-wide-signature.jac" hashable_signature_source in
+  Alcotest.(check (list string))
+    "signature continuation preserves canonical identity"
+    (surface_hashes "hashable-wide-signature.jac" hashable_signature_source)
+    (surface_hashes "hashable-wide-signature.jac" hashable_signature);
+  let field_label = "field" ^ String.make 50 'a' in
+  let field_type = "Type" ^ String.make 51 'a' in
+  let field_source = Printf.sprintf "type Container = | Make(%s: %s)\n" field_label field_type in
+  let field = format_surface "wide-field.jac" field_source in
+  Alcotest.(check bool)
+    "119-column labeled field breaks after its colon" true
+    (contains (Printf.sprintf "%s:\n" field_label) field);
+  Alcotest.(check bool)
+    "broken labeled-field lines fit the canonical width" true
+    (max_line_length field <= Surface_print.default_width);
+  Alcotest.(check string)
+    "broken labeled field is idempotent" field
+    (format_surface "wide-field.jac" field);
+  Alcotest.(check bool)
+    "broken labeled field preserves its lowered form" true (same_lowered field_source field);
+  let hashable_field_source =
+    Printf.sprintf "type Container %s = | Make(%s: %s)\n" type_var field_label type_var
+  in
+  let hashable_field = format_surface "hashable-wide-field.jac" hashable_field_source in
+  Alcotest.(check (list string))
+    "labeled-field continuation preserves canonical identity"
+    (surface_hashes "hashable-wide-field.jac" hashable_field_source)
+    (surface_hashes "hashable-wide-field.jac" hashable_field);
+  List.iter
+    (fun (label, source) ->
+      let compact = format_surface ~width:1000 (label ^ ".jac") source in
+      let boundary = max_line_length compact in
+      Alcotest.(check string)
+        (label ^ " stays flat at N") compact
+        (format_surface ~width:boundary (label ^ ".jac") source);
+      Alcotest.(check string)
+        (label ^ " stays flat at N+1") compact
+        (format_surface ~width:(boundary + 1) (label ^ ".jac") source);
+      Alcotest.(check bool)
+        (label ^ " breaks at N-1") true
+        (not (String.equal compact (format_surface ~width:(boundary - 1) (label ^ ".jac") source))))
+    [
+      ("signature group", "function-name : ResultType\nfunction-name = 0\n");
+      ("labeled-field group", "type T = | Make(field-name: ResultType)\n");
+    ]
+
 let test_comma_list_exact_width_boundaries () =
   let cases =
     [
@@ -1448,6 +1521,8 @@ let suite =
       test_constructor_standard_width_boundary;
     Alcotest.test_case "declaration header width exception" `Quick
       test_declaration_header_width_exception;
+    Alcotest.test_case "colon continuation width contract" `Quick
+      test_colon_continuation_width_contract;
     Alcotest.test_case "plain-text formatter contract" `Quick test_plain_text_formatter_contract;
     Alcotest.test_case "multiline comma layout contract" `Quick test_multiline_comma_layout_contract;
     Alcotest.test_case "multiline comma contexts" `Quick test_multiline_comma_contexts;

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -148,7 +148,11 @@ let test_plain_text_formatter_contract () =
   Alcotest.(check (list string))
     "formatting does not change canonical identity"
     (surface_hashes "plain-text.jac" source)
-    (surface_hashes "plain-text.jac" once)
+    (surface_hashes "plain-text.jac" once);
+  let indivisible = "indivisible-identifier-that-exceeds-width\n" in
+  Alcotest.(check string)
+    "an indivisible token is preserved past a narrow margin" indivisible
+    (format_surface ~width:10 "indivisible.jac" indivisible)
 
 let test_multiline_comma_layout_contract () =
   let source =
@@ -169,6 +173,9 @@ f(first-long-argument, -- after-final-comma
   Alcotest.(check bool)
     "compact multi-item tuple has no final comma" true
     (contains {|("first-long-item", "second-long-item", "third-long-item")|} compact);
+  Alcotest.(check bool)
+    "a trailing item comment forces vertical layout even at a wide margin" true
+    (contains "(\n  1,\n  -- first item\n  2,\n)" compact);
   Alcotest.(check bool)
     "wrapped tuple is one item per line with a final comma" true
     (contains {|(
@@ -295,6 +302,120 @@ very-long-function-name(
   Alcotest.(check string)
     "all comma-list contexts are idempotent" formatted
     (format_surface "comma-contexts.jac" formatted)
+
+let max_line_length text =
+  String.split_on_char '\n' text
+  |> List.fold_left (fun longest line -> max longest (String.length line)) 0
+
+let test_comma_list_exact_width_boundaries () =
+  let cases =
+    [
+      ( "call arguments",
+        "call(first-argument, second-argument)\n",
+        "first-argument",
+        "second-argument",
+        true );
+      ("list items", "[first-item, second-item]\n", "first-item", "second-item", true);
+      ("expression tuple", "(first-value, second-value)\n", "first-value", "second-value", true);
+      ( "function parameters",
+        "function-name(first-parameter, second-parameter) = first-parameter\n",
+        "first-parameter",
+        "second-parameter",
+        true );
+      ( "labeled constructor fields",
+        "type Example = | MakeExample(first-field: FirstType, second-field: SecondType)\n",
+        "first-field: FirstType",
+        "second-field: SecondType",
+        true );
+      ( "operation parameters",
+        "multi effect Example where {\n  operation : (FirstType, SecondType) -> ResultType\n}\n",
+        "FirstType",
+        "SecondType",
+        true );
+      ( "constructor-pattern arguments",
+        "match subject {\n  | MakeExample(first-pattern, second-pattern) -> first-pattern\n}\n",
+        "first-pattern",
+        "second-pattern",
+        false );
+      ( "handler-clause parameters",
+        "handle body() {\n\
+        \  | return value -> value\n\
+        \  | operation(first-parameter, second-parameter) resume continuation -> first-parameter\n\
+         }\n",
+        "first-parameter",
+        "second-parameter",
+        false );
+    ]
+  in
+  List.iter
+    (fun (label, source, first_item, second_item, vertical_at_boundary) ->
+      let compact = format_surface ~width:1000 (label ^ ".jac") source in
+      let boundary = max_line_length compact in
+      let at_boundary = format_surface ~width:boundary (label ^ ".jac") source in
+      let above_boundary = format_surface ~width:(boundary + 1) (label ^ ".jac") source in
+      let below_boundary = format_surface ~width:(boundary - 1) (label ^ ".jac") source in
+      Alcotest.(check string) (label ^ " fits at its exact boundary") compact at_boundary;
+      Alcotest.(check string) (label ^ " fits one column above its boundary") compact above_boundary;
+      Alcotest.(check bool)
+        (label ^ " wraps one column below its boundary")
+        true
+        (not (String.equal compact below_boundary));
+      if vertical_at_boundary then begin
+        Alcotest.(check bool)
+          (label ^ " puts the first item on its own comma-terminated line")
+          true
+          (contains (first_item ^ ",\n") below_boundary);
+        Alcotest.(check bool)
+          (label ^ " puts the final item on its own comma-terminated line")
+          true
+          (contains (second_item ^ ",\n") below_boundary)
+      end;
+      Alcotest.(check bool)
+        (label ^ " wrapped lines stay within the requested width")
+        true
+        (max_line_length below_boundary <= boundary - 1);
+      Alcotest.(check string)
+        (label ^ " wrapped rendering is idempotent")
+        below_boundary
+        (format_surface ~width:(boundary - 1) (label ^ ".jac") below_boundary))
+    cases
+
+let remove_exact_line expected text =
+  let rec remove rev_prefix = function
+    | [] -> Alcotest.failf "expected formatter line %S" expected
+    | line :: rest when String.equal line expected -> List.rev_append rev_prefix rest
+    | line :: rest -> remove (line :: rev_prefix) rest
+  in
+  String.split_on_char '\n' text |> remove [] |> String.concat "\n"
+
+let test_vertical_append_remove_diff_stability () =
+  let three =
+    format_surface ~width:24 "append-remove.jac"
+      "call(first-long-item, second-long-item, third-long-item)\n"
+  in
+  let four =
+    format_surface ~width:24 "append-remove.jac"
+      "call(first-long-item, second-long-item, third-long-item, fourth-long-item)\n"
+  in
+  Alcotest.(check bool)
+    "three-item fixture is vertical" true
+    (contains "  third-long-item,\n" three);
+  Alcotest.(check bool)
+    "appended item has one canonical line" true
+    (contains "  fourth-long-item,\n" four);
+  Alcotest.(check string)
+    "appending changes only the appended item line" three
+    (remove_exact_line "  fourth-long-item," four);
+  Alcotest.(check string)
+    "removing restores the byte-identical three-item layout" four
+    (let lines = String.split_on_char '\n' three in
+     let rec insert rev_prefix = function
+       | [] -> Alcotest.fail "vertical call closing delimiter was absent"
+       | ")" :: rest ->
+           List.rev_append rev_prefix ("  fourth-long-item," :: ")" :: rest) |> String.concat "\n"
+       | line :: rest -> insert (line :: rev_prefix) rest
+     in
+     insert [] lines)
 
 let trim = String.trim
 
@@ -1290,6 +1411,10 @@ let suite =
     Alcotest.test_case "plain-text formatter contract" `Quick test_plain_text_formatter_contract;
     Alcotest.test_case "multiline comma layout contract" `Quick test_multiline_comma_layout_contract;
     Alcotest.test_case "multiline comma contexts" `Quick test_multiline_comma_contexts;
+    Alcotest.test_case "comma-list exact width boundaries" `Quick
+      test_comma_list_exact_width_boundaries;
+    Alcotest.test_case "vertical append/remove diff stability" `Quick
+      test_vertical_append_remove_diff_stability;
     Alcotest.test_case "release tables stop before later subheadings" `Quick
       test_table_rows_stop_at_later_subheading;
     Alcotest.test_case "structured release decision" `Quick assert_release_valid;

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -307,6 +307,44 @@ let max_line_length text =
   String.split_on_char '\n' text
   |> List.fold_left (fun longest line -> max longest (String.length line)) 0
 
+let test_declaration_header_width_exception () =
+  let type_name = "T" ^ String.make 94 'a' in
+  let type_source = Printf.sprintf "type %s = | Make\n" type_name in
+  let formatted_type = format_surface "wide-type-header.jac" type_source in
+  Alcotest.(check int)
+    "indivisible type header exceeds width by its exact requirement" 102
+    (max_line_length formatted_type);
+  Alcotest.(check bool)
+    "type header stays on its one legal logical line" true
+    (contains (Printf.sprintf "type %s =\n  | Make\n" type_name) formatted_type);
+  Alcotest.(check string)
+    "wide type header formatting is idempotent" formatted_type
+    (format_surface "wide-type-header.jac" formatted_type);
+  Alcotest.(check (list string))
+    "wide type header formatting preserves canonical identity"
+    (surface_hashes "wide-type-header.jac" type_source)
+    (surface_hashes "wide-type-header.jac" formatted_type);
+  let effect_name = "E" ^ String.make 79 'a' in
+  let effect_source =
+    Printf.sprintf "multi effect %s where {\n  operation : () -> ()\n}\n" effect_name
+  in
+  let formatted_effect = format_surface "wide-effect-header.jac" effect_source in
+  Alcotest.(check int)
+    "indivisible effect header exceeds width by its exact requirement" 101
+    (max_line_length formatted_effect);
+  Alcotest.(check bool)
+    "effect header stays on its one legal logical line" true
+    (contains
+       (Printf.sprintf "multi effect %s where {\n  operation : () -> ()\n}\n" effect_name)
+       formatted_effect);
+  Alcotest.(check string)
+    "wide effect header formatting is idempotent" formatted_effect
+    (format_surface "wide-effect-header.jac" formatted_effect);
+  Alcotest.(check (list string))
+    "wide effect header formatting preserves canonical identity"
+    (surface_hashes "wide-effect-header.jac" effect_source)
+    (surface_hashes "wide-effect-header.jac" formatted_effect)
+
 let test_comma_list_exact_width_boundaries () =
   let cases =
     [
@@ -1408,6 +1446,8 @@ let suite =
       test_surface_formatter_corpus_stability;
     Alcotest.test_case "constructor standard width boundary" `Quick
       test_constructor_standard_width_boundary;
+    Alcotest.test_case "declaration header width exception" `Quick
+      test_declaration_header_width_exception;
     Alcotest.test_case "plain-text formatter contract" `Quick test_plain_text_formatter_contract;
     Alcotest.test_case "multiline comma layout contract" `Quick test_multiline_comma_layout_contract;
     Alcotest.test_case "multiline comma contexts" `Quick test_multiline_comma_contexts;

--- a/test/test_surface_types.ml
+++ b/test/test_surface_types.ml
@@ -232,6 +232,55 @@ let test_row_wrapping_threshold () =
   | [ reparsed ] -> Alcotest.(check string) "wrapped idempotence" once (print ~width:48 reparsed)
   | _ -> Alcotest.fail "wrapped row did not parse as one top"
 
+let max_line_length text =
+  String.split_on_char '\n' text
+  |> List.fold_left (fun longest line -> max longest (String.length line)) 0
+
+let test_tuple_and_arrow_parameter_width_boundaries () =
+  let tuple = "(ttuple (tref first-type) (tref second-type))" in
+  let compact_tuple = print_fragment ~width:1000 tuple in
+  let tuple_boundary = String.length compact_tuple in
+  Alcotest.(check string)
+    "type tuple fits at its exact boundary" compact_tuple
+    (print_fragment ~width:tuple_boundary tuple);
+  Alcotest.(check string)
+    "type tuple fits above its boundary" compact_tuple
+    (print_fragment ~width:(tuple_boundary + 1) tuple);
+  let wrapped_tuple = print_fragment ~width:(tuple_boundary - 1) tuple in
+  Alcotest.(check bool)
+    "type tuple wraps below its boundary" true
+    (not (String.equal compact_tuple wrapped_tuple));
+  Alcotest.(check bool)
+    "type tuple items are vertical and comma-terminated" true
+    (contains wrapped_tuple "FirstType,\n" && contains wrapped_tuple "SecondType,\n");
+  Alcotest.(check bool)
+    "wrapped type tuple stays within its requested width" true
+    (max_line_length wrapped_tuple <= tuple_boundary - 1);
+  let arrow = "(tarrow ((tref first-type) (tref second-type)) (row) (tref result-type))" in
+  let compact_arrow = print_fragment ~width:1000 arrow in
+  let arrow_boundary = String.length compact_arrow in
+  Alcotest.(check string)
+    "arrow fits at its exact boundary" compact_arrow
+    (print_fragment ~width:arrow_boundary arrow);
+  Alcotest.(check string)
+    "arrow fits above its boundary" compact_arrow
+    (print_fragment ~width:(arrow_boundary + 1) arrow);
+  let below_arrow = print_fragment ~width:(arrow_boundary - 1) arrow in
+  Alcotest.(check bool)
+    "arrow wraps below its boundary" true
+    (not (String.equal compact_arrow below_arrow));
+  Alcotest.(check bool)
+    "wrapped arrow stays within its requested width" true
+    (max_line_length below_arrow <= arrow_boundary - 1);
+  let vertical_arrow = print_fragment ~width:20 arrow in
+  Alcotest.(check bool)
+    "narrow arrow parameters are vertical and comma-terminated" true
+    (contains vertical_arrow "FirstType,\n" && contains vertical_arrow "SecondType,\n");
+  let vertical_arrow_file = vertical_arrow ^ "\n" in
+  Alcotest.(check string)
+    "narrow arrow rendering is idempotent" vertical_arrow_file
+    (print_recovered ~width:20 vertical_arrow_file)
+
 let test_hash_inversion_and_row_set_law () =
   let type_hash = Hash.of_string "ss14-result" in
   let net = Hash.of_string "ss14-net" in
@@ -603,6 +652,8 @@ let suite =
     Alcotest.test_case "documented signatures" `Quick test_documented_signatures;
     Alcotest.test_case "row forms and namespaces" `Quick test_row_forms_and_namespaces;
     Alcotest.test_case "row wrapping threshold" `Quick test_row_wrapping_threshold;
+    Alcotest.test_case "tuple and arrow parameter width boundaries" `Quick
+      test_tuple_and_arrow_parameter_width_boundaries;
     Alcotest.test_case "hash inversion and row set law" `Quick test_hash_inversion_and_row_set_law;
     Alcotest.test_case "resolved reference identity" `Quick test_resolved_reference_identity;
     Alcotest.test_case "checker surface signatures" `Quick test_checker_signatures_are_surface;

--- a/test/test_surface_types.ml
+++ b/test/test_surface_types.ml
@@ -459,16 +459,17 @@ let test_type_trivia_ownership () =
   in
   let once = print_recovered source in
   let expected =
-    {|f : forall a | e. -- forall-dot
-      (a) ->{ -- row-open
-        -- net-leading
-       Net, -- comma
-       -- clock-leading
-       Clock -- clock-trailing
-       | -- row-bar
-       e -- row-tail
-       } -- row-close
-        a
+    {|f :
+  forall a | e. -- forall-dot
+    (a) ->{ -- row-open
+      -- net-leading
+     Net, -- comma
+     -- clock-leading
+     Clock -- clock-trailing
+     | -- row-bar
+     e -- row-tail
+     } -- row-close
+      a
 f = 0
 |}
   in
@@ -515,12 +516,12 @@ let test_trailing_row_comma_trivia () =
         "f : () ->{Net, -- keep closed comma\n} Text\nf = 0\n",
         "f : () ->{Net} Text\nf = 0\n",
         "-- keep closed comma",
-        "->{\n         Net, -- keep closed comma\n       }" );
+        [ "Net, -- keep closed comma"; "} Text" ] );
       ( "open",
         "f : () ->{Net, -- keep open comma\n| e} Text\nf = 0\n",
         "f : () ->{Net | e} Text\nf = 0\n",
         "-- keep open comma",
-        "->{\n         Net -- keep open comma\n         | e\n       }" );
+        [ "Net -- keep open comma"; "| e"; "} Text" ] );
     ]
   in
   List.iter
@@ -529,7 +530,8 @@ let test_trailing_row_comma_trivia () =
       Alcotest.(check bool) (label ^ " comment survives") true (contains formatted comment);
       Alcotest.(check bool)
         (label ^ " comma and closing-row layout is canonical")
-        true (contains formatted expected);
+        true
+        (List.for_all (contains formatted) expected);
       Alcotest.(check string)
         (label ^ " formatting is idempotent")
         formatted (print_recovered formatted);


### PR DESCRIPTION
## Context

The canonical `.jac` formatter did not have a reliable contract at its 100-byte boundary. OCaml's formatting engine could break a group that fit exactly, and the fallback search for a narrower internal margin could remove indentation from a signature or labeled field. That made a one-byte edit change the visual structure of code in a misleading way.

Two valid but unbreakable forms also needed an honest policy. Type and effect declaration headers must keep their name with `=` or `where`, and a `forall` prefix has no grammar continuation in 0.1. The earlier documentation overcorrected by claiming that every other breakable line always fits. Concrete match-clause and raw-kernel examples show that the width is a layout target, not a global physical-line guarantee.

This PR completes the formatter boundary work without changing the language grammar, kernel, lowering, evaluator, native runtime, or file-carrier contract.

## What changed

- Measures complete formatting groups before choosing compact or multiline layout.
- Keeps groups compact when they fit exactly at the requested width.
- Uses one-item-per-line layout and trailing commas for multiline comma-separated groups.
- Preserves stable append/remove diffs for multiline lists.
- Keeps `else if` chains flat and adds W1203 for unusually large match scrutinees.
- Breaks top-level signatures and labeled constructor fields after `:`, with the colon on the owning line and a structural two-space type continuation.
- Removes the descending narrow-margin search that could erase continuation indentation.
- Adds W1204 for type/effect declaration headers whose shortest legal form exceeds 100 bytes.
- Adds W1205 for every over-wide `forall` prefix, including prefixes inside expression annotations, with diagnostics on the exact prefix in source order.
- Documents UTF-8 byte measurement and the three deliberate unbreakable forms.
- Narrows the overall promise: 100 bytes is a layout target, exact-fit behavior is decided per top-level item, and known overflow cases are explicitly non-exhaustive.
- Adds exact boundary, idempotence, lowering, hash-invariance, diff-stability, diagnostic-span, and public CLI coverage.

## Why it was done this way

The formatter is review infrastructure. Stable layout lets a reader see structure and meaning without mentally correcting indentation or interpreting avoidable diff churn. The exact-fit preflight keeps compact code compact, while falling back only to the requested margin preserves nesting cues when a line cannot fit.

The two grammar-driven exceptions remain valid `.jac` instead of being rejected or silently moved to `.jqd`. W1204 and W1205 make those cases visible and actionable. Multiline declaration headers and quantified binders remain a post-0.1 grammar question, which keeps this release-hardening change out of the language and kernel.

The documentation describes the behavior that is actually verified. It does not turn a formatter target into a stronger global guarantee than the implementation can support.

## How it was checked

- Full build passed.
- All 838 compiled and property tests passed in 374.391 seconds.
- All 27 documentation examples across 8 documents passed.
- Public command-line formatter transcripts passed.
- Packaged demo and Linux x86-64 installer smoke tests passed.
- Native/runtime checks passed.
- Documentation build and formatting checks passed.
- Historical evidence checks passed, including mutation tests that reject manifest drift.
- The immutable SS.22 surface-syntax evidence manifest remains unchanged.
- Version smoke reported `0.1.0`.
- Trailing-space, whitespace, and clean-worktree checks passed.
- Claude Opus 5 independently reviewed exact commit `555795662e78762f9261395f816c8f6d85d52d64` and returned PASS after reproducing the boundary and documented-overflow cases.

## Scope

There is no grammar, kernel-form, lowering, canonical-hash, evaluator, native-runtime, or carrier-format change. Parser additions are hash-excluded source metadata used only for precise diagnostics. Readability-study results are not a completion gate for this existing surface-syntax work.
