### PR TITLE
readability: compare schema values as JSON

### DIFF
--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -814,6 +814,37 @@ def json_type_matches(value: Any, declared: str | list[str]) -> bool:
     return False
 
 
+def json_values_equal(left: Any, right: Any) -> bool:
+    """Compare JSON values without Python's boolean/integer aliasing.
+
+    Draft 2020-12 treats booleans as distinct from numbers, while numerically
+    equal integer and finite floating-point representations denote the same
+    JSON number. Arrays and objects apply that rule recursively.
+    """
+
+    if isinstance(left, bool) or isinstance(right, bool):
+        return (
+            isinstance(left, bool) and isinstance(right, bool) and left is right
+        )
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return left == right
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(json_values_equal(a, b) for a, b in zip(left, right))
+        )
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and left.keys() == right.keys()
+            and all(json_values_equal(left[key], right[key]) for key in left)
+        )
+    return type(left) is type(right) and left == right
+
+
 def schema_matches(value: Any, rule: dict[str, Any]) -> bool:
     """Return whether a value satisfies a schema branch without leaking errors."""
 
@@ -837,9 +868,11 @@ def validate_schema_value(name: str, value: Any, rule: dict[str, Any]) -> None:
     declared_type = rule.get("type")
     if declared_type is not None and not json_type_matches(value, declared_type):
         raise ProtocolError(f"result {name} has the wrong JSON type")
-    if "const" in rule and value != rule["const"]:
+    if "const" in rule and not json_values_equal(value, rule["const"]):
         raise ProtocolError(f"result {name} must equal {rule['const']!r}")
-    if "enum" in rule and value not in rule["enum"]:
+    if "enum" in rule and not any(
+        json_values_equal(value, candidate) for candidate in rule["enum"]
+    ):
         raise ProtocolError(f"result {name} is outside its enum")
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         if "minimum" in rule and value < rule["minimum"]:
@@ -1807,6 +1840,20 @@ def self_test(
         "a duplicate synthetic row",
         lambda: validate_result_store(duplicate_synthetic, manifest, schema),
     )
+    mixed_subject_kinds = [
+        copy.deepcopy(human_store[0]),
+        copy.deepcopy(model_store[0]),
+    ]
+    expect_rejection(
+        "a mixed human/model result store",
+        lambda: validate_result_store(
+            mixed_subject_kinds,
+            manifest,
+            schema,
+            cohort=approved_cohort,
+            authority=approved_authority,
+        ),
+    )
 
     sentinel_manifest = copy.deepcopy(dict(manifest))
     sentinel_manifest["fixtures"][0]["options"].append(
@@ -1825,6 +1872,8 @@ def self_test(
 
     mutations = (
         ("syntax highlighting", "syntax_highlighting", True),
+        ("numeric plain-text boolean", "plain_text", 1),
+        ("numeric syntax-highlighting boolean", "syntax_highlighting", 0),
         ("readability scale", "perceived_readability", 0),
         ("outcome family", "outcome_family", "review"),
     )
@@ -1838,6 +1887,15 @@ def self_test(
             pass
         else:
             raise ProtocolError(f"schema validator accepted invalid {label}")
+    equality_cases = (
+        (1, 1.0, True),
+        (True, 1, False),
+        ([False], [0], False),
+        ({"flag": True}, {"flag": 1}, False),
+    )
+    for left, right, expected_equal in equality_cases:
+        if json_values_equal(left, right) is not expected_equal:
+            raise ProtocolError("JSON value equality drifted from Draft 2020-12")
     mutation = copy.deepcopy(rows[0])
     del mutation["confidence"]
     try:


### PR DESCRIPTION
## Context

Part of #86.

The readability result checker used Python equality for JSON Schema `const`
and `enum`. In Python, numeric `1` equals boolean `true`, and numeric `0` equals
boolean `false`. That meant a malformed row could claim `plain_text: 1` or
`syntax_highlighting: 0` and pass those schema constants.

## What changed

- Compare schema values with JSON-aware equality: booleans are distinct from
  numbers, equal number representations stay equal, and arrays/objects apply
  the same rule recursively.
- Route both the bounded `const` and `enum` checks through that equality rule.
- Add adversarial rows for numeric presentation booleans.
- Add the requested explicit mixed human/model store mutation.

## Contract

Malformed numeric booleans must fail closed. Valid boolean rows behave exactly
as before. The checked result schema, its SHA-256 identity, fixture manifest,
schedule bytes, row-ID algorithm, and every valid admitted row remain
unchanged. Mixed subject kinds remain separate stores.

## Deliberately excluded

This does not collect or analyze results, create study authority, contact a
participant or model provider, or make a readability claim. It does not change
Jacquard syntax, the 27 kernel forms, lowering, HASH_V0, diagnostics, evaluator
behavior, native runtime, or release claims. The later deterministic analysis,
blinded rescoring, subject-level exclusion flow, and publication gate remain
in #86.

## Validation

- Regression-first focused gate failed because numeric `plain_text: 1` was
  accepted before the fix.
- Exact-head readability gate passes all 5 jobs, 3 carriers, 15 synthetic
  conditions, 480 human assignments, and 450 model trials.
- Two same-seed dry runs are byte-identical and validate all 15 rows.
- Frozen human and model schedule hashes remain unchanged.
- Historical manifests, full build, docs, formatting/clean diff, version,
  policy checks, release-file presence, packaged installer, and demos pass.
- All 847 compiled tests pass. Native cram wrappers cannot finish locally
  because LeakSanitizer detects host tracing; no expected output was changed,
  and the required GitHub Development/clang/gcc lanes remain the sanitizer
  source of truth.
- Pinned Node 24.18.0 / pnpm 10.17.1 governance passes lint, typecheck, all 28
  unit/accessibility tests, build, and all 12 Chromium/Firefox/WebKit tests.
- Independent Claude Code review with the configured Fable 5 reviewer returned
  PASS on the exact PR head with no blockers or architecture conflict.

## Risks and follow-ups

This is intentionally a small admission-correctness patch. The mixed-store
mutation asserts rejection rather than a specific diagnostic because these
diagnostics are not a stable public API. The statistical evidence work remains
separate so admission logic and publication logic stay independently
reviewable.
