### PR TITLE
readability: add deterministic comparative evidence summaries

### DIFF
--- a/docs/research/readability-benchmark/EXECUTION.md
+++ b/docs/research/readability-benchmark/EXECUTION.md
@@ -1,8 +1,9 @@
 # Readability protocol v1 execution gate
 
 Status: deterministic planning, fail-closed result admission, analyzability,
-and descriptive-table tools are implemented. The checked manifests do not
-authorize real collection, and no human or model outcomes exist.
+descriptive tables, and `.jac`/`.jqd` comparison summaries are implemented.
+The checked manifests do not authorize real collection, and no human or model
+outcomes exist.
 
 The [protocol](PROTOCOL.md) defines the study. This document separates a
 reproducible plan from external authority. A generated schedule proves that
@@ -246,9 +247,45 @@ retained and reported but makes log/geometric mean null; it is never silently
 dropped or shifted. Running twice from byte-identical stores produces
 byte-identical output. Synthetic output exercises all table shapes but remains
 `synthetic-non-citable`; real human/model output remains candidate evidence
-with claim status `not-evaluated`. Pairwise effects, multiplicity correction,
-claim thresholds, blinded rescoring, and publication-number lineage are later
-gates and cannot be inferred from this file.
+with claim status `not-evaluated`. Pairwise effects are a separate evidence
+summary; neither file creates a product verdict. Blinded rescoring and any
+publication-number lineage still require real checked evidence.
+
+## Deterministic `.jac`/`.jqd` comparison
+
+Produce the pairwise evidence summary from the same validated store and exact
+analysis selection:
+
+```text
+python3 test/readability/readability_benchmark.py analyze-comparative \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json \
+  --input HUMAN-RESULTS.jsonl \
+  > .scratch/readability/human-comparative.json
+```
+
+`readability-comparative-v1` compares only `.jac` and `.jqd`. For each of the
+five functional outcomes it emits the correct-proportion difference, a
+Newcombe method-10 interval at per-outcome alpha `0.005` with nominal
+Bonferroni family coverage, a pooled two-proportion score p-value, and its Holm
+adjustment. The one completion-time estimate uses each human's geometric mean
+across all five jobs, a Welch interval on subject log milliseconds at alpha
+`0.025`, and the exponentiated `.jac`/`.jqd` ratio. A nonpositive effective
+time makes that interval unavailable instead of disappearing from analysis.
+
+The command binds the source JSONL, exact analysis and descriptive bundle
+digests, and ordered source/effective row IDs. It emits no timestamp, subject
+identifier, automatic threshold, or pass/fail result. Human output remains
+candidate evidence. Synthetic dry-run output is byte-deterministic and
+`synthetic-non-citable`; it normally reports insufficient subjects for a
+Welch interval. Model stores are refused rather than pooled or substituted.
+
+There is no minimum participant count and no automatic product or release
+gate. The frozen 480-person schedule and historical 141-person power target
+remain reference planning artifacts, not prerequisites for language ideas.
+Any future claim about people must instead state the real sample, exclusions,
+effect estimates, uncertainty, deviations, and limitations.
 
 ## What the checked gate proves
 
@@ -273,11 +310,16 @@ gates and cannot be inferred from this file.
 - deterministic descriptive tables for all six reporting families, exact
   effective-row selection, human expertise/presentation-order strata, model
   separation, timestamp omission, and byte-identical dual generation;
+- deterministic comparative accuracy and aggregate-time summaries, pinned
+  Newcombe/Bonferroni, pooled-score/Holm, and Welch calculations, exact
+  provenance, nonpositive-time refusal, model separation, and byte-identical
+  synthetic generation without an automatic verdict;
 - unconditional rejection of real rows with the checked pending authority and
   M0 cohort manifests; and
 - byte-identical schedule and dry-run generation.
 
 It does not prove that approvals exist, the live host is accessible,
 participants followed instructions, M0 is available or uncontaminated, quota
-exists, or any readability claim is true. Those require real external
-authority, collection, checked evidence, and reproducible analysis.
+exists, or any readability claim is true. Claims about people require real
+external authority, collection, checked evidence, and reproducible analysis;
+their absence is not an implementation or release gate.

--- a/docs/research/readability-benchmark/PROTOCOL.md
+++ b/docs/research/readability-benchmark/PROTOCOL.md
@@ -56,23 +56,27 @@ SHA-256 of the public seed, block, carrier, and order. The confirmatory seed is
 `jacquard-readability-v1`. Operators may not skip an ordinal after learning its
 assignment or selectively replace an excluded participant.
 
-Recruit 480 adults who self-attest that they can read small Python-like
-programs and have at least one year of programming or review experience. The
-plan assigns 160 enrollments to each carrier. There is no optional stopping.
-Fewer than 141 analyzable humans in either Jacquard carrier makes every
-confirmatory `.jac`/`.jqd` readability claim inconclusive.
+The frozen full-scale reference plan contains 480 adults who self-attest that
+they can read small Python-like programs and have at least one year of
+programming or review experience. It assigns 160 enrollment ordinals to each
+carrier and has no optional-stopping rule. The schedule is a reproducibility
+and harness-completeness artifact, not a required recruitment target. No
+language idea, implementation task, or release decision waits for this study
+or for any minimum participant count. A smaller future collection requires a
+separately reviewed schedule/admission version and reports its actual sample
+size rather than borrowing the full-scale plan's power assumptions.
 
-At two-sided alpha 0.025, 128 analyzable participants per Jacquard carrier give
+The original power-planning calculation used two-sided alpha 0.025. It
+estimated that 128 analyzable participants per Jacquard carrier would give
 about 80% power for a standardized log-time effect of 0.386, approximately a
-20% time change at coefficient of variation 0.5. The accuracy planning premise
-is 80% power to distinguish 70% from 90% accuracy between two independent
-carriers. The original three-job Holm calculation required fewer than 100 per
-carrier. For this protocol's five functional outcomes, the conservative
-Bonferroni bound for Holm uses two-sided alpha `0.025 / 5 = 0.005`; the standard
-two-proportion normal approximation gives about 105 per carrier. The target of
-141 covers both accuracy premises and the 128-person time calculation;
-enrolling 160 allows about 10% exclusion. Python remains balanced but does not
-enter the confirmatory power claim.
+20% time change at coefficient of variation 0.5. The accuracy premise was 80%
+power to distinguish 70% from 90% accuracy between two independent carriers.
+For five functional outcomes, the conservative Bonferroni bound uses
+two-sided alpha `0.025 / 5 = 0.005`; the standard two-proportion normal
+approximation gives about 105 per carrier. The historical target of 141 covered
+those premises plus exclusion headroom. It is a power-planning reference, not
+a minimum, claim threshold, or product gate. Python remains balanced in the
+reference schedule but does not enter the `.jac`/`.jqd` comparison.
 
 Before assignment, record only these de-identified reader covariates with the
 result rows: years of programming experience, years of code-review experience,
@@ -223,7 +227,7 @@ Pre-assignment no-consent and eligibility counts remain in the separately
 approved enrollment flow. They are reported as `external-required`, not
 inferred or invented from answer rows.
 
-## Preregistered analysis and claim gate
+## Prespecified analysis and evidence interpretation
 
 Produce separate deterministic tables for perceived ratings, comprehension,
 review, defect detection, modification/debugging, and diagnostic recovery.
@@ -243,29 +247,36 @@ presentation-order and expertise strata. Fixed 12-place decimal strings make
 equal inputs byte-identical; raw collection timestamps are omitted. A zero-ms
 observation is counted and leaves log/geometric means null rather than being
 dropped or adjusted. These descriptive tables remain `not-evaluated`; they do
-not perform the pairwise comparison or claim gate.
+not perform the pairwise comparison.
 
-Pairwise `.jac`/`.jqd` accuracy uses Newcombe-Wilson difference intervals with
-Holm correction across functional outcomes. Time uses each human's geometric
-mean and Welch intervals on log milliseconds, then reports the exponentiated
-ratio. Allocate family-wise alpha 0.025 to accuracy and 0.025 to time. Ratings
-are secondary and cannot establish task success.
+The comparison stage is `readability-comparative-v1`. For each of the five
+functional outcomes it reports `.jac` minus `.jqd` accuracy, a Newcombe method
+10 Wilson-score difference interval without continuity correction, and a
+supplementary two-sided pooled two-proportion score p-value. Accuracy has
+family alpha 0.025. Each interval uses the conservative per-outcome alpha
+`0.025 / 5 = 0.005`, giving nominal Bonferroni family coverage; Newcombe's
+component interval is approximate, so the output does not call that coverage
+exact. P-values receive standard Holm adjustment across the five outcomes.
+Neither interval bounds nor adjusted p-values create an automatic verdict.
 
-No measured readability claim may be published unless the approved protocol
-and consent flow exist, both Jacquard carriers have at least 141 analyzable
-humans, checked evidence validates, the preregistered analysis reproduces
-byte-for-byte modulo declared timestamps, and every cited model cohort is
-attested. Human evidence is always required.
+Time uses each human's geometric mean across the five functional jobs. A
+two-sided Welch interval at alpha 0.025 compares the subject-level log
+milliseconds, then exponentiates the `.jac` minus `.jqd` difference into a
+`.jac`/`.jqd` ratio. Job-specific times remain descriptive. An effective
+nonpositive completion time makes aggregate time inference unavailable; it is
+never dropped or shifted. Python is descriptive context and model stores are
+not substituted into this human comparison. Synthetic output exercises the
+code as `synthetic-non-citable` and normally lacks enough subjects for a Welch
+interval.
 
-- **Pass for a specific outcome claim:** the corrected interval supports the
-  stated direction and the paired co-primary measure shows no material harm
-  (accuracy lower bound above -5 points and completion-ratio upper bound below
-  1.10). State the exact job or aggregate; do not say “readable” in general.
-- **Fail:** fixture identity/behavior drift, authority/schema failure, an
-  adjusted accuracy upper bound below -5 points, or a completion-ratio lower
-  bound above 1.10.
-- **Inconclusive:** every other result, including mixed measures, insufficient
-  humans, protocol drift, contamination, or intervals crossing thresholds.
+There is no automatic product or release gate and no minimum-human-count gate.
+Readability ideas may be proposed, implemented, and reviewed without running
+this study. Any future measured claim about people still requires real approved
+human evidence, checked de-identified rows, reproducible analysis, the actual
+sample and exclusion flow, effect estimates with uncertainty, deviations, and
+plain limitations on generalization. Small or absent samples are not
+population-level proof, but they do not become a blocker for language work.
+Model or synthetic observations alone never become human evidence.
 
 Dependency distance, referent tracking, ambiguity, nesting, identifier cueing,
 canonical-format stability, diff stability, and code surprisal/naturalness may
@@ -303,12 +314,22 @@ python3 test/readability/readability_benchmark.py analyze-descriptive \
   --authority test/readability/authority-manifest.template.json \
   --input .scratch/readability/dry-run.jsonl \
   > .scratch/readability/descriptive.json
+python3 test/readability/readability_benchmark.py analyze-comparative \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority test/readability/authority-manifest.template.json \
+  --input .scratch/readability/dry-run.jsonl \
+  > .scratch/readability/comparative.json
 ```
 
 The dry run emits one synthetic, non-citable row for each of 15 conditions and
 makes no readability or performance claim. The analysis-input file contains no
 outcome analysis or claim. The descriptive file exercises every table but is
-also synthetic, non-citable, and claim-free. Schedules, renderings, logs,
-stores, and generated bundles remain under `.scratch/`. Generating a schedule
-is planning evidence, not permission to collect outcomes. The
+also synthetic, non-citable, and claim-free. The comparative file exercises the
+five accuracy contrasts and aggregate-time availability rules, but its
+synthetic source cannot support a human claim and its single observation per
+carrier leaves aggregate time inference unavailable. It emits no automatic
+verdict. Schedules, renderings, logs, stores, and generated bundles remain under
+`.scratch/`. Generating a schedule is planning evidence, not permission to
+collect outcomes. The
 [execution gate](EXECUTION.md) records the exact fail-closed boundary.

--- a/test/readability/dune
+++ b/test/readability/dune
@@ -3,6 +3,7 @@
  (deps
   readability_benchmark.py
   readability_analysis.py
+  readability_comparative.py
   readability_descriptive.py
   fixture-manifest.json
   result.schema.json
@@ -61,6 +62,19 @@
       --authority authority-manifest.template.json
       --input dry-run.jsonl))
     (diff descriptive-1.json descriptive-2.json)
+    (with-stdout-to comparative-1.json
+     (run %{bin:python3} readability_benchmark.py analyze-comparative
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (with-stdout-to comparative-2.json
+     (run %{bin:python3} readability_benchmark.py analyze-comparative
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl))
+    (diff comparative-1.json comparative-2.json)
     (with-stdout-to human-schedule.jsonl
      (run %{bin:python3} readability_benchmark.py human-schedule))
     (with-stdout-to model-schedule.jsonl

--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -26,6 +26,11 @@ from readability_analysis import (
     encode_analysis_bundle,
     prepare_analysis_bundle,
 )
+from readability_comparative import (
+    ComparativeError,
+    encode_comparative_bundle,
+    prepare_comparative_bundle,
+)
 from readability_descriptive import (
     DescriptiveError,
     encode_descriptive_bundle,
@@ -1328,8 +1333,13 @@ def verify_protocol_document(protocol_path: Path) -> None:
         "70% from 90% accuracy",
         "0.025 / 5 = 0.005",
         "readability-descriptive-v1",
+        "readability-comparative-v1",
         "97.5% wilson",
         "exact confidence-level calibration",
+        "nominal bonferroni",
+        "pooled two-proportion score",
+        "holm",
+        "no automatic product or release gate",
         "consent",
         "compensation",
         "accessibility",
@@ -1338,9 +1348,6 @@ def verify_protocol_document(protocol_path: Path) -> None:
         "data governance",
         "de-ident",
         "contamination",
-        "pass",
-        "fail",
-        "inconclusive",
         ".scratch",
     )
     for anchor in anchors:
@@ -1757,6 +1764,44 @@ def self_test(
         or '"recorded_at"' in synthetic_descriptive_bytes
     ):
         raise ProtocolError("descriptive bundle bytes or timestamp exclusion drifted")
+    synthetic_comparative = prepare_comparative_bundle(
+        rows, synthetic_digest, synthetic_analysis
+    )
+    synthetic_accuracy = synthetic_comparative["accuracy"]
+    if (
+        synthetic_comparative["comparative_version"]
+        != "readability-comparative-v1"
+        or synthetic_comparative["evidence_class"] != "synthetic-non-citable"
+        or synthetic_comparative["claim_status"] != "not-evaluated"
+        or synthetic_comparative["interpretation"]["automatic_product_gate"]
+        != "none"
+        or synthetic_comparative["interpretation"]["minimum_human_count"]
+        is not None
+        or len(synthetic_accuracy) != 5
+        or any(
+            summary["difference_jac_minus_jqd"] != "0.000000000000"
+            or summary["holm_adjusted_p"] != "1.000000000000"
+            for summary in synthetic_accuracy
+        )
+        or synthetic_comparative["completion_time"]["status"]
+        != "insufficient-subjects"
+        or synthetic_comparative["completion_time"]["carrier_subjects"]
+        != {"jac": 1, "jqd": 1}
+    ):
+        raise ProtocolError("synthetic comparative summaries drifted")
+    synthetic_comparative_bytes = encode_comparative_bundle(
+        synthetic_comparative
+    )
+    if (
+        synthetic_comparative_bytes
+        != encode_comparative_bundle(
+            prepare_comparative_bundle(rows, synthetic_digest, synthetic_analysis)
+        )
+        or FIXED_DRY_RUN_TIME in synthetic_comparative_bytes
+        or '"recorded_at"' in synthetic_comparative_bytes
+        or '"subject_id"' in synthetic_comparative_bytes
+    ):
+        raise ProtocolError("comparative bundle bytes or de-identification drifted")
     mismatched_analysis = copy.deepcopy(synthetic_analysis)
     mismatched_analysis["source"]["input_jsonl_sha256"] = digest_text(
         synthetic_jsonl + "\n"
@@ -1767,6 +1812,12 @@ def self_test(
         pass
     else:
         raise ProtocolError("descriptive analysis accepted mismatched provenance")
+    try:
+        prepare_comparative_bundle(rows, synthetic_digest, mismatched_analysis)
+    except ComparativeError:
+        pass
+    else:
+        raise ProtocolError("comparative analysis accepted mismatched provenance")
     zero_time_store = copy.deepcopy(rows)
     zero_time_store[0]["completion_ms"] = 0
     zero_time_store[0]["row_id"] = canonical_row_id(zero_time_store[0])
@@ -1794,6 +1845,18 @@ def self_test(
         or zero_time_table["completion_ms"]["geometric_mean_ms"] is not None
     ):
         raise ProtocolError("zero completion time was dropped or silently shifted")
+    zero_time_comparative = prepare_comparative_bundle(
+        zero_time_store, zero_time_digest, zero_time_analysis
+    )
+    if (
+        zero_time_comparative["completion_time"]["status"]
+        != "nonpositive-observation"
+        or zero_time_comparative["completion_time"]["ratio_jac_over_jqd"]
+        is not None
+        or zero_time_comparative["completion_time"]["nonpositive_rows"]
+        != {"jac": 1, "jqd": 0}
+    ):
+        raise ProtocolError("comparative time silently dropped or shifted zero ms")
 
     clean_human_analysis = prepare_analysis_bundle(
         human_store, digest_text(encode_jsonl(human_store))
@@ -1839,6 +1902,151 @@ def self_test(
         )
     ):
         raise ProtocolError("human descriptive expertise or learning strata drifted")
+
+    rank_by_ordinal: dict[int, int] = {}
+    next_carrier_rank = {carrier: 0 for carrier in CARRIERS}
+    for plan in humans:
+        carrier = plan["carrier"]
+        rank_by_ordinal[plan["ordinal"]] = next_carrier_rank[carrier]
+        next_carrier_rank[carrier] += 1
+    accuracy_targets = {
+        "jac": {
+            "seeded-bug": 128,
+            "predict-output": 144,
+            "authority-escalation": 136,
+            "modify-behavior": 120,
+            "diagnostic-recovery": 112,
+        },
+        "jqd": {
+            "seeded-bug": 120,
+            "predict-output": 128,
+            "authority-escalation": 120,
+            "modify-behavior": 112,
+            "diagnostic-recovery": 104,
+        },
+        "python": {job: 136 for job in JOBS},
+    }
+    carrier_time_offset = {"jac": 0, "jqd": 140, "python": 70}
+    job_index = {job: index for index, job in enumerate(JOBS)}
+    fixtures_by_job = fixture_index(manifest)
+    comparative_human_store = copy.deepcopy(human_store)
+    for result in comparative_human_store:
+        carrier = result["carrier"]
+        job = result["job"]
+        rank = rank_by_ordinal[result["schedule_ordinal"]]
+        correct = rank < accuracy_targets[carrier][job]
+        if correct:
+            result.update(
+                {
+                    "answer_id": fixtures_by_job[job]["correct_answer"],
+                    "correct": True,
+                    "error_code": None,
+                }
+            )
+        else:
+            wrong_answer = sorted(
+                fixtures_by_job[job]["wrong_answer_errors"]
+            )[0]
+            result.update(
+                {
+                    "answer_id": wrong_answer,
+                    "correct": False,
+                    "error_code": fixtures_by_job[job]["wrong_answer_errors"][
+                        wrong_answer
+                    ],
+                }
+            )
+        result["completion_ms"] = (
+            1000
+            + (7 * rank)
+            + (43 * job_index[job])
+            + carrier_time_offset[carrier]
+            + ((rank % 5) * (job_index[job] + 1))
+        )
+        result["confidence"] = 90 if correct else 60
+        result["perceived_readability"] = 5 if carrier == "jac" else 4
+        result["row_id"] = canonical_row_id(result)
+    validate_test_human_store(comparative_human_store)
+    comparative_human_jsonl = encode_jsonl(comparative_human_store)
+    comparative_human_digest = digest_text(comparative_human_jsonl)
+    comparative_human_analysis = prepare_analysis_bundle(
+        comparative_human_store, comparative_human_digest
+    )
+    comparative_human = prepare_comparative_bundle(
+        comparative_human_store,
+        comparative_human_digest,
+        comparative_human_analysis,
+    )
+    comprehension_effect = comparative_human["accuracy"][0]
+    time_effect = comparative_human["completion_time"]
+    if (
+        comparative_human["evidence_class"] != "human-candidate"
+        or comparative_human["subject_kind"] != "human"
+        or comparative_human["source"]["source_row_count"] != 2400
+        or comparative_human["source"]["effective_row_count"] != 2400
+        or comparative_human["methods"]["accuracy"]["per_outcome_alpha"]
+        != "0.005000000000"
+        or comprehension_effect
+        != {
+            "accuracy": {
+                "jac": {
+                    "correct": 144,
+                    "estimate": "0.900000000000",
+                    "rows": 160,
+                },
+                "jqd": {
+                    "correct": 128,
+                    "estimate": "0.800000000000",
+                    "rows": 160,
+                },
+            },
+            "difference_jac_minus_jqd": "0.100000000000",
+            "holm_adjusted_p": "0.061243500192",
+            "job": "predict-output",
+            "newcombe_interval": {
+                "confidence_level": "0.995000000000",
+                "lower": "-0.013591357053",
+                "upper": "0.212993178619",
+            },
+            "outcome_family": "comprehension",
+            "pooled_score_two_sided_p": "0.012248700038",
+        }
+        or time_effect
+        != {
+            "carrier_geometric_mean_ms": {
+                "jac": "1614.561858103575",
+                "jqd": "1757.361044573370",
+            },
+            "carrier_subjects": {"jac": 160, "jqd": 160},
+            "confidence_interval": {
+                "confidence_level": "0.975000000000",
+                "degrees_of_freedom": "315.665886838437",
+                "lower_ratio": "0.874806334541",
+                "standard_error_log": "0.021758408586",
+                "upper_ratio": "0.964884806357",
+            },
+            "log_difference_jac_minus_jqd": "-0.084749652747",
+            "log_summary_subjects": {"jac": 160, "jqd": 160},
+            "nonpositive_rows": {"jac": 0, "jqd": 0},
+            "ratio_jac_over_jqd": "0.918742260214",
+            "status": "available",
+        }
+    ):
+        raise ProtocolError("human comparative effect summaries drifted")
+    comparative_human_bytes = encode_comparative_bundle(comparative_human)
+    if (
+        comparative_human_bytes
+        != encode_comparative_bundle(
+            prepare_comparative_bundle(
+                comparative_human_store,
+                comparative_human_digest,
+                comparative_human_analysis,
+            )
+        )
+        or '"subject_id"' in comparative_human_bytes
+        or '"recorded_at"' in comparative_human_bytes
+    ):
+        raise ProtocolError("human comparative bytes or de-identification drifted")
 
     retry_analysis = prepare_analysis_bundle(
         human_store_with_retry,
@@ -1975,6 +2183,16 @@ def self_test(
         != expected_model_count
     ):
         raise ProtocolError("model descriptive tables were not kept cohort-separate")
+    try:
+        prepare_comparative_bundle(
+            model_store,
+            digest_text(encode_jsonl(model_store)),
+            clean_model_analysis,
+        )
+    except ComparativeError:
+        pass
+    else:
+        raise ProtocolError("model outcomes entered the human comparative analysis")
 
     def expect_rejection(label: str, operation: Callable[[], Any]) -> None:
         try:
@@ -2516,6 +2734,15 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     descriptive.add_argument("--cohort", type=Path)
     descriptive.add_argument("--authority", type=Path, required=True)
 
+    comparative = commands.add_parser(
+        "analyze-comparative",
+        help="emit deterministic .jac/.jqd effect summaries without a product verdict",
+    )
+    add_common_paths(comparative)
+    comparative.add_argument("--input", type=Path, required=True)
+    comparative.add_argument("--cohort", type=Path)
+    comparative.add_argument("--authority", type=Path, required=True)
+
     assign = commands.add_parser(
         "assign", help="debug one seeded assignment; admitted rows always use the frozen seed"
     )
@@ -2615,6 +2842,7 @@ def main(argv: Iterable[str]) -> int:
             "validate-results",
             "prepare-analysis",
             "analyze-descriptive",
+            "analyze-comparative",
         }:
             authority = load_json(args.authority)
             verify_authority_manifest(authority)
@@ -2646,6 +2874,16 @@ def main(argv: Iterable[str]) -> int:
                     )
                 )
                 return 0
+            if args.command == "analyze-comparative":
+                analysis_input = prepare_analysis_bundle(rows, input_sha256)
+                sys.stdout.write(
+                    encode_comparative_bundle(
+                        prepare_comparative_bundle(
+                            rows, input_sha256, analysis_input
+                        )
+                    )
+                )
+                return 0
             print(f"validated {count} rows across {len(conditions)} conditions")
             return 0
         if args.command == "verify":
@@ -2664,7 +2902,13 @@ def main(argv: Iterable[str]) -> int:
             print("readability protocol: PASS (5 jobs, 3 carriers, 15 dry-run conditions)")
             return 0
         raise ProtocolError(f"unknown command: {args.command}")
-    except (OSError, ProtocolError, AnalysisError, DescriptiveError) as error:
+    except (
+        OSError,
+        ProtocolError,
+        AnalysisError,
+        ComparativeError,
+        DescriptiveError,
+    ) as error:
         print(f"readability protocol: FAIL: {error}", file=sys.stderr)
         return 1
 

--- a/test/readability/readability_comparative.py
+++ b/test/readability/readability_comparative.py
@@ -1,0 +1,585 @@
+"""Deterministic comparative summaries for validated readability evidence.
+
+The public entry point consumes a complete store and its exact
+``readability-analysis-input-v1`` selection.  It compares only ``.jac`` with
+``.jqd``; Python remains descriptive context, model stores are refused, and
+synthetic stores remain non-citable.  The output contains effect estimates and
+prespecified uncertainty, never an automatic readability or product verdict.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+import hashlib
+import json
+import math
+import re
+from statistics import NormalDist
+from typing import Any, Iterable
+
+from readability_descriptive import (
+    DescriptiveError,
+    encode_descriptive_bundle,
+    prepare_descriptive_bundle,
+)
+
+
+COMPARATIVE_VERSION = "readability-comparative-v1"
+ANALYSIS_INPUT_VERSION = "readability-analysis-input-v1"
+DESCRIPTIVE_VERSION = "readability-descriptive-v1"
+FUNCTIONAL_OUTCOMES = (
+    "comprehension",
+    "review",
+    "defect-detection",
+    "modification-debugging",
+    "diagnostic-recovery",
+)
+JACQUARD_CARRIERS = ("jac", "jqd")
+HEX_SHA256 = re.compile(r"[0-9a-f]{64}")
+DECIMAL_PLACES = 12
+ACCURACY_FAMILY_ALPHA = 0.025
+ACCURACY_COMPARISONS = len(FUNCTIONAL_OUTCOMES)
+ACCURACY_PER_COMPARISON_ALPHA = ACCURACY_FAMILY_ALPHA / ACCURACY_COMPARISONS
+TIME_ALPHA = 0.025
+ACCURACY_Z = NormalDist().inv_cdf(1.0 - (ACCURACY_PER_COMPARISON_ALPHA / 2.0))
+
+
+class ComparativeError(RuntimeError):
+    """Raised when checked evidence cannot form one exact comparison bundle."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def encode_comparative_bundle(bundle: dict[str, Any]) -> str:
+    """Return canonical JSON plus one newline for a comparison bundle.
+
+    Derived decimals are fixed-width strings and the bundle carries no
+    timestamp, so equal validated input produces byte-identical output.
+    """
+
+    return _canonical_json(bundle) + "\n"
+
+
+def _field(row: dict[str, Any], name: str) -> Any:
+    if name not in row:
+        raise ComparativeError(f"comparative row is missing required field: {name}")
+    return row[name]
+
+
+def _decimal(value: float) -> str:
+    if not math.isfinite(value):
+        raise ComparativeError("comparative statistic is not finite")
+    rounded = 0.0 if abs(value) < 0.5 * (10**-DECIMAL_PLACES) else value
+    return f"{rounded:.{DECIMAL_PLACES}f}"
+
+
+def _fraction(numerator: int, denominator: int) -> str:
+    if denominator <= 0:
+        raise ComparativeError("comparative proportion has no observations")
+    return _decimal(numerator / denominator)
+
+
+def _wilson_bounds(correct: int, rows: int, z: float) -> tuple[float, float]:
+    if rows <= 0 or not 0 <= correct <= rows:
+        raise ComparativeError("comparative Wilson inputs are invalid")
+    estimate = correct / rows
+    z_squared = z * z
+    denominator = 1.0 + (z_squared / rows)
+    center = (estimate + (z_squared / (2.0 * rows))) / denominator
+    half_width = (
+        z
+        * math.sqrt(
+            (estimate * (1.0 - estimate) / rows)
+            + (z_squared / (4.0 * rows * rows))
+        )
+        / denominator
+    )
+    return max(0.0, center - half_width), min(1.0, center + half_width)
+
+
+def _newcombe_interval(
+    jac_correct: int, jac_rows: int, jqd_correct: int, jqd_rows: int
+) -> tuple[float, float, float]:
+    jac_estimate = jac_correct / jac_rows
+    jqd_estimate = jqd_correct / jqd_rows
+    difference = jac_estimate - jqd_estimate
+    jac_lower, jac_upper = _wilson_bounds(jac_correct, jac_rows, ACCURACY_Z)
+    jqd_lower, jqd_upper = _wilson_bounds(jqd_correct, jqd_rows, ACCURACY_Z)
+    lower = difference - math.sqrt(
+        ((jac_estimate - jac_lower) ** 2) + ((jqd_upper - jqd_estimate) ** 2)
+    )
+    upper = difference + math.sqrt(
+        ((jac_upper - jac_estimate) ** 2) + ((jqd_estimate - jqd_lower) ** 2)
+    )
+    return difference, max(-1.0, lower), min(1.0, upper)
+
+
+def _pooled_score_p_value(
+    jac_correct: int, jac_rows: int, jqd_correct: int, jqd_rows: int
+) -> float:
+    jac_estimate = jac_correct / jac_rows
+    jqd_estimate = jqd_correct / jqd_rows
+    pooled = (jac_correct + jqd_correct) / (jac_rows + jqd_rows)
+    variance = pooled * (1.0 - pooled) * ((1.0 / jac_rows) + (1.0 / jqd_rows))
+    if variance == 0.0:
+        if jac_estimate != jqd_estimate:
+            raise ComparativeError("zero pooled variance disagrees with accuracy estimates")
+        return 1.0
+    score = (jac_estimate - jqd_estimate) / math.sqrt(variance)
+    return min(1.0, max(0.0, 2.0 * NormalDist().cdf(-abs(score))))
+
+
+def _holm_adjust(raw_values: list[float]) -> list[float]:
+    if not raw_values or any(
+        not math.isfinite(value) or not 0.0 <= value <= 1.0
+        for value in raw_values
+    ):
+        raise ComparativeError("Holm adjustment requires finite p-values from zero to one")
+    ordered = sorted(range(len(raw_values)), key=lambda index: (raw_values[index], index))
+    adjusted = [0.0] * len(raw_values)
+    running = 0.0
+    count = len(raw_values)
+    for rank, index in enumerate(ordered):
+        candidate = min(1.0, (count - rank) * raw_values[index])
+        running = max(running, candidate)
+        adjusted[index] = running
+    return adjusted
+
+
+def _beta_fraction(a: float, b: float, value: float) -> float:
+    maximum_iterations = 240
+    epsilon = 3.0e-14
+    minimum = 1.0e-300
+    total = a + b
+    a_plus = a + 1.0
+    a_minus = a - 1.0
+    c_value = 1.0
+    d_value = 1.0 - (total * value / a_plus)
+    if abs(d_value) < minimum:
+        d_value = minimum
+    d_value = 1.0 / d_value
+    result = d_value
+    for iteration in range(1, maximum_iterations + 1):
+        doubled = 2 * iteration
+        coefficient = (
+            iteration
+            * (b - iteration)
+            * value
+            / ((a_minus + doubled) * (a + doubled))
+        )
+        d_value = 1.0 + (coefficient * d_value)
+        if abs(d_value) < minimum:
+            d_value = minimum
+        c_value = 1.0 + (coefficient / c_value)
+        if abs(c_value) < minimum:
+            c_value = minimum
+        d_value = 1.0 / d_value
+        result *= d_value * c_value
+
+        coefficient = -(
+            (a + iteration)
+            * (total + iteration)
+            * value
+            / ((a + doubled) * (a_plus + doubled))
+        )
+        d_value = 1.0 + (coefficient * d_value)
+        if abs(d_value) < minimum:
+            d_value = minimum
+        c_value = 1.0 + (coefficient / c_value)
+        if abs(c_value) < minimum:
+            c_value = minimum
+        d_value = 1.0 / d_value
+        change = d_value * c_value
+        result *= change
+        if abs(change - 1.0) <= epsilon:
+            return result
+    raise ComparativeError("regularized beta continued fraction did not converge")
+
+
+def _regularized_beta(value: float, a: float, b: float) -> float:
+    if not 0.0 <= value <= 1.0 or a <= 0.0 or b <= 0.0:
+        raise ComparativeError("regularized beta inputs are outside their domain")
+    if value == 0.0:
+        return 0.0
+    if value == 1.0:
+        return 1.0
+    factor = math.exp(
+        math.lgamma(a + b)
+        - math.lgamma(a)
+        - math.lgamma(b)
+        + (a * math.log(value))
+        + (b * math.log1p(-value))
+    )
+    if value < (a + 1.0) / (a + b + 2.0):
+        return factor * _beta_fraction(a, b, value) / a
+    return 1.0 - (factor * _beta_fraction(b, a, 1.0 - value) / b)
+
+
+def _student_t_cdf(value: float, degrees_of_freedom: float) -> float:
+    if not math.isfinite(value) or not math.isfinite(degrees_of_freedom):
+        raise ComparativeError("Student t inputs must be finite")
+    if degrees_of_freedom <= 0.0:
+        raise ComparativeError("Student t degrees of freedom must be positive")
+    if value == 0.0:
+        return 0.5
+    beta_value = degrees_of_freedom / (
+        degrees_of_freedom + (value * value)
+    )
+    tail = 0.5 * _regularized_beta(beta_value, degrees_of_freedom / 2.0, 0.5)
+    return 1.0 - tail if value > 0.0 else tail
+
+
+def _student_t_quantile(probability: float, degrees_of_freedom: float) -> float:
+    if not 0.0 < probability < 1.0:
+        raise ComparativeError("Student t probability must be strictly between zero and one")
+    if probability == 0.5:
+        return 0.0
+    if probability < 0.5:
+        return -_student_t_quantile(1.0 - probability, degrees_of_freedom)
+    lower = 0.0
+    upper = 1.0
+    while _student_t_cdf(upper, degrees_of_freedom) < probability:
+        upper *= 2.0
+        if upper > 1.0e12:
+            raise ComparativeError("Student t quantile search did not find an upper bound")
+    for _ in range(120):
+        middle = (lower + upper) / 2.0
+        if _student_t_cdf(middle, degrees_of_freedom) < probability:
+            lower = middle
+        else:
+            upper = middle
+    return (lower + upper) / 2.0
+
+
+def verify_comparative_methods() -> None:
+    """Check bounded hand-derived pins for the statistical primitives.
+
+    Failures raise :class:`ComparativeError`; this helper performs no I/O and
+    does not inspect or generate study evidence.
+    """
+
+    one_df = _student_t_quantile(0.9875, 1.0)
+    expected_one_df = math.tan(math.pi * (0.9875 - 0.5))
+    if abs(one_df - expected_one_df) > 1.0e-10:
+        raise ComparativeError("Student t quantile drifted from the analytic df=1 result")
+    two_df = _student_t_quantile(0.9875, 2.0)
+    centered_probability = (2.0 * 0.9875) - 1.0
+    expected_two_df = (
+        math.sqrt(2.0)
+        * centered_probability
+        / math.sqrt(1.0 - (centered_probability * centered_probability))
+    )
+    if abs(two_df - expected_two_df) > 1.0e-10:
+        raise ComparativeError("Student t quantile drifted from the analytic df=2 result")
+    adjusted = _holm_adjust([0.01, 0.04, 0.03, 0.002, 0.005])
+    if any(
+        abs(observed - expected) > 1.0e-15
+        for observed, expected in zip(adjusted, [0.03, 0.06, 0.06, 0.01, 0.02])
+    ):
+        raise ComparativeError("Holm adjustment drifted from the hand-derived example")
+    _, lower, upper = _newcombe_interval(90, 100, 70, 100)
+    if abs(lower - 0.04050718010598) > 1.0e-14 or abs(
+        upper - 0.3505105019724275
+    ) > 1.0e-14:
+        raise ComparativeError("Newcombe method-10 interval drifted from its pinned example")
+
+
+def _effective_selection(
+    rows: list[dict[str, Any]], input_sha256: str, analysis: dict[str, Any]
+) -> tuple[list[dict[str, Any]], dict[str, Any], str]:
+    try:
+        descriptive = prepare_descriptive_bundle(rows, input_sha256, analysis)
+    except DescriptiveError as error:
+        raise ComparativeError(
+            f"comparative rows cannot reproduce descriptive input: {error}"
+        ) from error
+    source = descriptive.get("source")
+    if not isinstance(source, dict):
+        raise ComparativeError("comparative descriptive source is missing")
+    effective_ids = source.get("effective_row_ids")
+    if not isinstance(effective_ids, list) or any(
+        not isinstance(row_id, str) or HEX_SHA256.fullmatch(row_id) is None
+        for row_id in effective_ids
+    ):
+        raise ComparativeError("comparative effective row identities are malformed")
+    effective_set = set(effective_ids)
+    if len(effective_set) != len(effective_ids):
+        raise ComparativeError("comparative effective row identities are duplicated")
+    effective_rows = [
+        row for row in rows if _field(row, "row_id") in effective_set
+    ]
+    if [_field(row, "row_id") for row in effective_rows] != effective_ids:
+        raise ComparativeError("comparative effective rows disagree with selected order")
+    descriptive_sha256 = hashlib.sha256(
+        encode_descriptive_bundle(descriptive).encode("utf-8")
+    ).hexdigest()
+    return effective_rows, descriptive, descriptive_sha256
+
+
+def _carrier_accuracy(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    values = [_field(row, "correct") for row in rows]
+    if not values or any(not isinstance(value, bool) for value in values):
+        raise ComparativeError("comparative accuracy requires Boolean observations")
+    correct = sum(values)
+    return {
+        "correct": correct,
+        "estimate": _fraction(correct, len(values)),
+        "rows": len(values),
+    }
+
+
+def _accuracy_summaries(effective_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in effective_rows:
+        carrier = _field(row, "carrier")
+        family = _field(row, "outcome_family")
+        if carrier in JACQUARD_CARRIERS:
+            if family not in FUNCTIONAL_OUTCOMES:
+                raise ComparativeError("comparative row has an unknown functional outcome")
+            grouped[(family, carrier)].append(row)
+    summaries: list[dict[str, Any]] = []
+    raw_p_values: list[float] = []
+    for family in FUNCTIONAL_OUTCOMES:
+        jac_rows = grouped.get((family, "jac"), [])
+        jqd_rows = grouped.get((family, "jqd"), [])
+        jac = _carrier_accuracy(jac_rows)
+        jqd = _carrier_accuracy(jqd_rows)
+        jobs = {
+            _field(row, "job") for row in [*jac_rows, *jqd_rows]
+        }
+        if len(jobs) != 1:
+            raise ComparativeError("comparative outcome does not map to exactly one job")
+        difference, lower, upper = _newcombe_interval(
+            jac["correct"], jac["rows"], jqd["correct"], jqd["rows"]
+        )
+        raw_p = _pooled_score_p_value(
+            jac["correct"], jac["rows"], jqd["correct"], jqd["rows"]
+        )
+        raw_p_values.append(raw_p)
+        summaries.append(
+            {
+                "accuracy": {"jac": jac, "jqd": jqd},
+                "difference_jac_minus_jqd": _decimal(difference),
+                "job": next(iter(jobs)),
+                "newcombe_interval": {
+                    "confidence_level": _decimal(
+                        1.0 - ACCURACY_PER_COMPARISON_ALPHA
+                    ),
+                    "lower": _decimal(lower),
+                    "upper": _decimal(upper),
+                },
+                "outcome_family": family,
+                "pooled_score_two_sided_p": _decimal(raw_p),
+            }
+        )
+    for summary, adjusted in zip(summaries, _holm_adjust(raw_p_values)):
+        summary["holm_adjusted_p"] = _decimal(adjusted)
+    return summaries
+
+
+def _subject_log_means(
+    effective_rows: list[dict[str, Any]],
+) -> tuple[dict[str, list[float]], dict[str, int], dict[str, int]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in effective_rows:
+        carrier = _field(row, "carrier")
+        if carrier in JACQUARD_CARRIERS:
+            subject_id = _field(row, "subject_id")
+            if not isinstance(subject_id, str):
+                raise ComparativeError("comparative subject identifier must be a string")
+            grouped[subject_id].append(row)
+    log_means = {carrier: [] for carrier in JACQUARD_CARRIERS}
+    nonpositive = {carrier: 0 for carrier in JACQUARD_CARRIERS}
+    subject_counts = {carrier: 0 for carrier in JACQUARD_CARRIERS}
+    for subject_rows in grouped.values():
+        carriers = {_field(row, "carrier") for row in subject_rows}
+        if len(carriers) != 1:
+            raise ComparativeError("comparative subject crosses carriers")
+        carrier = next(iter(carriers))
+        by_family: dict[str, dict[str, Any]] = {}
+        for row in subject_rows:
+            family = _field(row, "outcome_family")
+            if family in by_family or family not in FUNCTIONAL_OUTCOMES:
+                raise ComparativeError("comparative subject has duplicate or unknown outcomes")
+            by_family[family] = row
+        if set(by_family) != set(FUNCTIONAL_OUTCOMES):
+            raise ComparativeError("comparative subject lacks a functional outcome")
+        subject_counts[carrier] += 1
+        values: list[int] = []
+        for family in FUNCTIONAL_OUTCOMES:
+            value = _field(by_family[family], "completion_ms")
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ComparativeError(
+                    "comparative completion_ms must be a nonnegative integer"
+                )
+            values.append(value)
+        nonpositive[carrier] += sum(value <= 0 for value in values)
+        if all(value > 0 for value in values):
+            log_means[carrier].append(
+                math.fsum(math.log(value) for value in values) / len(values)
+            )
+    return log_means, nonpositive, subject_counts
+
+
+def _mean(values: list[float]) -> float:
+    return math.fsum(values) / len(values)
+
+
+def _sample_variance(values: list[float], mean: float) -> float:
+    return math.fsum((value - mean) ** 2 for value in values) / (len(values) - 1)
+
+
+def _completion_time_summary(effective_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    log_means, nonpositive, subject_counts = _subject_log_means(effective_rows)
+    log_counts = {carrier: len(log_means[carrier]) for carrier in JACQUARD_CARRIERS}
+    base: dict[str, Any] = {
+        "carrier_subjects": subject_counts,
+        "log_summary_subjects": log_counts,
+        "nonpositive_rows": nonpositive,
+    }
+    if any(nonpositive.values()):
+        return {
+            **base,
+            "confidence_interval": None,
+            "log_difference_jac_minus_jqd": None,
+            "ratio_jac_over_jqd": None,
+            "status": "nonpositive-observation",
+        }
+    jac_values = log_means["jac"]
+    jqd_values = log_means["jqd"]
+    if not jac_values or not jqd_values:
+        raise ComparativeError("comparative time has no Jacquard carrier observations")
+    jac_mean = _mean(jac_values)
+    jqd_mean = _mean(jqd_values)
+    difference = jac_mean - jqd_mean
+    ratio = math.exp(difference)
+    base.update(
+        {
+            "carrier_geometric_mean_ms": {
+                "jac": _decimal(math.exp(jac_mean)),
+                "jqd": _decimal(math.exp(jqd_mean)),
+            },
+            "log_difference_jac_minus_jqd": _decimal(difference),
+            "ratio_jac_over_jqd": _decimal(ratio),
+        }
+    )
+    if len(jac_values) < 2 or len(jqd_values) < 2:
+        return {**base, "confidence_interval": None, "status": "insufficient-subjects"}
+    jac_variance = _sample_variance(jac_values, jac_mean)
+    jqd_variance = _sample_variance(jqd_values, jqd_mean)
+    jac_component = jac_variance / len(jac_values)
+    jqd_component = jqd_variance / len(jqd_values)
+    standard_error_squared = jac_component + jqd_component
+    if standard_error_squared == 0.0:
+        return {**base, "confidence_interval": None, "status": "zero-variance"}
+    denominator = (
+        (jac_component * jac_component) / (len(jac_values) - 1)
+        + (jqd_component * jqd_component) / (len(jqd_values) - 1)
+    )
+    if denominator <= 0.0:
+        raise ComparativeError("Welch degrees-of-freedom denominator is invalid")
+    degrees_of_freedom = (standard_error_squared * standard_error_squared) / denominator
+    standard_error = math.sqrt(standard_error_squared)
+    critical = _student_t_quantile(1.0 - (TIME_ALPHA / 2.0), degrees_of_freedom)
+    lower_log = difference - (critical * standard_error)
+    upper_log = difference + (critical * standard_error)
+    return {
+        **base,
+        "confidence_interval": {
+            "confidence_level": _decimal(1.0 - TIME_ALPHA),
+            "degrees_of_freedom": _decimal(degrees_of_freedom),
+            "lower_ratio": _decimal(math.exp(lower_log)),
+            "standard_error_log": _decimal(standard_error),
+            "upper_ratio": _decimal(math.exp(upper_log)),
+        },
+        "status": "available",
+    }
+
+
+def prepare_comparative_bundle(
+    rows: list[dict[str, Any]], input_sha256: str, analysis: dict[str, Any]
+) -> dict[str, Any]:
+    """Build deterministic `.jac`/`.jqd` effect summaries.
+
+    ``rows`` must already pass complete result-store validation and ``analysis``
+    must be the exact analyzability bundle for the same source bytes.  Human
+    output remains candidate evidence, synthetic output is non-citable, and
+    model stores are refused.  The function returns no threshold verdict or
+    readability claim and raises :class:`ComparativeError` on any provenance,
+    selection, coverage, or numerical disagreement.
+    """
+
+    if not isinstance(rows, list) or not rows or any(
+        not isinstance(row, dict) for row in rows
+    ):
+        raise ComparativeError("comparative analysis requires one nonempty object store")
+    if not isinstance(input_sha256, str) or HEX_SHA256.fullmatch(input_sha256) is None:
+        raise ComparativeError("comparative input digest must be a lowercase SHA-256")
+    if not isinstance(analysis, dict):
+        raise ComparativeError("comparative analysis input must be an object")
+    effective_rows, descriptive, descriptive_sha256 = _effective_selection(
+        rows, input_sha256, analysis
+    )
+    subject_kind = descriptive.get("subject_kind")
+    if subject_kind == "model":
+        raise ComparativeError("model stores cannot enter the human carrier comparison")
+    if subject_kind not in {"human", "synthetic"}:
+        raise ComparativeError("comparative subject kind is unknown")
+    verify_comparative_methods()
+    descriptive_source = descriptive["source"]
+    return {
+        "accuracy": _accuracy_summaries(effective_rows),
+        "bundle_scope": "jac-versus-jqd-evidence-summary",
+        "claim_status": "not-evaluated",
+        "comparative_version": COMPARATIVE_VERSION,
+        "completion_time": _completion_time_summary(effective_rows),
+        "evidence_class": descriptive.get("evidence_class"),
+        "flow": json.loads(_canonical_json(descriptive.get("flow"))),
+        "interpretation": {
+            "automatic_product_gate": "none",
+            "minimum_human_count": None,
+            "population_claim_rule": "report-actual-sample-uncertainty-and-limitations",
+        },
+        "methods": {
+            "accuracy": {
+                "effect": "jac-minus-jqd-correct-proportion",
+                "family_alpha": _decimal(ACCURACY_FAMILY_ALPHA),
+                "interval": "newcombe-method-10-no-continuity-correction",
+                "interval_family_coverage": "nominal-bonferroni",
+                "per_outcome_alpha": _decimal(ACCURACY_PER_COMPARISON_ALPHA),
+                "p_adjustment": "holm",
+                "p_value": "pooled-two-proportion-score-two-sided",
+            },
+            "completion_time": {
+                "alpha": _decimal(TIME_ALPHA),
+                "effect": "jac-over-jqd-geometric-mean-ratio",
+                "interval": "welch-on-subject-log-means",
+                "subject_summary": "geometric-mean-across-five-functional-jobs",
+            },
+        },
+        "pre_assignment_flow": json.loads(
+            _canonical_json(descriptive.get("pre_assignment_flow"))
+        ),
+        "protocol_version": descriptive.get("protocol_version"),
+        "run_kind": descriptive.get("run_kind"),
+        "source": {
+            "analysis_input_sha256": descriptive_source["analysis_input_sha256"],
+            "analysis_input_version": ANALYSIS_INPUT_VERSION,
+            "descriptive_bundle_sha256": descriptive_sha256,
+            "descriptive_version": DESCRIPTIVE_VERSION,
+            "effective_row_count": descriptive_source["effective_row_count"],
+            "effective_row_ids": descriptive_source["effective_row_ids"],
+            "input_jsonl_sha256": input_sha256,
+            "source_row_count": descriptive_source["source_row_count"],
+            "source_row_ids": descriptive_source["source_row_ids"],
+        },
+        "subject_kind": subject_kind,
+    }


### PR DESCRIPTION
## Context

The readability protocol could validate result stores and produce descriptive
tables, but it could not yet compare the `.jac` and `.jqd` results in one
repeatable way. Its old wording also treated a historical 141-person power
target as a hard claim gate. That is not a realistic prerequisite for language
design work, and this repository currently has no human or model outcomes.

This change finishes the deterministic comparison tool without pretending that
synthetic rows are evidence about people.

## What changed

- Add `analyze-comparative`, which repeats full result-store validation and the
  exact existing effective-row selection before computing any comparison.
- Report `.jac` minus `.jqd` accuracy for each of the five functional outcomes
  with nominal Bonferroni/Newcombe uncertainty and supplementary pooled-score
  p-values with Holm adjustment.
- Report one completion-time ratio from each human's geometric mean across all
  five jobs, using a Welch interval on log milliseconds.
- Make aggregate time unavailable when any effective time is zero instead of
  silently dropping or shifting that observation.
- Refuse model stores, keep Python descriptive only, and mark synthetic output
  `synthetic-non-citable`.
- Emit canonical, timestamp-free, de-identified JSON with
  `claim_status: not-evaluated` and no pass/fail or product verdict.
- Reframe 141 and the frozen 480-person schedule as planning/reference
  artifacts, not requirements for proposing, implementing, or releasing
  readability ideas.

## Contract and boundaries

The five accuracy intervals use Newcombe method 10 without continuity
correction at per-outcome alpha `0.005` (`0.025 / 5`). Their family coverage is
described as nominal because the component interval is approximate. Holm is
applied only to the five supplementary pooled-score p-values.

Completion time is one `.jac/.jqd` ratio at alpha `0.025`, based on independent
subject-level log geometric means across the five jobs. Job-specific times stay
descriptive. Neither result automatically approves or rejects a language idea.

This does not change the result schema, schedules, fixtures, row IDs,
admission rules, Jacquard semantics, release claims, kernel forms, or canonical
identity.

## Deliberately excluded

- recruiting people or contacting models;
- inventing or checking in outcomes;
- claiming approval, consent, or a result about people;
- a new smaller-study schedule/admission version;
- blinded rescoring or publication-number lineage.

Any future claim about people still needs real approved evidence, its actual
sample and exclusions, reproducible estimates, uncertainty, deviations, and
plain limitations. Missing that evidence does not block language work.

## Validation

- `scripts/release/check-historical-manifests.sh --commit 91b89f5729b7dafb4f94b4331b9133c89d7c122a --require-history` — PASS
- `scripts/release/test-historical-manifests.sh --commit 91b89f5729b7dafb4f94b4331b9133c89d7c122a` — PASS
- `opam exec -- dune build --root "$PWD" @readability-protocol` — PASS; deterministic comparison bundles matched byte-for-byte
- `opam exec -- dune build --root "$PWD" @all` — PASS
- `opam exec -- dune runtest --root "$PWD"` — PASS in the LSan-capable execution mode; 847 tests plus native sanitizer/runtime rules
- `opam exec -- dune fmt --root "$PWD"` and clean Git diff — PASS
- `_build/default/bin/main.exe --version` — PASS (`0.1.0`)
- `opam exec -- dune build --root "$PWD" @doc` — PASS
- Independent Fable review of exact head `91b89f5729b7dafb4f94b4331b9133c89d7c122a` — PASS, no blockers or architecture conflicts

## Risks and follow-ups

The statistical code uses only Python's standard library, including a bounded
Student-t implementation. Analytic `df=1` and `df=2` identities, exact
Newcombe/Holm fixtures, an exact 160-per-carrier Welch fixture, provenance
mutation, model refusal, zero-time handling, and repeat-byte behavior pin it.

The current 480-person human schedule remains a full-scale reproducibility
fixture. If a real smaller collection is ever useful, it should get a separate
reviewed schedule/admission version instead of borrowing the old power plan.

Part of #86.
