### PR TITLE
Isolate CI evidence and retry dependency downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,58 +21,10 @@ env:
   TMPDIR: ${{ github.workspace }}/.scratch/tmp
 
 jobs:
-  governance-playground:
-    name: Governance playground
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: playground/governance
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-
-      - name: Set up pinned Node LTS
-        uses: actions/setup-node@v7.0.0
-        with:
-          node-version: 24.18.0
-
-      - name: Enable pinned pnpm
-        run: corepack enable
-
-      - name: Install frozen dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Typecheck
-        run: pnpm run typecheck
-
-      - name: Unit and accessibility tests
-        run: pnpm run test
-
-      - name: Production build
-        run: pnpm run build
-
-      - name: Install browser engines
-        run: pnpm exec playwright install --with-deps chromium firefox webkit
-
-      - name: Browser, keyboard, and offline-network tests
-        run: pnpm run test:e2e
-
-      - name: Upload static build
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: governance-playground-${{ github.run_number }}
-          if-no-files-found: error
-          path: playground/governance/dist
-
   development-gate:
     name: Development gate
     runs-on: ubuntu-latest
-    needs: governance-playground
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -84,6 +36,9 @@ jobs:
         run: |
           mkdir -p "$TMPDIR"
           scripts/check-temp-policy.sh
+
+      - name: Test dependency-install retry policy
+        run: scripts/ci/test-opam-install-deps.sh
 
       - name: Verify historical release manifests
         run: |
@@ -98,7 +53,9 @@ jobs:
           ocaml-compiler: ${{ env.OCAML_COMPILER }}
 
       - name: Install dependencies
-        run: opam install --deps-only . --with-test --with-doc --with-dev-setup -y
+        run: |
+          scripts/ci/opam-install-deps.sh \
+            --deps-only . --with-test --with-doc --with-dev-setup -y
 
       - name: Build
         run: opam exec -- dune build @all
@@ -126,111 +83,10 @@ jobs:
           test -f docs/release/0.1/RELEASE-NOTES.md
           test -x scripts/release/smoke-installer.sh
 
-  gm12b-exhaustive:
-    name: GM12B exhaustive forwarding evidence
-    runs-on: ubuntu-latest
-    timeout-minutes: 240
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Determine evidence scope
-        id: scope
-        shell: bash
-        run: |
-          scope_regex='^(src/|bin/|prelude/|\.github/workflows/ci\.yml$|\.tool-versions$|dune-project$|dune-workspace[^/]*$|[^/]+\.opam$|test/dune$|test/gm12b/dune$|test/cli/workspace-forward-laws\.(jqd|expected)$|scripts/release/check-gm12b-exhaustive\.sh$|docs/release/governed-membranes/GM12B-(EVIDENCE\.md|MANIFEST\.sha256)$)'
-          zero_sha=0000000000000000000000000000000000000000
-
-          range_is_relevant() {
-            base=$1
-            head=$2
-            if [[ -z "$base" || "$base" == "$zero_sha" ]] ||
-              ! git cat-file -e "$base^{commit}" 2>/dev/null ||
-              ! git cat-file -e "$head^{commit}" 2>/dev/null ||
-              ! git merge-base --is-ancestor "$base" "$head"; then
-              return 0
-            fi
-            if ! changed_files=$(
-              git -c core.quotePath=false diff --no-renames --name-only "$base" "$head"
-            ); then
-              return 0
-            fi
-            grep -Eq "$scope_regex" <<<"$changed_files"
-          }
-
-          run=false
-          case "${{ github.event_name }}" in
-            pull_request)
-              if range_is_relevant \
-                "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"; then
-                run=true
-              fi
-              ;;
-            push)
-              case "${{ github.ref }}" in
-                refs/heads/release/*)
-                  run=true
-                  ;;
-                refs/heads/main)
-                  if range_is_relevant "${{ github.event.before }}" "${{ github.sha }}"; then
-                    run=true
-                  fi
-                  ;;
-                *)
-                  run=true
-                  ;;
-              esac
-              ;;
-            workflow_dispatch)
-              run=true
-              ;;
-            *)
-              run=true
-              ;;
-          esac
-          echo "run=$run" >> "$GITHUB_OUTPUT"
-
-      - name: Report unrelated change
-        if: steps.scope.outputs.run != 'true'
-        run: echo "GM.12B semantic dependency closure is unchanged; exhaustive evidence remains valid."
-
-      - name: Prepare temporary storage
-        if: steps.scope.outputs.run == 'true'
-        run: |
-          mkdir -p "$TMPDIR"
-          scripts/check-temp-policy.sh
-
-      - name: Set up OCaml
-        if: steps.scope.outputs.run == 'true'
-        uses: ocaml/setup-ocaml@v3.6.1
-        with:
-          ocaml-compiler: ${{ env.OCAML_COMPILER }}
-
-      - name: Install dependencies
-        if: steps.scope.outputs.run == 'true'
-        run: opam install --deps-only . --with-test -y
-
-      - name: Verify exhaustive forwarding evidence
-        if: steps.scope.outputs.run == 'true'
-        run: |
-          GM12B_EVIDENCE_OUT="$PWD/.scratch/evidence/gm12b/workspace-forward-laws.actual" \
-            opam exec -- dune build @test/gm12b/gm12b-evidence --force
-
-      - name: Upload exhaustive transcript
-        if: always() && steps.scope.outputs.run == 'true'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: gm12b-exhaustive-${{ github.run_number }}
-          if-no-files-found: warn
-          include-hidden-files: true
-          path: .scratch/evidence/gm12b/workspace-forward-laws.actual
-
   native-parity:
     name: Native parity (${{ matrix.cc }})
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -252,7 +108,9 @@ jobs:
           ocaml-compiler: ${{ env.OCAML_COMPILER }}
 
       - name: Install dependencies
-        run: opam install --deps-only . --with-test -y
+        run: |
+          scripts/ci/opam-install-deps.sh \
+            --deps-only . --with-test -y
 
       - name: Build
         run: opam exec -- dune build @all

--- a/.github/workflows/gm12b.yml
+++ b/.github/workflows/gm12b.yml
@@ -1,0 +1,126 @@
+name: GM12B
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gm12b-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.run_id || 'cancelable' }}
+  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+
+env:
+  OCAML_COMPILER: 5.1.1
+  JACQUARD_PRELUDE: ${{ github.workspace }}/prelude
+  TMPDIR: ${{ github.workspace }}/.scratch/tmp
+
+jobs:
+  gm12b-exhaustive:
+    name: GM12B exhaustive forwarding evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Determine evidence scope
+        id: scope
+        shell: bash
+        run: |
+          scope_regex='^(src/|bin/|prelude/|\.github/workflows/(ci|gm12b)\.yml$|\.tool-versions$|dune-project$|dune-workspace[^/]*$|[^/]+\.opam$|test/dune$|test/gm12b/dune$|test/cli/workspace-forward-laws\.(jqd|expected)$|scripts/ci/opam-install-deps\.sh$|scripts/release/check-gm12b-exhaustive\.sh$|docs/release/governed-membranes/GM12B-(EVIDENCE\.md|MANIFEST\.sha256)$)'
+          zero_sha=0000000000000000000000000000000000000000
+
+          range_is_relevant() {
+            base=$1
+            head=$2
+            if [[ -z "$base" || "$base" == "$zero_sha" ]] ||
+              ! git cat-file -e "$base^{commit}" 2>/dev/null ||
+              ! git cat-file -e "$head^{commit}" 2>/dev/null ||
+              ! git merge-base --is-ancestor "$base" "$head"; then
+              return 0
+            fi
+            if ! changed_files=$(
+              git -c core.quotePath=false diff --no-renames --name-only "$base" "$head"
+            ); then
+              return 0
+            fi
+            grep -Eq "$scope_regex" <<<"$changed_files"
+          }
+
+          run=false
+          case "${{ github.event_name }}" in
+            pull_request)
+              if range_is_relevant \
+                "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"; then
+                run=true
+              fi
+              ;;
+            push)
+              case "${{ github.ref }}" in
+                refs/heads/release/*)
+                  run=true
+                  ;;
+                refs/heads/main)
+                  if range_is_relevant "${{ github.event.before }}" "${{ github.sha }}"; then
+                    run=true
+                  fi
+                  ;;
+                *)
+                  run=true
+                  ;;
+              esac
+              ;;
+            workflow_dispatch)
+              run=true
+              ;;
+            *)
+              run=true
+              ;;
+          esac
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
+      - name: Report unrelated change
+        if: steps.scope.outputs.run != 'true'
+        run: echo "GM.12B semantic dependency closure is unchanged; exhaustive evidence remains valid."
+
+      - name: Prepare temporary storage
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          mkdir -p "$TMPDIR"
+          scripts/check-temp-policy.sh
+
+      - name: Set up OCaml
+        if: steps.scope.outputs.run == 'true'
+        uses: ocaml/setup-ocaml@v3.6.1
+        with:
+          ocaml-compiler: ${{ env.OCAML_COMPILER }}
+
+      - name: Install dependencies
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          scripts/ci/opam-install-deps.sh \
+            --deps-only . --with-test -y
+
+      - name: Verify exhaustive forwarding evidence
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          GM12B_EVIDENCE_OUT="$PWD/.scratch/evidence/gm12b/workspace-forward-laws.actual" \
+            opam exec -- dune build @test/gm12b/gm12b-evidence --force
+
+      - name: Upload exhaustive transcript
+        if: always() && steps.scope.outputs.run == 'true'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: gm12b-exhaustive-${{ github.run_number }}
+          if-no-files-found: warn
+          include-hidden-files: true
+          path: .scratch/evidence/gm12b/workspace-forward-laws.actual

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,72 @@
+name: Governance
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: governance-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.run_id || 'cancelable' }}
+  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+
+env:
+  TMPDIR: ${{ github.workspace }}/.scratch/tmp
+
+jobs:
+  governance-playground:
+    name: Governance playground
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: playground/governance
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+
+      - name: Prepare temporary storage
+        working-directory: ${{ github.workspace }}
+        run: mkdir -p "$TMPDIR"
+
+      - name: Set up pinned Node LTS
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24.18.0
+
+      - name: Enable pinned pnpm
+        run: corepack enable
+
+      - name: Install frozen dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Unit and accessibility tests
+        run: pnpm run test
+
+      - name: Production build
+        run: pnpm run build
+
+      - name: Install browser engines
+        run: pnpm exec playwright install --with-deps chromium firefox webkit
+
+      - name: Browser, keyboard, and offline-network tests
+        run: pnpm run test:e2e
+
+      - name: Upload static build
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: governance-playground-${{ github.run_number }}
+          if-no-files-found: error
+          path: playground/governance/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,12 @@ GitHub Actions mirrors the local definition of done:
 
 - `CI / Development gate` runs build, full tests, clean formatting, version
   smoke, and release-doc presence on PRs, `main`, and `release/**`.
+- `CI / Native parity (clang)` and `CI / Native parity (gcc)` run the runtime
+  memory, differential, leak, and seeded fuzz evidence.
+- `Governance / Governance playground` runs the source-checkout viewer's
+  lint, type, unit/accessibility, build, and browser checks.
+- `GM12B / GM12B exhaustive forwarding evidence` runs or explicitly carries
+  forward the scoped 50,000-case forwarding proof.
 - `Release Evidence / Reproduce 0.1 evidence` runs
   `scripts/release/reproduce-0.1.sh` on `release/**`, `jacquard-core-*` tags, and
   manual dispatch, then uploads the evidence transcripts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,14 @@ milestones; release docs and current issues define active work. The spec
 ## GitHub gates
 
 See `docs/ci-cd.md` for the branch protection and release evidence process.
-Ordinary PRs must satisfy `CI / Development gate`. Release-candidate branches
-and `jacquard-core-*` tags must also satisfy `Release Evidence / Reproduce 0.1
-evidence`, which runs the reproducibility script and uploads the transcript
-artifact.
+Ordinary PRs must satisfy the independent core, native-parity, governance, and
+GM.12B checks described there. Keeping those evidence classes in separate
+workflows permits a failed class to be rerun without repeating the others.
+Each class is enforced by its own required branch-protection context after the
+staged context-name rollout described in `docs/ci-cd.md`. Release-candidate
+branches and `jacquard-core-*` tags must also satisfy
+`Release Evidence / Reproduce 0.1 evidence`, which runs the reproducibility
+script and uploads the transcript artifact.
 
 ## Contributor licensing
 

--- a/README.md
+++ b/README.md
@@ -619,10 +619,17 @@ JACQUARD_RELEASE_REF=HEAD JACQUARD_RELEASE_BASE=738dc8e scripts/release/reproduc
 
 ## CI/CD
 
-GitHub Actions has three principal workflows:
+GitHub Actions separates independently retryable evidence:
 
 - `CI / Development gate`: build, full tests, clean formatting, version smoke,
   and release-doc presence on PRs, `main`, and `release/**`.
+- `CI / Native parity (clang|gcc)`: runtime memory, differential, leak, and
+  seeded fuzz evidence for both supported C compilers.
+- `Governance / Governance playground`: lint, types, unit/accessibility tests,
+  production build, and browser/keyboard/offline-network checks.
+- `GM12B / GM12B exhaustive forwarding evidence`: the scoped 50,000-case
+  forwarding proof, with a successful no-op result outside its dependency
+  closure.
 - `Release Evidence / Reproduce 0.1 evidence`: release branches, `jacquard-core-*`
   tags, and manual dispatch; runs `scripts/release/reproduce-0.1.sh` and uploads
   transcripts.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,6 +4,42 @@ Jacquard's CI is intentionally a release discipline, not just a build bot. The
 project rule is that nothing merges unless the definition-of-done evidence is
 machine-checkable.
 
+## Workflow Topology and Retry Isolation
+
+Pull-request evidence is split into three workflows:
+
+- `.github/workflows/ci.yml` runs the OCaml development gate and the clang/GCC
+  native-parity matrix.
+- `.github/workflows/governance.yml` runs the governance playground's Node,
+  browser, keyboard, accessibility, and offline-network checks.
+- `.github/workflows/gm12b.yml` runs or explicitly carries forward the GM.12B
+  exhaustive forwarding evidence.
+
+The split changes scheduling and retry boundaries, not the definition of done.
+All three workflows run for pull requests, `main`, `release/**`, and manual
+dispatch. A transient failure in one workflow can be rerun without repeating
+the independent workflows. The core workflow keeps the established
+`Development gate`, `Native parity (clang)`, and `Native parity (gcc)` job
+names so the existing protected contexts do not disappear during migration.
+The new Governance and GM.12B contexts become required only after their exact
+names have reported on both a real pull request and the resulting `main` push;
+the rollout procedure is in Recommended Branch Protection below.
+
+OCaml dependency installation in these pull-request workflows goes through
+`scripts/ci/opam-install-deps.sh`. It retries only opam status 40, the
+documented repository/download synchronization failure, for at most three
+total attempts with a 15-second delay. Solver, metadata, configuration, and
+package-build failures retain their original status without a retry, so
+deterministic failures remain visible and cannot consume the whole job
+timeout. The wrapper re-runs the same resolution and neither pins nor freezes
+resolved dependencies. Its success, retry, argument-forwarding, validation,
+and exit-status behavior is pinned by
+`scripts/ci/test-opam-install-deps.sh`.
+
+The Development gate has a 60-minute timeout, each native-parity lane has a
+90-minute timeout, the governance workflow has a 30-minute timeout, and the
+GM.12B proof retains its 240-minute fail-closed timeout.
+
 ## Development Gate
 
 Workflow: `.github/workflows/ci.yml`
@@ -15,9 +51,10 @@ Required check for protected branches:
 
 - `CI / Development gate`
 
-The required development gate waits for the separate
-`CI / Governance playground` job. That dependency prevents the protected
-check from becoming green while the local review surface is failing.
+The gate is independent of governance and GM.12B so GitHub can schedule and
+rerun those evidence classes separately. Branch protection, rather than a
+cross-job `needs` edge, will require the complete evidence set once the staged
+rollout in Recommended Branch Protection completes.
 
 The gate runs:
 
@@ -26,7 +63,8 @@ scripts/release/check-historical-manifests.sh \
   --commit "$(git rev-parse HEAD)" \
   --require-history
 scripts/release/test-historical-manifests.sh --commit "$(git rev-parse HEAD)"
-opam install --deps-only . --with-test --with-doc --with-dev-setup -y
+scripts/ci/opam-install-deps.sh \
+  --deps-only . --with-test --with-doc --with-dev-setup -y
 opam exec -- dune build @all
 opam exec -- dune runtest
 opam exec -- dune fmt
@@ -98,8 +136,15 @@ and the publication to be the last commit that changed the immutable manifest.
 
 ## Governance Playground
 
+Workflow: `.github/workflows/governance.yml`
+
+Required check for protected branches after the staged rollout in Recommended
+Branch Protection:
+
+- `Governance / Governance playground`
+
 The source-checkout-only Workspace v0 decision-chain viewer has its own CI
-job. It uses the exact Node and pnpm versions pinned in
+workflow. It uses the exact Node and pnpm versions pinned in
 `playground/governance/package.json`, installs the committed lockfile without
 updating it, and runs:
 
@@ -130,9 +175,12 @@ JACQUARD_GOVERNANCE_PLAYGROUND_FIXTURES_OUT="$PWD/playground/governance/fixtures
 
 ## GM.12B Exhaustive Forwarding Evidence
 
-The reusable Workspace forwarding membrane has a separate required check:
+Workflow: `.github/workflows/gm12b.yml`
 
-- `CI / GM12B exhaustive forwarding evidence`
+The reusable Workspace forwarding membrane has a separate check, required
+after the staged rollout in Recommended Branch Protection:
+
+- `GM12B / GM12B exhaustive forwarding evidence`
 
 It runs the full 50,000-case grid through two real forwarding handlers and a
 hermetic leaf, then byte-compares the result with the checked-in transcript.
@@ -150,7 +198,8 @@ relevant range.
 The proof owns a dedicated Dune rule in `test/gm12b/dune`, so changes to
 unrelated cram dependencies do not enter its CI scope. Its conservative
 dependency closure still includes the implementation, prelude, toolchain,
-proof carrier and expected transcript, checker, workflow, and dedicated rule.
+proof carrier and expected transcript, checker, core and GM.12B workflows,
+dependency-install wrapper, and dedicated rule.
 
 Local equivalent:
 
@@ -278,14 +327,20 @@ For `main`:
 
 - require pull requests before merging
 - require `CI / Development gate`
-- require `CI / GM12B exhaustive forwarding evidence`
+- require `CI / Native parity (clang)`
+- require `CI / Native parity (gcc)`
+- require `Governance / Governance playground`
+- require `GM12B / GM12B exhaustive forwarding evidence`
 - require branches to be up to date before merging
 - dismiss stale approvals when new commits are pushed
 
 For `release/**`:
 
 - require `CI / Development gate`
-- require `CI / GM12B exhaustive forwarding evidence`
+- require `CI / Native parity (clang)`
+- require `CI / Native parity (gcc)`
+- require `Governance / Governance playground`
+- require `GM12B / GM12B exhaustive forwarding evidence`
 - require `Release Evidence / Reproduce 0.1 evidence`
 - restrict changes to correctness, reproducibility, documentation, and demos
 
@@ -295,6 +350,23 @@ For `jacquard-core-*` tags:
   commit being tagged
 - preserve the uploaded evidence artifact with the tag/release notes
 - require the release-binaries workflow to complete before announcing the tag
+
+When introducing, renaming, or moving an independent workflow:
+
+1. Keep every existing required context unchanged while the new workflow
+   reports on a real pull request.
+2. Merge that workflow change, confirm the new context on the resulting
+   `main` push, and add all new contexts to branch protection in one settings
+   edit.
+3. If a required context is ever replaced, keep a compatibility job reporting
+   the old context until the replacement is required. Remove the compatibility
+   job and retired context only in a follow-up change.
+
+This migration does not replace a live required context: `Development gate`
+and both native-parity names stay unchanged. Governance and GM.12B are added
+to protection only after their independent contexts have reported. Keeping
+that interval to one merge cycle prevents a missing context from deadlocking
+the migration while making the final evidence policy explicit.
 
 ## Local Equivalents
 

--- a/scripts/ci/opam-install-deps.sh
+++ b/scripts/ci/opam-install-deps.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -u
+
+opam_bin=${OPAM_BIN:-opam}
+attempt_limit=${OPAM_INSTALL_ATTEMPTS:-3}
+retry_delay=${OPAM_INSTALL_RETRY_DELAY_SECONDS:-15}
+
+case "$attempt_limit" in
+  ''|*[!0-9]*)
+    echo "OPAM_INSTALL_ATTEMPTS must be a positive integer" >&2
+    exit 64
+    ;;
+esac
+if [ "$attempt_limit" -lt 1 ]; then
+  echo "OPAM_INSTALL_ATTEMPTS must be a positive integer" >&2
+  exit 64
+fi
+
+case "$retry_delay" in
+  ''|*[!0-9]*)
+    echo "OPAM_INSTALL_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+    exit 64
+    ;;
+esac
+
+attempt=1
+while :; do
+  "$opam_bin" install "$@"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+  if [ "$status" -ne 40 ]; then
+    echo "opam dependency installation failed with non-sync status $status; not retrying" >&2
+    exit "$status"
+  fi
+  if [ "$attempt" -ge "$attempt_limit" ]; then
+    echo "opam dependency download failed after $attempt attempt(s)" >&2
+    exit "$status"
+  fi
+
+  echo "opam dependency download failed on attempt $attempt/$attempt_limit; retrying in ${retry_delay}s" >&2
+  sleep "$retry_delay"
+  attempt=$((attempt + 1))
+done

--- a/scripts/ci/test-opam-install-deps.sh
+++ b/scripts/ci/test-opam-install-deps.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+scratch_root=${TMPDIR:-"$repo_root/.scratch/tmp"}
+mkdir -p "$scratch_root"
+test_root=$(mktemp -d "$scratch_root/opam-install-retry.XXXXXX")
+trap 'rm -rf -- "$test_root"' EXIT HUP INT TERM
+
+fake_opam="$test_root/opam"
+cat >"$fake_opam" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+
+count=0
+if [ -f "$FAKE_OPAM_COUNT_FILE" ]; then
+  count=$(cat "$FAKE_OPAM_COUNT_FILE")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$FAKE_OPAM_COUNT_FILE"
+printf '%s\n' "$@" >"$FAKE_OPAM_ARGS_FILE"
+
+if [ "$count" -le "$FAKE_OPAM_FAILURES" ]; then
+  exit "${FAKE_OPAM_FAILURE_STATUS:-7}"
+fi
+EOF
+chmod +x "$fake_opam"
+
+count_file="$test_root/count"
+args_file="$test_root/args"
+
+FAKE_OPAM_COUNT_FILE="$count_file" \
+FAKE_OPAM_ARGS_FILE="$args_file" \
+FAKE_OPAM_FAILURES=0 \
+OPAM_BIN="$fake_opam" \
+OPAM_INSTALL_ATTEMPTS=3 \
+OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+  "$repo_root/scripts/ci/opam-install-deps.sh" \
+    --deps-only . "path with space" --with-test -y
+
+test "$(cat "$count_file")" = 1
+expected_args=$(printf '<%s>\n' install --deps-only . "path with space" --with-test -y)
+actual_args=$(sed 's/^/</; s/$/>/' "$args_file")
+test "$actual_args" = "$expected_args"
+
+rm -f "$count_file"
+FAKE_OPAM_COUNT_FILE="$count_file" \
+FAKE_OPAM_ARGS_FILE="$args_file" \
+FAKE_OPAM_FAILURES=2 \
+FAKE_OPAM_FAILURE_STATUS=40 \
+OPAM_BIN="$fake_opam" \
+OPAM_INSTALL_ATTEMPTS=3 \
+OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+  "$repo_root/scripts/ci/opam-install-deps.sh" --deps-only . --with-test -y
+
+test "$(cat "$count_file")" = 3
+expected_args=$(printf '<%s>\n' install --deps-only . --with-test -y)
+actual_args=$(sed 's/^/</; s/$/>/' "$args_file")
+test "$actual_args" = "$expected_args"
+
+rm -f "$count_file"
+if FAKE_OPAM_COUNT_FILE="$count_file" \
+  FAKE_OPAM_ARGS_FILE="$args_file" \
+  FAKE_OPAM_FAILURES=3 \
+  FAKE_OPAM_FAILURE_STATUS=40 \
+  OPAM_BIN="$fake_opam" \
+  OPAM_INSTALL_ATTEMPTS=2 \
+  OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+    "$repo_root/scripts/ci/opam-install-deps.sh" --deps-only .; then
+  echo "retry wrapper unexpectedly succeeded after exhausting its attempts" >&2
+  exit 1
+else
+  status=$?
+fi
+
+test "$status" = 40
+test "$(cat "$count_file")" = 2
+
+rm -f "$count_file"
+if FAKE_OPAM_COUNT_FILE="$count_file" \
+  FAKE_OPAM_ARGS_FILE="$args_file" \
+  FAKE_OPAM_FAILURES=3 \
+  FAKE_OPAM_FAILURE_STATUS=31 \
+  OPAM_BIN="$fake_opam" \
+  OPAM_INSTALL_ATTEMPTS=3 \
+  OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+    "$repo_root/scripts/ci/opam-install-deps.sh" --deps-only .; then
+  echo "retry wrapper unexpectedly retried a package-operation failure" >&2
+  exit 1
+else
+  status=$?
+fi
+
+test "$status" = 31
+test "$(cat "$count_file")" = 1
+
+if OPAM_BIN="$fake_opam" \
+  OPAM_INSTALL_ATTEMPTS=0 \
+  OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+    "$repo_root/scripts/ci/opam-install-deps.sh"; then
+  echo "retry wrapper accepted an invalid attempt limit" >&2
+  exit 1
+else
+  status=$?
+fi
+test "$status" = 64
+
+if OPAM_BIN="$fake_opam" \
+  OPAM_INSTALL_ATTEMPTS=three \
+  OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+    "$repo_root/scripts/ci/opam-install-deps.sh"; then
+  echo "retry wrapper accepted a non-numeric attempt limit" >&2
+  exit 1
+else
+  status=$?
+fi
+test "$status" = 64
+
+if OPAM_BIN="$fake_opam" \
+  OPAM_INSTALL_ATTEMPTS=1 \
+  OPAM_INSTALL_RETRY_DELAY_SECONDS=later \
+    "$repo_root/scripts/ci/opam-install-deps.sh"; then
+  echo "retry wrapper accepted a non-numeric retry delay" >&2
+  exit 1
+else
+  status=$?
+fi
+test "$status" = 64
+
+rm -f "$count_file"
+FAKE_OPAM_COUNT_FILE="$count_file" \
+FAKE_OPAM_ARGS_FILE="$args_file" \
+FAKE_OPAM_FAILURES=2 \
+FAKE_OPAM_FAILURE_STATUS=40 \
+OPAM_BIN="$fake_opam" \
+OPAM_INSTALL_RETRY_DELAY_SECONDS=0 \
+  "$repo_root/scripts/ci/opam-install-deps.sh" --deps-only .
+
+test "$(cat "$count_file")" = 3
+
+echo "opam dependency-install retry policy: ok"


### PR DESCRIPTION
## Context

The previous pull request exposed two CI problems at the same time.

First, the Development gate failed before the project built because opam
exhausted its own retries while downloading dependencies over TLS. The same
commit passed when that job was rerun, so this was an infrastructure failure,
not a Jacquard failure.

Second, GitHub would not let us rerun that completed Development job while the
50,000-case GM12B proof was still running in the same workflow. Governance,
Development, GM12B, and both native compilers were grouped together even
though they produce independent evidence. Development also waited for
Governance despite consuming none of its artifacts.

That made a transient network problem expensive to recover from and obscured
which part of the system was actually red. The live branch protection and the
CI documentation had also drifted: protection required Development and both
native jobs, while the documentation described a different set.

This PR changes CI orchestration and its documentation only. It does not
change the Jacquard language, runtime, CLI, release artifacts, historical
evidence, or release-tag contract.

## What changed

- Kept the core `CI` workflow for `Development gate`,
  `Native parity (clang)`, and `Native parity (gcc)`, preserving all three
  existing required-check names.
- Moved `Governance playground` into its own `Governance` workflow.
- Moved `GM12B exhaustive forwarding evidence` into its own `GM12B` workflow.
- Removed the unused Development-to-Governance dependency.
- Kept exact `main` evidence non-canceling while allowing superseded pull
  request runs to be canceled independently in each workflow.
- Kept GM12B's conservative job-level scope check. It still fails closed and
  now recognizes its split workflow file and the shared dependency helper as
  evidence-relevant inputs.
- Added explicit job ceilings: 60 minutes for Development, 90 minutes for
  each native compiler, 30 minutes for Governance, and 240 minutes for GM12B.
- Added a small opam dependency wrapper that retries only documented
  synchronization/download failures (exit 40), for three total attempts.
  Package build failures and every other exit status return immediately
  unchanged.
- Added a hermetic regression suite for retry recovery, retry exhaustion,
  exact argument forwarding, non-network failures, invalid configuration, and
  the default attempt count.
- Updated contributor, setup, agent, and CI/release documentation to explain
  the workflow topology, retry boundary, timeout policy, and staged
  branch-protection migration.

## Why it was done this way

Every evidence class remains merge-grade. The improvement comes from making
independent checks independently visible and rerunnable, not from sampling or
dropping expensive proof.

The opam wrapper is deliberately narrow. Retrying arbitrary failures can hide
a real package or compiler problem; retrying only exit 40 addresses the
observed fetch failure while preserving meaningful red builds.

The three existing protected context names stay unchanged so this PR cannot
create a required-check reporting gap. Governance and GM12B will be added to
strict branch protection in one staged edit only after their new contexts
have reported successfully on this real pull request and the resulting
`main` run.

## Contract and exclusions

- Development, both native compilers, Governance, and GM12B remain required
  merge evidence after the staged rollout.
- Main-push evidence is never canceled.
- GM12B remains exhaustive and fail closed.
- Release workflows and the exact 0.1 reproduction contract are unchanged.
- No language surface, kernel form, lowering, hash, evaluator, native runtime,
  diagnostic, manifest, or published release artifact changes.
- No integration branch, PR stack, merge queue, or weaker sampled evidence
  tier is introduced.

## Independent review

Claude Code Opus 5 at xhigh effort reviewed the migration.

The first review found valid issues in Governance temporary-storage setup,
overbroad retry behavior, retry regression coverage, and rollout wording.
Those findings were fixed together. Its assumption that GM12B was already a
live required context was rejected using the repository's branch-protection
API state.

The final review returned `PASS` on reviewed ancestor `d9e2549`. The exact
final head adds only the reviewer's requested wording that Governance and
GM12B become required after the staged rollout, says “three total attempts”
instead of “three retries,” and pins the wrapper's default attempt count in
the regression suite. There is no workflow-semantic change after the passing
review.

## How it was checked

On exact clean head `83f19afe5fdf97c52f354837ca2bd851877f7b6e`:

- actionlint 1.7.12, YAML parsing, shell syntax, whitespace, formatting, and
  repository temporary-storage policy passed.
- The opam retry regression suite passed every success, recovery, exhaustion,
  argument-boundary, non-network-failure, invalid-config, and default-count
  case.
- `dune build @all`, `dune build @doc`, all 838 compiled/property tests, all
  27 documentation examples, version smoke, installer smoke, immutable
  surface-syntax checks, and historical-publication mutation checks passed.
- Clang and GCC sanitizer/runtime checks passed.
- Native differential evidence reported 69 identical programs, 8 expected
  refusals, and 0 failures.
- All 41 native leak-gauntlet programs passed.
- A forced GCC native fuzz run completed 1,000 cases with no divergence.
- Forced GM12B evidence verified 50,000 cases: 1 passed, 0 failed, 0 skipped,
  and 0 refused.
- Governance passed under exact Node 24.18.0 and pnpm 10.17.1: frozen install,
  lint, typecheck, 28 unit/accessibility tests, production build, and 12
  Chromium, Firefox, and WebKit keyboard/offline-network tests.
- The full 0.1 release reproduction passed, including runtime/memory, native
  differential/leak/fuzz evidence, packaged demos, installer, CLI/gauntlet,
  and release evidence generation.

## Risks and follow-up

The workflow split creates two new check contexts. They are intentionally not
required before GitHub has observed them, because requiring an unknown context
would deadlock merging. After this PR and its `main` run report both contexts,
strict protection will be updated once to require:

- `Development gate`
- `Native parity (clang)`
- `Native parity (gcc)`
- `Governance playground`
- `GM12B exhaustive forwarding evidence`

No other deferred CI or release behavior is hidden in this change.
