### PR TITLE
Add deterministic readability analysis admission

### DIFF
--- a/docs/research/readability-benchmark/EXECUTION.md
+++ b/docs/research/readability-benchmark/EXECUTION.md
@@ -163,6 +163,46 @@ Preserve, under the approved data controls:
 No human-identifying data, provider secrets, raw model conversations, or
 synthetic rows represented as outcomes may be committed.
 
+## Deterministic analysis input
+
+After `validate-results` accepts a complete store, prepare its versioned row
+selection and provenance bundle with the same exact admission context:
+
+```text
+python3 test/readability/readability_benchmark.py prepare-analysis \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json \
+  --input HUMAN-RESULTS.jsonl \
+  > .scratch/readability/human-analysis-input.json
+
+python3 test/readability/readability_benchmark.py prepare-analysis \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json --cohort COHORT.json \
+  --input MODEL-RESULTS.jsonl \
+  > .scratch/readability/model-analysis-input.json
+```
+
+The command validates the complete store before emitting anything. Its
+canonical `readability-analysis-input-v1` JSON binds the exact source-file
+SHA-256, ordered row identity, reviewed pins, per-subject decisions, and total
+and per-carrier flow. A successful human retry replaces only its failed first
+attempt; successful here means the retry itself did not have a system failure,
+not that its answer was correct. More than one verified system failure,
+including a failed retry, or
+any stable non-system exclusion removes the whole human subject from effective
+rows. Model sessions remain row-local. Source, effective, and excluded row-ID
+lists partition the input so every count can be recomputed.
+
+The output deliberately omits timestamps and measured outcomes. Running the
+command twice on byte-identical input therefore produces byte-identical output.
+Human pre-assignment consent and eligibility flow is `external-required`
+because those approved records remain outside answer JSONL. This tool neither
+creates that flow nor authorizes collection. Synthetic output is explicitly
+non-citable; human and model output remains candidate evidence with no claim
+evaluated.
+
 ## What the checked gate proves
 
 `dune build @readability-protocol` verifies:
@@ -180,6 +220,9 @@ synthetic rows represented as outcomes may be committed.
   authority, digest, assignment, cohort, repetition, retry, completeness,
   ordering, and fresh-session mutations; the fixtures are synthetic tests and
   are not collection authority or outcomes;
+- deterministic analyzability provenance for clean stores, a successful retry,
+  a failed retry, multiple first-attempt failures, stable subject exclusions,
+  and an excluded model session, including exact-source digest sensitivity;
 - unconditional rejection of real rows with the checked pending authority and
   M0 cohort manifests; and
 - byte-identical schedule and dry-run generation.

--- a/docs/research/readability-benchmark/PROTOCOL.md
+++ b/docs/research/readability-benchmark/PROTOCOL.md
@@ -195,6 +195,29 @@ prompt parse failure, or more than one system failure. Enrollment, exclusion,
 analyzable, failure, missing-data, and timeout flow is published by carrier and
 cohort before outcomes are unblinded.
 
+Analysis starts only after the complete answer store passes result validation.
+The versioned `readability-analysis-input-v1` bundle binds the SHA-256 of the
+exact JSONL bytes, the ordered canonical row IDs, and the existing schema,
+fixture, authority, assignment, schedule, and cohort pins. It contains only
+pseudonymous subject IDs, row IDs, selection decisions, and flow counts; it has
+no timestamp or outcome statistic.
+
+For a human with no system failure, all five first attempts are effective. One
+failed first attempt remains excluded and its successful final retry replaces
+it. Here successful means the retry itself did not have a system failure; an
+incorrect answer or timeout remains an outcome. More than one verified system
+failure, including a failed retry, excludes
+the whole subject and makes none of that subject's rows effective. Any stable
+non-system human exclusion also excludes the whole subject. Each model session
+is effective exactly when its one admitted row is not excluded. Timeouts remain
+outcomes, not exclusions. Human, model, and synthetic stores always produce
+separate bundles; synthetic bundles are marked `synthetic-non-citable`, and
+real-store bundles are candidate evidence with claim status `not-evaluated`.
+
+Pre-assignment no-consent and eligibility counts remain in the separately
+approved enrollment flow. They are reported as `external-required`, not
+inferred or invented from answer rows.
+
 ## Preregistered analysis and claim gate
 
 Produce separate deterministic tables for perceived ratings, comprehension,
@@ -252,10 +275,17 @@ python3 test/readability/readability_benchmark.py validate-results \
   --cohort test/readability/cohorts/m0-fable5.json \
   --authority test/readability/authority-manifest.template.json \
   --input .scratch/readability/dry-run.jsonl
+python3 test/readability/readability_benchmark.py prepare-analysis \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority test/readability/authority-manifest.template.json \
+  --input .scratch/readability/dry-run.jsonl \
+  > .scratch/readability/analysis-input.json
 ```
 
 The dry run emits one synthetic, non-citable row for each of 15 conditions and
-makes no readability or performance claim. Schedules, renderings, logs, and
-stores remain under `.scratch/`. Generating a schedule is planning evidence,
-not permission to collect outcomes. The [execution gate](EXECUTION.md) records
-the exact fail-closed boundary.
+makes no readability or performance claim. The analysis-input file likewise
+contains no outcome analysis or claim. Schedules, renderings, logs, stores, and
+generated bundles remain under `.scratch/`. Generating a schedule is planning
+evidence, not permission to collect outcomes. The [execution gate](EXECUTION.md)
+records the exact fail-closed boundary.

--- a/test/readability/dune
+++ b/test/readability/dune
@@ -2,6 +2,7 @@
  (aliases readability-protocol runtest)
  (deps
   readability_benchmark.py
+  readability_analysis.py
   fixture-manifest.json
   result.schema.json
   model-prompt.txt
@@ -22,6 +23,30 @@
      --authority authority-manifest.template.json
      --jacquard %{bin:jacquard}
      --prelude ../../prelude)
+    (with-stdout-to dry-run.jsonl
+     (run %{bin:python3} readability_benchmark.py dry-run
+      --seed ux1-analysis-v1
+      --manifest fixture-manifest.json
+      --schema result.schema.json))
+    (with-stdout-to validated-results.txt
+     (run %{bin:python3} readability_benchmark.py validate-results
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (with-stdout-to analysis-input-1.json
+     (run %{bin:python3} readability_benchmark.py prepare-analysis
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (with-stdout-to analysis-input-2.json
+     (run %{bin:python3} readability_benchmark.py prepare-analysis
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (diff analysis-input-1.json analysis-input-2.json)
     (with-stdout-to human-schedule.jsonl
      (run %{bin:python3} readability_benchmark.py human-schedule))
     (with-stdout-to model-schedule.jsonl

--- a/test/readability/readability_analysis.py
+++ b/test/readability/readability_analysis.py
@@ -1,0 +1,427 @@
+"""Deterministic analyzability and provenance for validated readability stores.
+
+This module never computes outcome statistics or a readability claim.  Its
+public entry point accepts rows only after the result-store validator has
+accepted the complete store, selects the effective rows prescribed by the v1
+protocol, and returns a canonical-JSON-compatible bundle.  Invalid transition
+shapes raise :class:`AnalysisError`; no partial bundle is returned.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import hashlib
+import json
+import re
+from typing import Any, Iterable
+
+
+ANALYSIS_VERSION = "readability-analysis-input-v1"
+PROTOCOL_VERSION = "readability-protocol-v1"
+HUMAN_SCHEDULE_VERSION = "readability-human-schedule-v1"
+HUMAN_SCHEDULE_SHA256 = (
+    "356f000ba5af0421ef6eaaf246bbb78527ff9ffb97f61d84f5f795d96b114178"
+)
+MODEL_SCHEDULE_VERSION = "readability-model-schedule-v1"
+CARRIERS = ("jac", "jqd", "python")
+HEX_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+class AnalysisError(RuntimeError):
+    """Raised when validated-store assumptions cannot produce one exact bundle."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def encode_analysis_bundle(bundle: dict[str, Any]) -> str:
+    """Return canonical JSON plus one newline for a prepared analysis bundle.
+
+    The encoder rejects non-JSON numeric values through ``allow_nan=False``.
+    Given an equal bundle, it always returns byte-identical UTF-8-compatible
+    text and never adds a timestamp.
+    """
+
+    return _canonical_json(bundle) + "\n"
+
+
+def _field(row: dict[str, Any], name: str) -> Any:
+    if name not in row:
+        raise AnalysisError(f"analysis row is missing required field: {name}")
+    return row[name]
+
+
+def _unique_values(rows: Iterable[dict[str, Any]], name: str) -> list[Any]:
+    values: dict[str, Any] = {}
+    for row in rows:
+        value = _field(row, name)
+        values[_canonical_json(value)] = value
+    return [values[key] for key in sorted(values)]
+
+
+def _single_value(rows: list[dict[str, Any]], name: str) -> Any:
+    values = _unique_values(rows, name)
+    if len(values) != 1:
+        raise AnalysisError(f"analysis store has multiple values for {name}")
+    return values[0]
+
+
+def _ordered_subject_groups(
+    rows: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
+    groups: list[list[dict[str, Any]]] = []
+    indexes: dict[str, int] = {}
+    for row in rows:
+        subject_id = _field(row, "subject_id")
+        if not isinstance(subject_id, str):
+            raise AnalysisError("analysis subject_id must be a string")
+        if subject_id not in indexes:
+            indexes[subject_id] = len(groups)
+            groups.append([])
+        elif indexes[subject_id] != len(groups) - 1:
+            raise AnalysisError("analysis subject rows are not contiguous")
+        groups[indexes[subject_id]].append(row)
+    return groups
+
+
+def _row_ids(rows: Iterable[dict[str, Any]]) -> list[str]:
+    ids: list[str] = []
+    for row in rows:
+        row_id = _field(row, "row_id")
+        if not isinstance(row_id, str) or HEX_SHA256.fullmatch(row_id) is None:
+            raise AnalysisError("analysis row_id must be a lowercase SHA-256")
+        ids.append(row_id)
+    return ids
+
+
+def _trial_reference(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "job": _field(row, "job"),
+        "outcome_family": _field(row, "outcome_family"),
+        "presentation_order": _field(row, "presentation_order"),
+        "row_id": _field(row, "row_id"),
+        "trial_attempt": _field(row, "trial_attempt"),
+    }
+
+
+def _human_decision(group: list[dict[str, Any]]) -> dict[str, Any]:
+    first_attempts = [row for row in group if _field(row, "trial_attempt") == 1]
+    retries = [row for row in group if _field(row, "trial_attempt") == 2]
+    first_attempts.sort(key=lambda row: _field(row, "presentation_order"))
+    system_failures = sum(
+        _field(row, "error_code") == "system-failure" for row in group
+    )
+    stable_codes = sorted(
+        {
+            code
+            for row in group
+            for code in _field(row, "exclusion_codes")
+            if code != "system-failure"
+        }
+    )
+    subject_codes = list(stable_codes)
+    if system_failures > 1:
+        subject_codes.append("system-failure")
+        subject_codes.sort()
+
+    effective: list[dict[str, Any]] = []
+    if not subject_codes:
+        retry_by_job = {_field(row, "job"): row for row in retries}
+        for first in first_attempts:
+            if _field(first, "error_code") == "system-failure":
+                selected = retry_by_job.get(_field(first, "job"))
+                if selected is None or _field(selected, "error_code") == "system-failure":
+                    raise AnalysisError(
+                        "analyzable human system failure lacks a successful final retry"
+                    )
+            else:
+                selected = first
+            if _field(selected, "excluded"):
+                raise AnalysisError("an analyzable human trial remains row-excluded")
+            effective.append(selected)
+        if len(effective) != 5:
+            raise AnalysisError("an analyzable human must contribute five effective trials")
+
+    effective_ids = _row_ids(effective)
+    effective_set = set(effective_ids)
+    excluded = [row for row in group if _field(row, "row_id") not in effective_set]
+    source_ids = _row_ids(group)
+    excluded_ids = _row_ids(excluded)
+    return {
+        "analyzable": not subject_codes,
+        "carrier": _single_value(group, "carrier"),
+        "effective_row_ids": effective_ids,
+        "effective_trials": [_trial_reference(row) for row in effective],
+        "excluded_row_ids": excluded_ids,
+        "schedule_ordinal": _single_value(group, "schedule_ordinal"),
+        "source_row_ids": source_ids,
+        "subject_exclusion_codes": subject_codes,
+        "subject_id": _single_value(group, "subject_id"),
+        "system_failure_count": system_failures,
+    }
+
+
+def _single_session_decision(
+    group: list[dict[str, Any]], subject_kind: str
+) -> dict[str, Any]:
+    if subject_kind == "model" and len(group) != 1:
+        raise AnalysisError("each model subject must identify exactly one fresh session")
+    subject_codes = sorted(
+        {code for row in group for code in _field(row, "exclusion_codes")}
+    )
+    excluded_flags = {_field(row, "excluded") for row in group}
+    if excluded_flags - {True, False}:
+        raise AnalysisError("analysis excluded flags must be booleans")
+    if subject_codes and not all(excluded_flags):
+        raise AnalysisError("excluded session rows do not share their exclusion decision")
+    if not subject_codes and any(excluded_flags):
+        raise AnalysisError("session row is excluded without an exclusion code")
+    effective = [] if subject_codes else list(group)
+    effective_ids = _row_ids(effective)
+    effective_set = set(effective_ids)
+    excluded = [row for row in group if _field(row, "row_id") not in effective_set]
+    return {
+        "analyzable": not subject_codes,
+        "carrier": _single_value(group, "carrier"),
+        "effective_row_ids": effective_ids,
+        "effective_trials": [_trial_reference(row) for row in effective],
+        "excluded_row_ids": _row_ids(excluded),
+        "schedule_ordinal": _single_value(group, "schedule_ordinal"),
+        "source_row_ids": _row_ids(group),
+        "subject_exclusion_codes": subject_codes,
+        "subject_id": _single_value(group, "subject_id"),
+        "system_failure_count": sum(
+            _field(row, "error_code") == "system-failure" for row in group
+        ),
+    }
+
+
+def _counter_dict(values: Iterable[str]) -> dict[str, int]:
+    counts = Counter(values)
+    return {key: counts[key] for key in sorted(counts)}
+
+
+def _flow_for(
+    rows: list[dict[str, Any]], decisions: list[dict[str, Any]]
+) -> dict[str, Any]:
+    effective_ids = {
+        row_id for decision in decisions for row_id in decision["effective_row_ids"]
+    }
+    excluded_ids = {
+        row_id for decision in decisions for row_id in decision["excluded_row_ids"]
+    }
+    source_ids = set(_row_ids(rows))
+    if effective_ids.intersection(excluded_ids) or effective_ids.union(excluded_ids) != source_ids:
+        raise AnalysisError("analysis decisions do not partition every source row exactly once")
+    return {
+        "row_exclusion_counts": _counter_dict(
+            code for row in rows for code in _field(row, "exclusion_codes")
+        ),
+        "subject_exclusion_counts": _counter_dict(
+            code
+            for decision in decisions
+            for code in decision["subject_exclusion_codes"]
+        ),
+        "subjects": {
+            "analyzable": sum(decision["analyzable"] for decision in decisions),
+            "answer_store": len(decisions),
+            "excluded": sum(not decision["analyzable"] for decision in decisions),
+        },
+        "trials": {
+            "effective_retry_rows": sum(
+                _field(row, "row_id") in effective_ids
+                and _field(row, "trial_attempt") == 2
+                for row in rows
+            ),
+            "effective_rows": len(effective_ids),
+            "excluded_rows": len(excluded_ids),
+            "missing_expected_rows": 0,
+            "source_retries": sum(_field(row, "trial_attempt") == 2 for row in rows),
+            "source_rows": len(rows),
+            "system_failure_rows": sum(
+                _field(row, "error_code") == "system-failure" for row in rows
+            ),
+            "timeout_rows": sum(_field(row, "error_code") == "timeout" for row in rows),
+        },
+    }
+
+
+def _flow(
+    rows: list[dict[str, Any]], decisions: list[dict[str, Any]]
+) -> dict[str, Any]:
+    by_carrier: dict[str, Any] = {}
+    for carrier in CARRIERS:
+        carrier_rows = [row for row in rows if _field(row, "carrier") == carrier]
+        carrier_decisions = [
+            decision for decision in decisions if decision["carrier"] == carrier
+        ]
+        if carrier_rows:
+            by_carrier[carrier] = _flow_for(carrier_rows, carrier_decisions)
+    return {"by_carrier": by_carrier, "overall": _flow_for(rows, decisions)}
+
+
+def _fixture_pins(rows: list[dict[str, Any]]) -> dict[str, str]:
+    pins: dict[str, str] = {}
+    for row in rows:
+        condition = _field(row, "condition_id")
+        fixture_sha256 = _field(row, "fixture_sha256")
+        if condition in pins and pins[condition] != fixture_sha256:
+            raise AnalysisError(f"analysis fixture pin drift for {condition}")
+        pins[condition] = fixture_sha256
+    return {condition: pins[condition] for condition in sorted(pins)}
+
+
+def _observed_model_pins(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    names = (
+        "cohort_id",
+        "cohort_manifest_sha256",
+        "provider",
+        "model_id",
+        "client_name",
+        "client_version",
+        "control_kind",
+        "control_value",
+        "prompt_sha256",
+        "training_cutoff_attested",
+    )
+    variants: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        model = _field(row, "model")
+        if not isinstance(model, dict):
+            raise AnalysisError("model analysis row lacks its model pin record")
+        variant = {name: _field(model, name) for name in names}
+        variants[_canonical_json(variant)] = variant
+    return [variants[key] for key in sorted(variants)]
+
+
+def _source_provenance(
+    rows: list[dict[str, Any]], subject_kind: str, input_sha256: str
+) -> dict[str, Any]:
+    row_ids = _row_ids(rows)
+    provenance: dict[str, Any] = {
+        "assignment_seed_sha256": _single_value(rows, "assignment_seed_sha256"),
+        "authority_manifest_sha256": _single_value(
+            rows, "authority_manifest_sha256"
+        ),
+        "fixture_manifest_sha256": _single_value(
+            rows, "fixture_manifest_sha256"
+        ),
+        "fixture_sha256_by_condition": _fixture_pins(rows),
+        "input_jsonl_sha256": input_sha256,
+        "row_count": len(rows),
+        "row_id_sequence_sha256": hashlib.sha256(
+            ("\n".join(row_ids) + "\n").encode("ascii")
+        ).hexdigest(),
+        "schema_sha256": _single_value(rows, "schema_sha256"),
+        "schema_version": _single_value(rows, "schema_version"),
+        "source_row_ids": row_ids,
+    }
+    if subject_kind == "human":
+        provenance["consent_versions"] = _unique_values(rows, "consent_version")
+        provenance["schedule"] = {
+            "schema_version": HUMAN_SCHEDULE_VERSION,
+            "sha256": HUMAN_SCHEDULE_SHA256,
+        }
+    elif subject_kind == "model":
+        models = [_field(row, "model") for row in rows]
+        cohort_ids = {_field(model, "cohort_id") for model in models}
+        cohort_digests = {
+            _field(model, "cohort_manifest_sha256") for model in models
+        }
+        if len(cohort_ids) != 1 or len(cohort_digests) != 1:
+            raise AnalysisError("model analysis store mixes cohort identity")
+        provenance["observed_model_pins"] = _observed_model_pins(rows)
+        provenance["schedule"] = {
+            "cohort_id": next(iter(cohort_ids)),
+            "cohort_manifest_sha256": next(iter(cohort_digests)),
+            "derivation": "validated-cohort-fixture-and-assignment-pins",
+            "ordinal_count": len(rows),
+            "schema_version": MODEL_SCHEDULE_VERSION,
+        }
+    else:
+        provenance["schedule"] = {
+            "condition_count": len(provenance["fixture_sha256_by_condition"]),
+            "kind": "synthetic-dry-run",
+        }
+    return provenance
+
+
+def prepare_analysis_bundle(
+    rows: list[dict[str, Any]], input_sha256: str
+) -> dict[str, Any]:
+    """Prepare deterministic row selection and provenance for one valid store.
+
+    ``rows`` must first pass the complete single-kind result-store validator;
+    ``input_sha256`` must be the digest of the exact JSONL bytes that produced
+    them.  Human subjects with more than one verified system-failure row are
+    excluded as a whole.  Exactly one failed first attempt is replaced by its
+    non-system-failure final retry.  Stable human exclusions exclude the whole
+    subject; model sessions are effective exactly when their row is not
+    excluded.  Synthetic bundles are always marked non-citable.
+
+    The function returns no outcome statistic and no claim.  It raises
+    :class:`AnalysisError` rather than returning a partial or ambiguous bundle.
+    """
+
+    if not isinstance(rows, list) or not rows:
+        raise AnalysisError("analysis requires one validated nonempty result store")
+    if any(not isinstance(row, dict) for row in rows):
+        raise AnalysisError("analysis rows must be JSON objects")
+    if not isinstance(input_sha256, str) or HEX_SHA256.fullmatch(input_sha256) is None:
+        raise AnalysisError("analysis input digest must be a lowercase SHA-256")
+    row_ids = _row_ids(rows)
+    if len(set(row_ids)) != len(row_ids):
+        raise AnalysisError("analysis source row IDs must be unique")
+
+    protocol_version = _single_value(rows, "protocol_version")
+    if protocol_version != PROTOCOL_VERSION:
+        raise AnalysisError("analysis protocol version drifted")
+    subject_kind = _single_value(rows, "subject_kind")
+    run_kind = _single_value(rows, "run_kind")
+    if subject_kind not in {"human", "model", "synthetic"}:
+        raise AnalysisError(f"unknown analysis subject kind: {subject_kind}")
+    expected_run_kind = {
+        "human": "confirmatory",
+        "synthetic": "dry-run",
+    }.get(subject_kind)
+    if expected_run_kind is not None and run_kind != expected_run_kind:
+        raise AnalysisError("analysis run kind disagrees with its subject kind")
+
+    groups = _ordered_subject_groups(rows)
+    if subject_kind == "human":
+        decisions = [_human_decision(group) for group in groups]
+        evidence_class = "human-candidate"
+        pre_assignment_flow = {
+            "included_in_answer_store": False,
+            "reason": "consent and eligibility records remain outside answer JSONL",
+            "status": "external-required",
+        }
+    else:
+        decisions = [
+            _single_session_decision(group, subject_kind) for group in groups
+        ]
+        evidence_class = (
+            "model-candidate" if subject_kind == "model" else "synthetic-non-citable"
+        )
+        pre_assignment_flow = {"status": "not-applicable"}
+
+    return {
+        "analysis_version": ANALYSIS_VERSION,
+        "bundle_scope": "answer-store-analyzability",
+        "claim_status": "not-evaluated",
+        "evidence_class": evidence_class,
+        "flow": _flow(rows, decisions),
+        "pre_assignment_flow": pre_assignment_flow,
+        "protocol_version": protocol_version,
+        "run_kind": run_kind,
+        "source": _source_provenance(rows, subject_kind, input_sha256),
+        "subject_kind": subject_kind,
+        "subjects": decisions,
+    }

--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -21,6 +21,12 @@ import subprocess
 import sys
 from typing import Any, Callable, Iterable
 
+from readability_analysis import (
+    AnalysisError,
+    encode_analysis_bundle,
+    prepare_analysis_bundle,
+)
+
 
 SCHEMA_VERSION = "readability-result-v1"
 PROTOCOL_VERSION = "readability-protocol-v1"
@@ -1062,10 +1068,13 @@ def validate_row(
         "system-failure": "system-failure",
         "prompt-parse-failure": "prompt-parse-failure",
     }
-    if row["error_code"] in failure_exclusions:
-        required_exclusion = failure_exclusions[row["error_code"]]
-        if required_exclusion not in row["exclusion_codes"]:
-            raise ProtocolError("failure result is missing its required exclusion code")
+    for error_code, exclusion_code in failure_exclusions.items():
+        if (row["error_code"] == error_code) != (
+            exclusion_code in row["exclusion_codes"]
+        ):
+            raise ProtocolError(
+                f"{error_code} result/exclusion code must appear together"
+            )
     if row["row_id"] != canonical_row_id(row):
         raise ProtocolError("row_id is not the canonical SHA-256 of the result row")
     if row["run_kind"] != "dry-run" and row["assignment_seed_sha256"] != digest_text(
@@ -1654,6 +1663,162 @@ def self_test(
     human_store_with_retry.insert(5, retry)
     validate_test_human_store(human_store_with_retry)
 
+    synthetic_jsonl = encode_jsonl(rows)
+    synthetic_digest = digest_text(synthetic_jsonl)
+    synthetic_analysis = prepare_analysis_bundle(rows, synthetic_digest)
+    if (
+        synthetic_analysis["evidence_class"] != "synthetic-non-citable"
+        or synthetic_analysis["claim_status"] != "not-evaluated"
+        or synthetic_analysis["source"]["input_jsonl_sha256"] != synthetic_digest
+        or synthetic_analysis["flow"]["overall"]["subjects"]
+        != {"analyzable": 3, "answer_store": 3, "excluded": 0}
+        or synthetic_analysis["flow"]["overall"]["trials"]["effective_rows"] != 15
+    ):
+        raise ProtocolError("synthetic analysis provenance or non-citable flow drifted")
+    if encode_analysis_bundle(synthetic_analysis) != encode_analysis_bundle(
+        prepare_analysis_bundle(rows, synthetic_digest)
+    ):
+        raise ProtocolError("analysis bundle bytes are not deterministic")
+    changed_source_analysis = prepare_analysis_bundle(
+        rows, digest_text(synthetic_jsonl + "\n")
+    )
+    if (
+        changed_source_analysis["source"]["input_jsonl_sha256"] == synthetic_digest
+        or encode_analysis_bundle(changed_source_analysis)
+        == encode_analysis_bundle(synthetic_analysis)
+    ):
+        raise ProtocolError("analysis bundle does not bind exact source JSONL bytes")
+
+    clean_human_analysis = prepare_analysis_bundle(
+        human_store, digest_text(encode_jsonl(human_store))
+    )
+    if (
+        clean_human_analysis["evidence_class"] != "human-candidate"
+        or clean_human_analysis["pre_assignment_flow"]["status"]
+        != "external-required"
+        or clean_human_analysis["flow"]["overall"]["subjects"]
+        != {"analyzable": 480, "answer_store": 480, "excluded": 0}
+        or clean_human_analysis["flow"]["overall"]["trials"]["effective_rows"]
+        != 2400
+        or clean_human_analysis["source"]["schedule"]
+        != {
+            "schema_version": HUMAN_SCHEDULE_VERSION,
+            "sha256": HUMAN_SCHEDULE_SHA256,
+        }
+    ):
+        raise ProtocolError("clean human analyzability flow drifted")
+
+    retry_analysis = prepare_analysis_bundle(
+        human_store_with_retry,
+        digest_text(encode_jsonl(human_store_with_retry)),
+    )
+    retry_subject = retry_analysis["subjects"][0]
+    retry_trials = retry_analysis["flow"]["overall"]["trials"]
+    if (
+        not retry_subject["analyzable"]
+        or retry_subject["system_failure_count"] != 1
+        or failed["row_id"] not in retry_subject["excluded_row_ids"]
+        or retry["row_id"] not in retry_subject["effective_row_ids"]
+        or retry_trials["source_rows"] != 2401
+        or retry_trials["effective_rows"] != 2400
+        or retry_trials["excluded_rows"] != 1
+        or retry_trials["effective_retry_rows"] != 1
+    ):
+        raise ProtocolError("successful human retry did not replace its failed first row")
+
+    failed_retry_store = copy.deepcopy(human_store_with_retry)
+    failed_retry = failed_retry_store[5]
+    failed_retry.update(
+        {
+            "answer_id": "__system_failure__",
+            "correct": False,
+            "error_code": "system-failure",
+            "excluded": True,
+            "exclusion_codes": ["system-failure"],
+        }
+    )
+    failed_retry["row_id"] = canonical_row_id(failed_retry)
+    validate_test_human_store(failed_retry_store)
+    failed_retry_analysis = prepare_analysis_bundle(
+        failed_retry_store, digest_text(encode_jsonl(failed_retry_store))
+    )
+    failed_retry_subject = failed_retry_analysis["subjects"][0]
+    if (
+        failed_retry_subject["analyzable"]
+        or failed_retry_subject["subject_exclusion_codes"] != ["system-failure"]
+        or failed_retry_subject["system_failure_count"] != 2
+        or failed_retry_subject["effective_row_ids"]
+        or failed_retry_analysis["flow"]["overall"]["subjects"]["excluded"] != 1
+        or failed_retry_analysis["flow"]["overall"]["trials"]["effective_rows"]
+        != 2395
+    ):
+        raise ProtocolError("failed retry did not exclude the complete human subject")
+
+    two_failure_store = copy.deepcopy(human_store)
+    for failure in two_failure_store[:2]:
+        failure.update(
+            {
+                "answer_id": "__system_failure__",
+                "correct": False,
+                "error_code": "system-failure",
+                "excluded": True,
+                "exclusion_codes": ["system-failure"],
+            }
+        )
+        failure["row_id"] = canonical_row_id(failure)
+    validate_test_human_store(two_failure_store)
+    two_failure_analysis = prepare_analysis_bundle(
+        two_failure_store, digest_text(encode_jsonl(two_failure_store))
+    )
+    if (
+        two_failure_analysis["subjects"][0]["subject_exclusion_codes"]
+        != ["system-failure"]
+        or two_failure_analysis["flow"]["overall"]["trials"]["effective_rows"]
+        != 2395
+    ):
+        raise ProtocolError("multiple first-attempt failures did not exclude the subject")
+
+    stable_exclusion_store = copy.deepcopy(human_store)
+    for excluded_row in stable_exclusion_store[:5]:
+        excluded_row.update(
+            {"excluded": True, "exclusion_codes": ["prohibited-tools"]}
+        )
+        excluded_row["row_id"] = canonical_row_id(excluded_row)
+    validate_test_human_store(stable_exclusion_store)
+    stable_exclusion_analysis = prepare_analysis_bundle(
+        stable_exclusion_store,
+        digest_text(encode_jsonl(stable_exclusion_store)),
+    )
+    if (
+        stable_exclusion_analysis["subjects"][0]["subject_exclusion_codes"]
+        != ["prohibited-tools"]
+        or stable_exclusion_analysis["subjects"][0]["effective_row_ids"]
+    ):
+        raise ProtocolError("stable human exclusion did not exclude the complete subject")
+
+    drift_store = copy.deepcopy(model_store)
+    drift_store[0]["model"]["client_version"] = "observed-unreviewed-client"
+    drift_store[0].update(
+        {"excluded": True, "exclusion_codes": ["model-version-drift"]}
+    )
+    drift_store[0]["row_id"] = canonical_row_id(drift_store[0])
+    validate_test_model_store(drift_store)
+    clean_model_analysis = prepare_analysis_bundle(
+        model_store, digest_text(encode_jsonl(model_store))
+    )
+    drift_model_analysis = prepare_analysis_bundle(
+        drift_store, digest_text(encode_jsonl(drift_store))
+    )
+    if (
+        clean_model_analysis["evidence_class"] != "model-candidate"
+        or clean_model_analysis["flow"]["overall"]["trials"]["effective_rows"]
+        != expected_model_count
+        or drift_model_analysis["flow"]["overall"]["subjects"]["excluded"] != 1
+        or drift_model_analysis["flow"]["overall"]["trials"]["effective_rows"]
+        != expected_model_count - 1
+    ):
+        raise ProtocolError("model session analyzability flow drifted")
+
     def expect_rejection(label: str, operation: Callable[[], Any]) -> None:
         try:
             operation()
@@ -1782,6 +1947,27 @@ def self_test(
     expect_rejection(
         "the pending model cohort",
         lambda: validate_test_model(model, cohort),
+    )
+
+    invented_human_failure = copy.deepcopy(human)
+    invented_human_failure.update(
+        {"excluded": True, "exclusion_codes": ["system-failure"]}
+    )
+    invented_human_failure["row_id"] = canonical_row_id(invented_human_failure)
+    expect_rejection(
+        "a successful human row mislabeled as a system failure",
+        lambda: validate_test_human(invented_human_failure),
+    )
+    invented_model_parse_failure = copy.deepcopy(model)
+    invented_model_parse_failure.update(
+        {"excluded": True, "exclusion_codes": ["prompt-parse-failure"]}
+    )
+    invented_model_parse_failure["row_id"] = canonical_row_id(
+        invented_model_parse_failure
+    )
+    expect_rejection(
+        "a parsed model row mislabeled as a prompt parse failure",
+        lambda: validate_test_model(invented_model_parse_failure),
     )
 
     expect_rejection(
@@ -2056,9 +2242,30 @@ def validate_jsonl(
 ) -> tuple[int, set[str]]:
     """Load JSONL with line-local diagnostics, then validate the complete store."""
 
+    _, _, count, conditions = load_validated_jsonl(
+        input_path,
+        manifest,
+        schema,
+        cohort=cohort,
+        authority=authority,
+    )
+    return count, conditions
+
+
+def load_jsonl_rows(input_path: Path) -> tuple[list[dict[str, Any]], str]:
+    """Load JSONL rows and bind them to the SHA-256 of their exact source bytes.
+
+    Duplicate fields, non-standard constants, invalid UTF-8, and non-object
+    rows fail before result-store validation or analysis can begin.
+    """
+
+    try:
+        source_bytes = input_path.read_bytes()
+        source_text = source_bytes.decode("utf-8")
+    except (OSError, UnicodeError) as error:
+        raise ProtocolError(f"cannot load result JSONL {input_path}: {error}") from error
     rows: list[dict[str, Any]] = []
-    input_lines = input_path.read_text(encoding="utf-8").splitlines()
-    for line_number, raw in enumerate(input_lines, start=1):
+    for line_number, raw in enumerate(source_text.splitlines(), start=1):
         if not raw.strip():
             continue
         try:
@@ -2072,8 +2279,27 @@ def validate_jsonl(
         if not isinstance(row, dict):
             raise ProtocolError(f"{input_path}:{line_number}: result row must be an object")
         rows.append(row)
+    return rows, digest_bytes(source_bytes)
+
+
+def load_validated_jsonl(
+    input_path: Path,
+    manifest: dict[str, Any],
+    schema: dict[str, Any],
+    *,
+    cohort: dict[str, Any] | None = None,
+    authority: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], str, int, set[str]]:
+    """Load and validate a complete store before returning rows or provenance.
+
+    Store-level failures retain the input path in their diagnostic.  No caller
+    can prepare an analysis bundle from this helper unless the existing schema,
+    admission-context, completeness, ordering, and retry checks all pass.
+    """
+
+    rows, input_sha256 = load_jsonl_rows(input_path)
     try:
-        return validate_result_store(
+        count, conditions = validate_result_store(
             rows,
             manifest,
             schema,
@@ -2082,6 +2308,7 @@ def validate_jsonl(
         )
     except ProtocolError as error:
         raise ProtocolError(f"{input_path}: {error}") from error
+    return rows, input_sha256, count, conditions
 
 
 def add_common_paths(parser: argparse.ArgumentParser) -> None:
@@ -2113,6 +2340,15 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     validate.add_argument("--input", type=Path, required=True)
     validate.add_argument("--cohort", type=Path)
     validate.add_argument("--authority", type=Path, required=True)
+
+    analysis = commands.add_parser(
+        "prepare-analysis",
+        help="validate a complete store and emit deterministic analyzability provenance",
+    )
+    add_common_paths(analysis)
+    analysis.add_argument("--input", type=Path, required=True)
+    analysis.add_argument("--cohort", type=Path)
+    analysis.add_argument("--authority", type=Path, required=True)
 
     assign = commands.add_parser(
         "assign", help="debug one seeded assignment; admitted rows always use the frozen seed"
@@ -2209,20 +2445,27 @@ def main(argv: Iterable[str]) -> int:
                     )
                 )
             return 0
-        if args.command == "validate-results":
+        if args.command in {"validate-results", "prepare-analysis"}:
             authority = load_json(args.authority)
             verify_authority_manifest(authority)
             cohort = None
             if args.cohort is not None:
                 cohort = load_json(args.cohort)
                 verify_cohort_manifest(cohort, args.cohort)
-            count, conditions = validate_jsonl(
+            rows, input_sha256, count, conditions = load_validated_jsonl(
                 args.input,
                 manifest,
                 schema,
                 cohort=cohort,
                 authority=authority,
             )
+            if args.command == "prepare-analysis":
+                sys.stdout.write(
+                    encode_analysis_bundle(
+                        prepare_analysis_bundle(rows, input_sha256)
+                    )
+                )
+                return 0
             print(f"validated {count} rows across {len(conditions)} conditions")
             return 0
         if args.command == "verify":
@@ -2241,7 +2484,7 @@ def main(argv: Iterable[str]) -> int:
             print("readability protocol: PASS (5 jobs, 3 carriers, 15 dry-run conditions)")
             return 0
         raise ProtocolError(f"unknown command: {args.command}")
-    except (OSError, ProtocolError) as error:
+    except (OSError, ProtocolError, AnalysisError) as error:
         print(f"readability protocol: FAIL: {error}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Context

Issue #86 can already reject incomplete or unauthorized readability result stores, but accepted rows still need one reproducible rule for deciding which subjects and trials may enter later statistics. In particular, a failed retry or a second system failure must exclude the whole human subject rather than only the failed row.

## What changed

- Add a `prepare-analysis` command that validates the complete store first, then emits canonical `readability-analysis-input-v1` JSON.
- Bind that bundle to the exact source-file SHA-256, ordered row identities, and the reviewed schema, fixture, authority, assignment, schedule, and cohort pins.
- Publish per-subject source, effective, and excluded row IDs plus total and per-carrier flow counts.
- Derive the frozen human retry and whole-subject exclusion transitions; keep model sessions row-local and synthetic output explicitly non-citable.
- Require row-level system/parse failure exclusions to match the deterministically scored failure outcome in both directions.
- Make the checked Dune alias generate two analysis bundles and require byte-identical output.

## Semantic contract

- No system failure: use the human's five first attempts.
- One failed first attempt: preserve that row and use the final retry if the retry itself does not have another system failure. An incorrect answer or timeout remains an outcome.
- More than one verified system failure, including a failed retry: exclude the entire human subject.
- Any stable non-system human exclusion: exclude the entire human subject.
- A model session is effective exactly when its admitted row is not excluded.
- Every source row belongs to exactly one effective or excluded list. The bundle has no timestamp, measured outcome statistic, or readability claim.

## Deliberate exclusions

This does not contact a model, recruit participants, collect real outcomes, claim approval or consent, compute inferential tables, perform blinded rescoring, or make a readability, language, runtime, or release claim. Pre-assignment consent and eligibility flow remains `external-required` because approved enrollment records live outside answer JSONL; this change does not invent a data-governance schema.

## Validation

- Fresh Fable 5 review of `9a3801794e6388c3d5ad3cb1afd9ee1e303ce7a5`: `PASS`, no blockers or architecture conflicts.
- Readability protocol verification: 5 jobs, 3 carriers, 15 dry-run conditions, 480 human assignments, 450 M0 model trials.
- Adversarial self-tests cover a successful retry, failed retry, multiple first-attempt failures, stable subject exclusion, excluded model session, strict failure labeling, complete flow partitions, and exact-source digest sensitivity.
- Two independent synthetic bundles were byte-identical (`53c44754d4203e37086849cc945ef4e26988a39437a6fc3068de4b74ec3fdb9d`) from source `ecc5acb96f439f3a2f39c9bfdc6dde8e174ab315d17ceee7728080342cf5db01`.
- `dune build @all`, `dune build @doc`, `dune fmt`, historical-manifest verification and mutation tests, version smoke, whitespace check, and clean-tree check passed.
- All 847 compiled Alcotest/QCheck tests passed. Existing native sanitizer crams cannot run under the Codex ptrace boundary; an outside-sandbox retry reproduced that explicit LeakSanitizer limitation while the direct runtime suite reported `runtime check: PASS`. Required GitHub clang and GCC lanes remain the clean-host sanitizer evidence.

## Risk and follow-up

The analysis and benchmark modules duplicate a few frozen version/schedule constants. Tests cross-check those constants against each other and against generated schedule bytes, so this is optional cleanup rather than a correctness blocker. Later #86 slices still own inferential outputs, uncertainty/effect sizes, blinded rescoring, published-number derivation, and measured claim gates.

Part of #86.
