### PR TITLE
Add deterministic readability descriptive tables

### DIFF
--- a/docs/research/readability-benchmark/EXECUTION.md
+++ b/docs/research/readability-benchmark/EXECUTION.md
@@ -1,8 +1,8 @@
 # Readability protocol v1 execution gate
 
-Status: deterministic planning and fail-closed result-admission tools are
-implemented. The checked manifests do not authorize real collection, and no
-human or model outcomes exist.
+Status: deterministic planning, fail-closed result admission, analyzability,
+and descriptive-table tools are implemented. The checked manifests do not
+authorize real collection, and no human or model outcomes exist.
 
 The [protocol](PROTOCOL.md) defines the study. This document separates a
 reproducible plan from external authority. A generated schedule proves that
@@ -203,6 +203,53 @@ creates that flow nor authorizes collection. Synthetic output is explicitly
 non-citable; human and model output remains candidate evidence with no claim
 evaluated.
 
+## Deterministic descriptive tables
+
+Produce the first measured-outcome stage directly from the same validated
+store and admission context:
+
+```text
+python3 test/readability/readability_benchmark.py analyze-descriptive \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json \
+  --input HUMAN-RESULTS.jsonl \
+  > .scratch/readability/human-descriptive.json
+
+python3 test/readability/readability_benchmark.py analyze-descriptive \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json --cohort COHORT.json \
+  --input MODEL-RESULTS.jsonl \
+  > .scratch/readability/model-descriptive.json
+```
+
+The command repeats complete result-store validation, prepares the exact
+`readability-analysis-input-v1` selection in memory, and emits one canonical
+`readability-descriptive-v1` object. Its provenance binds the exact source
+JSONL, ordered source and effective row IDs, and SHA-256 of the canonical
+analysis-input bytes. Only effective rows contribute outcomes; failed or
+otherwise excluded rows remain visible through copied flow and per-condition
+source/effective/excluded counts.
+
+Perceived readability has its own table. Each of comprehension, review, defect
+detection, modification/debugging, and diagnostic recovery has a separate
+table with accuracy and 97.5% Wilson uncertainty, completion median and
+log/geometric mean, confidence distribution and exact-level calibration,
+error counts, and timeouts. Human output also reports presentation-order and
+the four frozen expertise/familiarity strata within each functional outcome.
+These are descriptive strata, not post-hoc subgroups or a fitted effect model.
+
+Every derived decimal is a fixed 12-place string. The object has no timestamp,
+raw subject identifier, free text, or checked-in output path. A zero-ms row is
+retained and reported but makes log/geometric mean null; it is never silently
+dropped or shifted. Running twice from byte-identical stores produces
+byte-identical output. Synthetic output exercises all table shapes but remains
+`synthetic-non-citable`; real human/model output remains candidate evidence
+with claim status `not-evaluated`. Pairwise effects, multiplicity correction,
+claim thresholds, blinded rescoring, and publication-number lineage are later
+gates and cannot be inferred from this file.
+
 ## What the checked gate proves
 
 `dune build @readability-protocol` verifies:
@@ -223,6 +270,9 @@ evaluated.
 - deterministic analyzability provenance for clean stores, a successful retry,
   a failed retry, multiple first-attempt failures, stable subject exclusions,
   and an excluded model session, including exact-source digest sensitivity;
+- deterministic descriptive tables for all six reporting families, exact
+  effective-row selection, human expertise/presentation-order strata, model
+  separation, timestamp omission, and byte-identical dual generation;
 - unconditional rejection of real rows with the checked pending authority and
   M0 cohort manifests; and
 - byte-identical schedule and dry-run generation.

--- a/docs/research/readability-benchmark/PROTOCOL.md
+++ b/docs/research/readability-benchmark/PROTOCOL.md
@@ -64,10 +64,15 @@ confirmatory `.jac`/`.jqd` readability claim inconclusive.
 
 At two-sided alpha 0.025, 128 analyzable participants per Jacquard carrier give
 about 80% power for a standardized log-time effect of 0.386, approximately a
-20% time change at coefficient of variation 0.5. The target of 141 covers that
-calculation and the prior accuracy calculation; enrolling 160 allows about 10%
-exclusion. Python remains balanced but does not enter the confirmatory power
-claim.
+20% time change at coefficient of variation 0.5. The accuracy planning premise
+is 80% power to distinguish 70% from 90% accuracy between two independent
+carriers. The original three-job Holm calculation required fewer than 100 per
+carrier. For this protocol's five functional outcomes, the conservative
+Bonferroni bound for Holm uses two-sided alpha `0.025 / 5 = 0.005`; the standard
+two-proportion normal approximation gives about 105 per carrier. The target of
+141 covers both accuracy premises and the 128-person time calculation;
+enrolling 160 allows about 10% exclusion. Python remains balanced but does not
+enter the confirmatory power claim.
 
 Before assignment, record only these de-identified reader covariates with the
 result rows: years of programming experience, years of code-review experience,
@@ -229,6 +234,17 @@ only p-values. Model presentation order, expertise, prior Jacquard/domain
 knowledge, and learning/familiarity effects. Explain Python's control-language
 limitations.
 
+The first analysis stage is `readability-descriptive-v1`. It consumes only a
+complete validated single-kind store and its exact
+`readability-analysis-input-v1` selection. It reports 97.5% Wilson intervals,
+completion median/log/geometric mean, exact confidence-level calibration,
+rating and error distributions, source/effective/excluded counts, and human
+presentation-order and expertise strata. Fixed 12-place decimal strings make
+equal inputs byte-identical; raw collection timestamps are omitted. A zero-ms
+observation is counted and leaves log/geometric means null rather than being
+dropped or adjusted. These descriptive tables remain `not-evaluated`; they do
+not perform the pairwise comparison or claim gate.
+
 Pairwise `.jac`/`.jqd` accuracy uses Newcombe-Wilson difference intervals with
 Holm correction across functional outcomes. Time uses each human's geometric
 mean and Welch intervals on log milliseconds, then reports the exponentiated
@@ -281,11 +297,18 @@ python3 test/readability/readability_benchmark.py prepare-analysis \
   --authority test/readability/authority-manifest.template.json \
   --input .scratch/readability/dry-run.jsonl \
   > .scratch/readability/analysis-input.json
+python3 test/readability/readability_benchmark.py analyze-descriptive \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority test/readability/authority-manifest.template.json \
+  --input .scratch/readability/dry-run.jsonl \
+  > .scratch/readability/descriptive.json
 ```
 
 The dry run emits one synthetic, non-citable row for each of 15 conditions and
-makes no readability or performance claim. The analysis-input file likewise
-contains no outcome analysis or claim. Schedules, renderings, logs, stores, and
-generated bundles remain under `.scratch/`. Generating a schedule is planning
-evidence, not permission to collect outcomes. The [execution gate](EXECUTION.md)
-records the exact fail-closed boundary.
+makes no readability or performance claim. The analysis-input file contains no
+outcome analysis or claim. The descriptive file exercises every table but is
+also synthetic, non-citable, and claim-free. Schedules, renderings, logs,
+stores, and generated bundles remain under `.scratch/`. Generating a schedule
+is planning evidence, not permission to collect outcomes. The
+[execution gate](EXECUTION.md) records the exact fail-closed boundary.

--- a/test/readability/dune
+++ b/test/readability/dune
@@ -3,6 +3,7 @@
  (deps
   readability_benchmark.py
   readability_analysis.py
+  readability_descriptive.py
   fixture-manifest.json
   result.schema.json
   model-prompt.txt
@@ -47,6 +48,19 @@
       --authority authority-manifest.template.json
       --input dry-run.jsonl))
     (diff analysis-input-1.json analysis-input-2.json)
+    (with-stdout-to descriptive-1.json
+     (run %{bin:python3} readability_benchmark.py analyze-descriptive
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (with-stdout-to descriptive-2.json
+     (run %{bin:python3} readability_benchmark.py analyze-descriptive
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (diff descriptive-1.json descriptive-2.json)
     (with-stdout-to human-schedule.jsonl
      (run %{bin:python3} readability_benchmark.py human-schedule))
     (with-stdout-to model-schedule.jsonl

--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -26,6 +26,11 @@ from readability_analysis import (
     encode_analysis_bundle,
     prepare_analysis_bundle,
 )
+from readability_descriptive import (
+    DescriptiveError,
+    encode_descriptive_bundle,
+    prepare_descriptive_bundle,
+)
 
 
 SCHEMA_VERSION = "readability-result-v1"
@@ -1320,6 +1325,11 @@ def verify_protocol_document(protocol_path: Path) -> None:
         "prior jacquard",
         "plain text",
         "sample size",
+        "70% from 90% accuracy",
+        "0.025 / 5 = 0.005",
+        "readability-descriptive-v1",
+        "97.5% wilson",
+        "exact confidence-level calibration",
         "consent",
         "compensation",
         "accessibility",
@@ -1689,6 +1699,102 @@ def self_test(
     ):
         raise ProtocolError("analysis bundle does not bind exact source JSONL bytes")
 
+    synthetic_descriptive = prepare_descriptive_bundle(
+        rows, synthetic_digest, synthetic_analysis
+    )
+    descriptive_tables = synthetic_descriptive["tables"]
+    expected_descriptive_tables = {
+        "perceived-readability",
+        "comprehension",
+        "review",
+        "defect-detection",
+        "modification-debugging",
+        "diagnostic-recovery",
+    }
+    jac_comprehension = next(
+        table
+        for table in descriptive_tables["comprehension"]
+        if table["carrier"] == "jac"
+    )
+    if (
+        synthetic_descriptive["evidence_class"] != "synthetic-non-citable"
+        or synthetic_descriptive["claim_status"] != "not-evaluated"
+        or synthetic_descriptive["source"]["input_jsonl_sha256"]
+        != synthetic_digest
+        or synthetic_descriptive["source"]["effective_row_count"] != 15
+        or set(descriptive_tables) != expected_descriptive_tables
+        or len(descriptive_tables["perceived-readability"]) != 15
+        or any(
+            len(descriptive_tables[name]) != 3
+            for name in expected_descriptive_tables - {"perceived-readability"}
+        )
+        or jac_comprehension["accuracy"]["correct"] != 1
+        or jac_comprehension["accuracy"]["estimate"] != "1.000000000000"
+        or jac_comprehension["accuracy"]["wilson"]
+        != {
+            "confidence_level": "0.975000000000",
+            "lower": "0.166005792424",
+            "upper": "1.000000000000",
+        }
+        or jac_comprehension["confidence"]["calibration"]
+        != [
+            {
+                "accuracy": "1.000000000000",
+                "confidence": 100,
+                "correct": 1,
+                "rows": 1,
+            }
+        ]
+    ):
+        raise ProtocolError("synthetic descriptive tables drifted")
+    synthetic_descriptive_bytes = encode_descriptive_bundle(synthetic_descriptive)
+    if (
+        synthetic_descriptive_bytes
+        != encode_descriptive_bundle(
+            prepare_descriptive_bundle(rows, synthetic_digest, synthetic_analysis)
+        )
+        or FIXED_DRY_RUN_TIME in synthetic_descriptive_bytes
+        or '"recorded_at"' in synthetic_descriptive_bytes
+    ):
+        raise ProtocolError("descriptive bundle bytes or timestamp exclusion drifted")
+    mismatched_analysis = copy.deepcopy(synthetic_analysis)
+    mismatched_analysis["source"]["input_jsonl_sha256"] = digest_text(
+        synthetic_jsonl + "\n"
+    )
+    try:
+        prepare_descriptive_bundle(rows, synthetic_digest, mismatched_analysis)
+    except DescriptiveError:
+        pass
+    else:
+        raise ProtocolError("descriptive analysis accepted mismatched provenance")
+    zero_time_store = copy.deepcopy(rows)
+    zero_time_store[0]["completion_ms"] = 0
+    zero_time_store[0]["row_id"] = canonical_row_id(zero_time_store[0])
+    validate_result_store(zero_time_store, manifest, schema)
+    zero_time_jsonl = encode_jsonl(zero_time_store)
+    zero_time_digest = digest_text(zero_time_jsonl)
+    zero_time_analysis = prepare_analysis_bundle(
+        zero_time_store, zero_time_digest
+    )
+    zero_time_descriptive = prepare_descriptive_bundle(
+        zero_time_store, zero_time_digest, zero_time_analysis
+    )
+    zero_time_row = zero_time_store[0]
+    zero_time_table = next(
+        table
+        for table in zero_time_descriptive["tables"][
+            zero_time_row["outcome_family"]
+        ]
+        if table["carrier"] == zero_time_row["carrier"]
+        and table["job"] == zero_time_row["job"]
+    )
+    if (
+        zero_time_table["completion_ms"]["nonpositive_rows"] != 1
+        or zero_time_table["completion_ms"]["log_mean"] is not None
+        or zero_time_table["completion_ms"]["geometric_mean_ms"] is not None
+    ):
+        raise ProtocolError("zero completion time was dropped or silently shifted")
+
     clean_human_analysis = prepare_analysis_bundle(
         human_store, digest_text(encode_jsonl(human_store))
     )
@@ -1707,6 +1813,32 @@ def self_test(
         }
     ):
         raise ProtocolError("clean human analyzability flow drifted")
+    clean_human_descriptive = prepare_descriptive_bundle(
+        human_store,
+        digest_text(encode_jsonl(human_store)),
+        clean_human_analysis,
+    )
+    human_expertise = clean_human_descriptive["strata"]["human_expertise"]
+    programming_strata = human_expertise["programming_experience_years"]
+    if (
+        clean_human_descriptive["evidence_class"] != "human-candidate"
+        or clean_human_descriptive["pre_assignment_flow"]["status"]
+        != "external-required"
+        or clean_human_descriptive["source"]["source_row_count"] != 2400
+        or clean_human_descriptive["source"]["effective_row_count"] != 2400
+        or programming_strata
+        != [
+            {"carrier": carrier, "subjects": 160, "value": 5}
+            for carrier in CARRIERS
+        ]
+        or len(clean_human_descriptive["strata"]["presentation_order"]) != 75
+        or any(
+            len(clean_human_descriptive["strata"]["human_profile_outcomes"][field])
+            != 15
+            for field in HUMAN_PROFILE_FIELDS
+        )
+    ):
+        raise ProtocolError("human descriptive expertise or learning strata drifted")
 
     retry_analysis = prepare_analysis_bundle(
         human_store_with_retry,
@@ -1725,6 +1857,18 @@ def self_test(
         or retry_trials["effective_retry_rows"] != 1
     ):
         raise ProtocolError("successful human retry did not replace its failed first row")
+    retry_descriptive = prepare_descriptive_bundle(
+        human_store_with_retry,
+        digest_text(encode_jsonl(human_store_with_retry)),
+        retry_analysis,
+    )
+    if (
+        retry_descriptive["source"]["source_row_count"] != 2401
+        or retry_descriptive["source"]["effective_row_count"] != 2400
+        or failed["row_id"] in retry_descriptive["source"]["effective_row_ids"]
+        or retry["row_id"] not in retry_descriptive["source"]["effective_row_ids"]
+    ):
+        raise ProtocolError("descriptive tables did not honor effective retry selection")
 
     failed_retry_store = copy.deepcopy(human_store_with_retry)
     failed_retry = failed_retry_store[5]
@@ -1818,6 +1962,19 @@ def self_test(
         != expected_model_count - 1
     ):
         raise ProtocolError("model session analyzability flow drifted")
+    clean_model_descriptive = prepare_descriptive_bundle(
+        model_store,
+        digest_text(encode_jsonl(model_store)),
+        clean_model_analysis,
+    )
+    if (
+        clean_model_descriptive["evidence_class"] != "model-candidate"
+        or clean_model_descriptive["subject_kind"] != "model"
+        or clean_model_descriptive["strata"]["human_expertise"] is not None
+        or clean_model_descriptive["source"]["effective_row_count"]
+        != expected_model_count
+    ):
+        raise ProtocolError("model descriptive tables were not kept cohort-separate")
 
     def expect_rejection(label: str, operation: Callable[[], Any]) -> None:
         try:
@@ -2350,6 +2507,15 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     analysis.add_argument("--cohort", type=Path)
     analysis.add_argument("--authority", type=Path, required=True)
 
+    descriptive = commands.add_parser(
+        "analyze-descriptive",
+        help="validate a complete store and emit deterministic descriptive tables",
+    )
+    add_common_paths(descriptive)
+    descriptive.add_argument("--input", type=Path, required=True)
+    descriptive.add_argument("--cohort", type=Path)
+    descriptive.add_argument("--authority", type=Path, required=True)
+
     assign = commands.add_parser(
         "assign", help="debug one seeded assignment; admitted rows always use the frozen seed"
     )
@@ -2445,7 +2611,11 @@ def main(argv: Iterable[str]) -> int:
                     )
                 )
             return 0
-        if args.command in {"validate-results", "prepare-analysis"}:
+        if args.command in {
+            "validate-results",
+            "prepare-analysis",
+            "analyze-descriptive",
+        }:
             authority = load_json(args.authority)
             verify_authority_manifest(authority)
             cohort = None
@@ -2463,6 +2633,16 @@ def main(argv: Iterable[str]) -> int:
                 sys.stdout.write(
                     encode_analysis_bundle(
                         prepare_analysis_bundle(rows, input_sha256)
+                    )
+                )
+                return 0
+            if args.command == "analyze-descriptive":
+                analysis_input = prepare_analysis_bundle(rows, input_sha256)
+                sys.stdout.write(
+                    encode_descriptive_bundle(
+                        prepare_descriptive_bundle(
+                            rows, input_sha256, analysis_input
+                        )
                     )
                 )
                 return 0
@@ -2484,7 +2664,7 @@ def main(argv: Iterable[str]) -> int:
             print("readability protocol: PASS (5 jobs, 3 carriers, 15 dry-run conditions)")
             return 0
         raise ProtocolError(f"unknown command: {args.command}")
-    except (OSError, ProtocolError, AnalysisError) as error:
+    except (OSError, ProtocolError, AnalysisError, DescriptiveError) as error:
         print(f"readability protocol: FAIL: {error}", file=sys.stderr)
         return 1
 

--- a/test/readability/readability_descriptive.py
+++ b/test/readability/readability_descriptive.py
@@ -1,0 +1,588 @@
+"""Deterministic descriptive tables for validated readability result stores.
+
+The public entry point consumes rows only after complete result-store
+validation and requires the exact effective-row selection emitted by
+``readability-analysis-input-v1``.  It reports prespecified descriptive
+summaries and strata, never an inferential comparison or readability claim.
+Mismatched provenance or selection raises :class:`DescriptiveError`; no
+partial table bundle is returned.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import hashlib
+import json
+import math
+import re
+from typing import Any, Iterable
+
+from readability_analysis import (
+    AnalysisError,
+    encode_analysis_bundle,
+    prepare_analysis_bundle,
+)
+
+
+DESCRIPTIVE_VERSION = "readability-descriptive-v1"
+ANALYSIS_INPUT_VERSION = "readability-analysis-input-v1"
+CARRIERS = ("jac", "jqd", "python")
+JOBS = (
+    "seeded-bug",
+    "predict-output",
+    "authority-escalation",
+    "modify-behavior",
+    "diagnostic-recovery",
+)
+OUTCOME_FAMILIES = (
+    "comprehension",
+    "review",
+    "defect-detection",
+    "modification-debugging",
+    "diagnostic-recovery",
+)
+HUMAN_PROFILE_FIELDS = (
+    "programming_experience_years",
+    "code_review_experience_years",
+    "jacquard_familiarity",
+    "functional_programming_familiarity",
+)
+HEX_SHA256 = re.compile(r"[0-9a-f]{64}")
+DECIMAL_PLACES = 12
+CONFIDENCE_LEVEL = 0.975
+# Standard-normal quantile at 0.9875 for a two-sided alpha of 0.025.
+WILSON_Z = 2.241402727604947
+
+
+class DescriptiveError(RuntimeError):
+    """Raised when checked rows and analysis selection cannot form one bundle."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def encode_descriptive_bundle(bundle: dict[str, Any]) -> str:
+    """Return canonical JSON plus one newline for a descriptive bundle.
+
+    Numeric summaries are fixed-width decimal strings, so equal validated
+    inputs produce byte-identical output without timestamps or locale effects.
+    Non-JSON numeric values are rejected by the canonical encoder.
+    """
+
+    return _canonical_json(bundle) + "\n"
+
+
+def _field(row: dict[str, Any], name: str) -> Any:
+    if name not in row:
+        raise DescriptiveError(f"descriptive row is missing required field: {name}")
+    return row[name]
+
+
+def _decimal(value: float) -> str:
+    if not math.isfinite(value):
+        raise DescriptiveError("descriptive statistic is not finite")
+    rounded = 0.0 if abs(value) < 0.5 * (10 ** -DECIMAL_PLACES) else value
+    return f"{rounded:.{DECIMAL_PLACES}f}"
+
+
+def _fraction(numerator: int, denominator: int) -> str | None:
+    if denominator == 0:
+        return None
+    return _decimal(numerator / denominator)
+
+
+def _median(values: list[int]) -> str | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        value = float(ordered[middle])
+    else:
+        value = (ordered[middle - 1] + ordered[middle]) / 2
+    return _decimal(value)
+
+
+def _mean(values: list[int]) -> str | None:
+    if not values:
+        return None
+    return _decimal(math.fsum(values) / len(values))
+
+
+def _wilson(correct: int, rows: int) -> dict[str, Any]:
+    if rows == 0:
+        return {
+            "confidence_level": _decimal(CONFIDENCE_LEVEL),
+            "lower": None,
+            "upper": None,
+        }
+    proportion = correct / rows
+    z_squared = WILSON_Z * WILSON_Z
+    denominator = 1 + z_squared / rows
+    center = (proportion + z_squared / (2 * rows)) / denominator
+    half_width = (
+        WILSON_Z
+        * math.sqrt(
+            proportion * (1 - proportion) / rows
+            + z_squared / (4 * rows * rows)
+        )
+        / denominator
+    )
+    return {
+        "confidence_level": _decimal(CONFIDENCE_LEVEL),
+        "lower": _decimal(max(0.0, center - half_width)),
+        "upper": _decimal(min(1.0, center + half_width)),
+    }
+
+
+def _accuracy(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    correct_values = [_field(row, "correct") for row in rows]
+    if any(not isinstance(value, bool) for value in correct_values):
+        raise DescriptiveError("descriptive correctness values must be booleans")
+    correct = sum(correct_values)
+    return {
+        "correct": correct,
+        "estimate": _fraction(correct, len(rows)),
+        "rows": len(rows),
+        "wilson": _wilson(correct, len(rows)),
+    }
+
+
+def _completion(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    values = [_field(row, "completion_ms") for row in rows]
+    if any(
+        not isinstance(value, int) or isinstance(value, bool) or value < 0
+        for value in values
+    ):
+        raise DescriptiveError("descriptive completion_ms values must be nonnegative integers")
+    nonpositive = sum(value <= 0 for value in values)
+    log_mean: str | None = None
+    geometric_mean: str | None = None
+    if values and nonpositive == 0:
+        log_value = math.fsum(math.log(value) for value in values) / len(values)
+        log_mean = _decimal(log_value)
+        geometric_mean = _decimal(math.exp(log_value))
+    return {
+        "geometric_mean_ms": geometric_mean,
+        "log_mean": log_mean,
+        "maximum_ms": max(values) if values else None,
+        "median_ms": _median(values),
+        "minimum_ms": min(values) if values else None,
+        "nonpositive_rows": nonpositive,
+        "rows": len(values),
+    }
+
+
+def _confidence(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    values = [_field(row, "confidence") for row in rows]
+    if any(
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not 0 <= value <= 100
+        for value in values
+    ):
+        raise DescriptiveError("descriptive confidence values must be integers from 0 to 100")
+    counts = Counter(values)
+    calibration: list[dict[str, Any]] = []
+    for confidence in sorted(counts):
+        bucket = [row for row in rows if _field(row, "confidence") == confidence]
+        correct = sum(_field(row, "correct") for row in bucket)
+        calibration.append(
+            {
+                "accuracy": _fraction(correct, len(bucket)),
+                "confidence": confidence,
+                "correct": correct,
+                "rows": len(bucket),
+            }
+        )
+    return {
+        "calibration": calibration,
+        "distribution": [
+            {"count": counts[value], "value": value} for value in sorted(counts)
+        ],
+        "mean": _mean(values),
+        "rows": len(values),
+    }
+
+
+def _ratings(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    values = [_field(row, "perceived_readability") for row in rows]
+    if any(
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not 1 <= value <= 7
+        for value in values
+    ):
+        raise DescriptiveError(
+            "descriptive perceived_readability values must be integers from 1 to 7"
+        )
+    counts = Counter(values)
+    return {
+        "distribution": [
+            {"count": counts[value], "value": value} for value in range(1, 8)
+        ],
+        "mean": _mean(values),
+        "median": _median(values),
+        "rows": len(values),
+    }
+
+
+def _error_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    values = [_field(row, "error_code") for row in rows]
+    if any(value is not None and not isinstance(value, str) for value in values):
+        raise DescriptiveError("descriptive error_code values must be strings or null")
+    counts = Counter(value for value in values if value is not None)
+    return {value: counts[value] for value in sorted(counts)}
+
+
+def _outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "accuracy": _accuracy(rows),
+        "completion_ms": _completion(rows),
+        "confidence": _confidence(rows),
+        "error_counts": _error_counts(rows),
+        "perceived_readability": _ratings(rows),
+        "timeout_rows": sum(_field(row, "error_code") == "timeout" for row in rows),
+    }
+
+
+def _condition_rows(
+    rows: Iterable[dict[str, Any]],
+) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    conditions: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for row in rows:
+        carrier = _field(row, "carrier")
+        job = _field(row, "job")
+        if carrier not in CARRIERS or job not in JOBS:
+            raise DescriptiveError("descriptive row has an unknown carrier or job")
+        conditions.setdefault((carrier, job), []).append(row)
+    return conditions
+
+
+def _condition_base(
+    source_rows: list[dict[str, Any]], effective_rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    first = source_rows[0]
+    carrier = _field(first, "carrier")
+    job = _field(first, "job")
+    family = _field(first, "outcome_family")
+    if any(
+        (_field(row, "carrier"), _field(row, "job"), _field(row, "outcome_family"))
+        != (carrier, job, family)
+        for row in source_rows
+    ):
+        raise DescriptiveError("descriptive condition rows disagree on identity")
+    return {
+        "carrier": carrier,
+        "effective_rows": len(effective_rows),
+        "excluded_rows": len(source_rows) - len(effective_rows),
+        "job": job,
+        "outcome_family": family,
+        "source_rows": len(source_rows),
+    }
+
+
+def _tables(
+    source_rows: list[dict[str, Any]], effective_rows: list[dict[str, Any]]
+) -> dict[str, list[dict[str, Any]]]:
+    source = _condition_rows(source_rows)
+    effective = _condition_rows(effective_rows)
+    expected = {(carrier, job) for carrier in CARRIERS for job in JOBS}
+    if set(source) != expected:
+        raise DescriptiveError("descriptive source store does not cover all 15 conditions")
+
+    perceived: list[dict[str, Any]] = []
+    functional: dict[str, list[dict[str, Any]]] = {
+        family: [] for family in OUTCOME_FAMILIES
+    }
+    for carrier in CARRIERS:
+        for job in JOBS:
+            condition = (carrier, job)
+            source_condition = source[condition]
+            effective_condition = effective.get(condition, [])
+            base = _condition_base(source_condition, effective_condition)
+            family = base["outcome_family"]
+            if family not in functional:
+                raise DescriptiveError("descriptive row has an unknown outcome family")
+            perceived.append({**base, "ratings": _ratings(effective_condition)})
+            functional[family].append(
+                {**base, **_outcomes(effective_condition)}
+            )
+    return {"perceived-readability": perceived, **functional}
+
+
+def _stratum_entry(
+    keys: dict[str, Any], rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {**keys, **_outcomes(rows)}
+
+
+def _presentation_order(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, int, str, str], list[dict[str, Any]]] = {}
+    for row in rows:
+        carrier = _field(row, "carrier")
+        order = _field(row, "presentation_order")
+        family = _field(row, "outcome_family")
+        job = _field(row, "job")
+        if not isinstance(order, int) or isinstance(order, bool) or not 1 <= order <= 5:
+            raise DescriptiveError("descriptive presentation_order must be from 1 to 5")
+        grouped.setdefault((carrier, order, family, job), []).append(row)
+    return [
+        _stratum_entry(
+            {
+                "carrier": carrier,
+                "job": job,
+                "outcome_family": family,
+                "presentation_order": order,
+            },
+            grouped[(carrier, order, family, job)],
+        )
+        for carrier in CARRIERS
+        for order in range(1, 6)
+        for job in JOBS
+        for family in OUTCOME_FAMILIES
+        if (carrier, order, family, job) in grouped
+    ]
+
+
+def _subject_rows(
+    rows: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        subject_id = _field(row, "subject_id")
+        if not isinstance(subject_id, str):
+            raise DescriptiveError("descriptive subject_id must be a string")
+        grouped.setdefault(subject_id, []).append(row)
+    return grouped
+
+
+def _human_expertise(
+    source_rows: list[dict[str, Any]], analysis: dict[str, Any]
+) -> dict[str, list[dict[str, Any]]]:
+    grouped = _subject_rows(source_rows)
+    counts: dict[str, Counter[tuple[str, int]]] = {
+        field: Counter() for field in HUMAN_PROFILE_FIELDS
+    }
+    for decision in analysis["subjects"]:
+        if not decision.get("analyzable"):
+            continue
+        subject_id = decision.get("subject_id")
+        subject = grouped.get(subject_id)
+        if not subject:
+            raise DescriptiveError("an analyzable subject is absent from descriptive rows")
+        carriers = {_field(row, "carrier") for row in subject}
+        if len(carriers) != 1:
+            raise DescriptiveError("descriptive human subject mixes carriers")
+        carrier = next(iter(carriers))
+        for field in HUMAN_PROFILE_FIELDS:
+            values = {_field(row, field) for row in subject}
+            if len(values) != 1:
+                raise DescriptiveError(f"descriptive human subject mixes {field}")
+            value = next(iter(values))
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise DescriptiveError(f"descriptive human {field} must be an integer")
+            counts[field][(carrier, value)] += 1
+    return {
+        field: [
+            {"carrier": carrier, "subjects": counts[field][(carrier, value)], "value": value}
+            for carrier in CARRIERS
+            for value in sorted(
+                observed
+                for observed_carrier, observed in counts[field]
+                if observed_carrier == carrier
+            )
+        ]
+        for field in HUMAN_PROFILE_FIELDS
+    }
+
+
+def _human_profile_outcomes(
+    rows: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    output: dict[str, list[dict[str, Any]]] = {}
+    for field in HUMAN_PROFILE_FIELDS:
+        grouped: dict[tuple[str, int, str, str], list[dict[str, Any]]] = {}
+        for row in rows:
+            carrier = _field(row, "carrier")
+            value = _field(row, field)
+            family = _field(row, "outcome_family")
+            job = _field(row, "job")
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise DescriptiveError(f"descriptive human {field} must be an integer")
+            grouped.setdefault((carrier, value, family, job), []).append(row)
+        output[field] = [
+            _stratum_entry(
+                {
+                    "carrier": carrier,
+                    "job": job,
+                    "outcome_family": family,
+                    "value": value,
+                },
+                grouped[(carrier, value, family, job)],
+            )
+            for carrier in CARRIERS
+            for value in sorted(
+                {
+                    observed
+                    for observed_carrier, observed, _, _ in grouped
+                    if observed_carrier == carrier
+                }
+            )
+            for job in JOBS
+            for family in OUTCOME_FAMILIES
+            if (carrier, value, family, job) in grouped
+        ]
+    return output
+
+
+def _selection(
+    rows: list[dict[str, Any]], input_sha256: str, analysis: dict[str, Any]
+) -> tuple[list[dict[str, Any]], str]:
+    if (
+        not isinstance(input_sha256, str)
+        or HEX_SHA256.fullmatch(input_sha256) is None
+    ):
+        raise DescriptiveError("descriptive input digest must be a lowercase SHA-256")
+    if not isinstance(analysis, dict):
+        raise DescriptiveError("descriptive analysis input must be an object")
+    if analysis.get("analysis_version") != ANALYSIS_INPUT_VERSION:
+        raise DescriptiveError("descriptive analysis input version drifted")
+    if analysis.get("claim_status") != "not-evaluated":
+        raise DescriptiveError("descriptive analysis input already claims an outcome")
+    try:
+        expected_analysis = prepare_analysis_bundle(rows, input_sha256)
+    except AnalysisError as error:
+        raise DescriptiveError(
+            f"descriptive rows cannot reproduce analysis input: {error}"
+        ) from error
+    analysis_bytes = encode_analysis_bundle(analysis).encode("utf-8")
+    expected_bytes = encode_analysis_bundle(expected_analysis).encode("utf-8")
+    if analysis_bytes != expected_bytes:
+        raise DescriptiveError("descriptive analysis input is not the exact derived bundle")
+    source = analysis.get("source")
+    if not isinstance(source, dict) or source.get("input_jsonl_sha256") != input_sha256:
+        raise DescriptiveError("descriptive source digest disagrees with analysis input")
+
+    row_ids = [_field(row, "row_id") for row in rows]
+    if any(
+        not isinstance(row_id, str) or HEX_SHA256.fullmatch(row_id) is None
+        for row_id in row_ids
+    ):
+        raise DescriptiveError("descriptive row IDs must be lowercase SHA-256 values")
+    if len(set(row_ids)) != len(row_ids):
+        raise DescriptiveError("descriptive source row IDs must be unique")
+    if source.get("source_row_ids") != row_ids:
+        raise DescriptiveError("descriptive source row sequence disagrees with analysis input")
+
+    decisions = analysis.get("subjects")
+    if not isinstance(decisions, list):
+        raise DescriptiveError("descriptive analysis input lacks subject decisions")
+    decision_source: list[str] = []
+    effective_ids: list[str] = []
+    excluded_ids: list[str] = []
+    for decision in decisions:
+        if not isinstance(decision, dict):
+            raise DescriptiveError("descriptive subject decision must be an object")
+        for name, destination in (
+            ("source_row_ids", decision_source),
+            ("effective_row_ids", effective_ids),
+            ("excluded_row_ids", excluded_ids),
+        ):
+            values = decision.get(name)
+            if not isinstance(values, list) or any(
+                not isinstance(value, str) for value in values
+            ):
+                raise DescriptiveError(f"descriptive decision {name} is malformed")
+            destination.extend(values)
+    if decision_source != row_ids:
+        raise DescriptiveError("descriptive subject decisions reorder source rows")
+    if (
+        len(effective_ids) != len(set(effective_ids))
+        or len(excluded_ids) != len(set(excluded_ids))
+        or set(effective_ids).intersection(excluded_ids)
+        or set(effective_ids).union(excluded_ids) != set(row_ids)
+    ):
+        raise DescriptiveError("descriptive decisions do not partition source rows")
+
+    effective_set = set(effective_ids)
+    effective_rows = [row for row in rows if _field(row, "row_id") in effective_set]
+    return effective_rows, hashlib.sha256(analysis_bytes).hexdigest()
+
+
+def prepare_descriptive_bundle(
+    rows: list[dict[str, Any]], input_sha256: str, analysis: dict[str, Any]
+) -> dict[str, Any]:
+    """Build deterministic descriptive tables for one validated result store.
+
+    ``rows`` must first pass complete single-kind result-store validation, and
+    ``analysis`` must be the exact ``readability-analysis-input-v1`` bundle for
+    those source bytes.  Only its effective row IDs contribute outcome values;
+    excluded rows remain visible through source/effective counts and copied
+    flow evidence.  Human expertise and presentation-order strata are
+    descriptive only.  The result contains no timestamp, inferential carrier
+    comparison, threshold verdict, or readability claim.
+
+    The function raises :class:`DescriptiveError` on provenance, selection,
+    type, or coverage disagreement rather than returning partial statistics.
+    """
+
+    if not isinstance(rows, list) or not rows:
+        raise DescriptiveError("descriptive analysis requires one nonempty store")
+    if any(not isinstance(row, dict) for row in rows):
+        raise DescriptiveError("descriptive rows must be JSON objects")
+    effective_rows, analysis_sha256 = _selection(rows, input_sha256, analysis)
+    subject_kind = analysis.get("subject_kind")
+    if subject_kind not in {"human", "model", "synthetic"}:
+        raise DescriptiveError("descriptive subject kind is unknown")
+    if any(_field(row, "subject_kind") != subject_kind for row in rows):
+        raise DescriptiveError("descriptive rows disagree with analysis subject kind")
+
+    if subject_kind == "human":
+        human_expertise: dict[str, list[dict[str, Any]]] | None = _human_expertise(
+            rows, analysis
+        )
+        human_profile_outcomes: dict[str, list[dict[str, Any]]] | None = (
+            _human_profile_outcomes(effective_rows)
+        )
+    else:
+        human_expertise = None
+        human_profile_outcomes = None
+
+    row_ids = [_field(row, "row_id") for row in rows]
+    effective_ids = [_field(row, "row_id") for row in effective_rows]
+    return {
+        "bundle_scope": "descriptive-outcomes",
+        "claim_status": "not-evaluated",
+        "descriptive_version": DESCRIPTIVE_VERSION,
+        "evidence_class": analysis.get("evidence_class"),
+        "flow": json.loads(_canonical_json(analysis.get("flow"))),
+        "pre_assignment_flow": json.loads(
+            _canonical_json(analysis.get("pre_assignment_flow"))
+        ),
+        "protocol_version": analysis.get("protocol_version"),
+        "run_kind": analysis.get("run_kind"),
+        "source": {
+            "analysis_input_sha256": analysis_sha256,
+            "analysis_input_version": ANALYSIS_INPUT_VERSION,
+            "effective_row_count": len(effective_rows),
+            "effective_row_ids": effective_ids,
+            "input_jsonl_sha256": input_sha256,
+            "source_row_count": len(rows),
+            "source_row_ids": row_ids,
+        },
+        "strata": {
+            "human_expertise": human_expertise,
+            "human_profile_outcomes": human_profile_outcomes,
+            "presentation_order": _presentation_order(effective_rows),
+        },
+        "subject_kind": subject_kind,
+        "tables": _tables(rows, effective_rows),
+    }


### PR DESCRIPTION
Part of #86.

## Context

The readability benchmark can already validate submitted result rows and decide which retries or exclusions are usable. It still needs a deterministic way to turn those decisions into descriptive tables before any statistical comparison or readability claim is allowed.

## What changed

- Add an `analyze-descriptive` command that accepts only a complete, validated single-kind result store and its exact derived analysis input.
- Produce separate tables for perceived readability and the five functional outcome families: comprehension, review, defect detection, modification/debugging, and diagnostic recovery.
- Report observable counts, accuracy with 97.5% Wilson intervals, completion-time summaries, ratings, confidence calibration, error/timeout counts, flow, human-expertise strata, and presentation-order strata.
- Pin the output contract and sample-size premise in the public protocol and execution guide, and exercise the command through the Dune readability gate.

## Contract and invariants

- The complete store validator runs before analysis. Effective and excluded row identities must exactly reproduce the supplied `readability-analysis-input-v1` bundle.
- Output binds the exact source JSONL digest, ordered row identities, and canonical analysis-input digest. Equal validated inputs produce equal bytes in the same environment.
- Human, model, and synthetic stores stay separate. Synthetic output remains non-citable, and every output has claim status `not-evaluated`.
- Zero-millisecond observations remain in ordinary summaries; logarithmic and geometric summaries become null rather than silently shifting or dropping them.
- Output contains no timestamp, subject identifier, free-text response, inferred enrollment count, comparison result, or readability conclusion.

## Deliberate exclusions

This slice does not perform pairwise `.jac`/`.jqd` inference, multiplicity correction, Welch time comparisons, fitted covariate models, threshold evaluation, blinded rescoring, real-data collection, or publication-lineage checks. It changes no Jacquard syntax or semantics, result schema, fixture, schedule, admission rule, row identity, release claim, or canonical hash.

## Validation

- Claude Code with Fable 5: `PASS` on exact head `13d9b8e1a1f6170d0e4eb92809fc28131645d7`; no blockers, disputed tests, or architecture conflicts.
- Focused `@readability-protocol`: pass across clean, retry, exclusion, zero-time, model, synthetic, provenance-mutation, and stratum cases.
- Dual generated outputs were byte-identical: `cf9107c6f3f46ed5b88f9fe42922a3abc55c00cc6bf9d03ae435f34f57bb3230`.
- `dune build @all`, `dune build @doc`, `dune fmt`, version smoke (`0.1.0`), retained-manifest verification, and every adversarial manifest mutation: pass.
- Full exact-head test run: all 847 compiled Alcotest/QCheck tests passed in 345.553 seconds. The overall local command exited 1 only for four existing native sanitizer rules because LeakSanitizer cannot run under the Codex ptrace environment; the required clean GitHub clang and GCC native lanes remain the decisive sanitizer evidence.

## Risks and follow-ups

- Twelve-place logarithmic summaries use the host math library. Same-environment determinism is pinned; cross-platform byte identity is not claimed.
- Frozen domain constants are duplicated in the descriptive module, but all drift paths fail closed against exact regenerated inputs and coverage checks.
- Comparative inference, claim evaluation, blinded rescoring, and published-number lineage remain later independent parts of #86.
