### PR TITLE
readability: bind blinded rescoring and evidence lineage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,8 @@ project shape from file names alone.
 - `research/readability-benchmark/PROTOCOL.md`: human-first v1 reviewer tasks,
   paired-carrier fixtures, model-family-neutral cohorts, scoring, privacy, and
   synthetic reproduction evidence for future syntax decisions.
-- `research/readability-benchmark/EXECUTION.md`: fail-closed UX.1 authority
-  boundary and deterministic human/model schedule commands.
+- `research/readability-benchmark/EXECUTION.md`: fail-closed UX.1 authority,
+  analysis, blinded-rescore, and exact evidence-lineage boundary.
 - `ci-cd.md`: GitHub gates, branch protection, and release evidence workflow.
 
 ## Core Design

--- a/docs/research/readability-benchmark/EXECUTION.md
+++ b/docs/research/readability-benchmark/EXECUTION.md
@@ -1,9 +1,9 @@
 # Readability protocol v1 execution gate
 
 Status: deterministic planning, fail-closed result admission, analyzability,
-descriptive tables, and `.jac`/`.jqd` comparison summaries are implemented.
-The checked manifests do not authorize real collection, and no human or model
-outcomes exist.
+descriptive and comparative analysis, blinded-rescore mechanics, and exact
+publication lineage are implemented. The checked manifests do not authorize
+real collection, and no human or model outcomes exist.
 
 The [protocol](PROTOCOL.md) defines the study. This document separates a
 reproducible plan from external authority. A generated schedule proves that
@@ -248,8 +248,9 @@ dropped or shifted. Running twice from byte-identical stores produces
 byte-identical output. Synthetic output exercises all table shapes but remains
 `synthetic-non-citable`; real human/model output remains candidate evidence
 with claim status `not-evaluated`. Pairwise effects are a separate evidence
-summary; neither file creates a product verdict. Blinded rescoring and any
-publication-number lineage still require real checked evidence.
+summary; neither file creates a product verdict. The mechanics for blinded
+rescoring and publication-number lineage are described below. Actual outcomes,
+an independent reviewer, and publication authority remain external.
 
 ## Deterministic `.jac`/`.jqd` comparison
 
@@ -287,6 +288,81 @@ remain reference planning artifacts, not prerequisites for language ideas.
 Any future claim about people must instead state the real sample, exclusions,
 effect estimates, uncertainty, deviations, and limitations.
 
+## Blinded rescore and exact evidence bundle
+
+Freeze the rescore sample seed and positive sample count in a reviewed study
+record before outcomes are unblinded. The tool does not choose either value and
+does not impose a minimum. After complete store admission, generate the packet:
+
+```text
+python3 test/readability/readability_benchmark.py prepare-rescore \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json \
+  --input HUMAN-RESULTS.jsonl \
+  --sample-seed REVIEWED-SEED --sample-size REVIEWED-COUNT \
+  > .scratch/readability/human-rescore-packet.json
+```
+
+The command reproduces `readability-analysis-input-v1`, ranks effective rows by
+domain-separated SHA-256 of the reviewed seed and canonical row ID, and takes
+the requested prefix. It refuses zero, negative, or oversized samples rather
+than silently changing the count. Each packet trial contains only an opaque
+blind ID, fixture ID, and submitted answer ID. It omits carrier, subject and row
+identity, existing scores, timing, confidence, ratings, and outcome summaries.
+The packet records only a digest of the seed, so the reviewer need not receive
+the source store, analysis selection, or raw seed.
+
+The independent reviewer returns canonical JSON with this shape, preserving
+packet order:
+
+```json
+{
+  "assessment_version": "readability-rescore-assessment-v1",
+  "decisions": [
+    {"blind_id": "64-lowercase-hex", "correct": true, "error_code": null}
+  ],
+  "independence_attestation_sha256": "64-lowercase-hex",
+  "packet_sha256": "64-lowercase-hex"
+}
+```
+
+The attestation digest binds separately retained evidence about reviewer
+identity and independence; it does not place that private record in the result
+store. The verifier confirms only that the digest is present and that every
+ordered decision agrees with the frozen answer key. It cannot prove who
+performed the review or whether they were independent. Synthetic self-checks
+must use `null` for the attestation and remain `synthetic-non-citable`.
+
+Assemble the exact candidate artifact only after that independent action:
+
+```text
+python3 test/readability/readability_benchmark.py assemble-evidence \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority AUTHORITY.json \
+  --input HUMAN-RESULTS.jsonl \
+  --sample-seed REVIEWED-SEED --sample-size REVIEWED-COUNT \
+  --assessment INDEPENDENT-ASSESSMENT.json \
+  > .scratch/readability/human-evidence-bundle.json
+```
+
+`assemble-evidence` does not trust a caller-supplied packet. It revalidates the
+complete store and internally regenerates the analysis selection, blinded
+packet, descriptive tables, and human comparison before verifying the
+assessment. `readability-evidence-bundle-v1` embeds each exact object and its
+canonical SHA-256. Model evidence uses the same command with `--cohort` but
+embeds no `.jac`/`.jqd` comparison; model results remain cohort-specific and
+cannot substitute for people. The bundle has no timestamp, minimum count,
+automatic verdict, or publication claim. Its machine-verified number lineage
+covers only values inside that exact bundle. External prose must cite the exact
+bundle and JSON path or establish its own checked derivation.
+
+Actual participant collection, a real second reviewer, validation of that
+reviewer's identity and independence, approval to publish, and interpretation
+of the observed sample remain external requirements. Their absence prevents a
+measured human claim, not language design or release work.
+
 ## What the checked gate proves
 
 `dune build @readability-protocol` verifies:
@@ -314,6 +390,12 @@ effect estimates, uncertainty, deviations, and limitations.
   Newcombe/Bonferroni, pooled-score/Holm, and Welch calculations, exact
   provenance, nonpositive-time refusal, model separation, and byte-identical
   synthetic generation without an automatic verdict;
+- deterministic outcome-blinded effective-row sampling; strict refusal of
+  missing, reordered, substituted, wrongly scored, or cross-packet decisions;
+  explicit non-verification of reviewer identity/independence; and
+- byte-identical evidence assembly with exact embedded artifact digests,
+  internal packet regeneration, human/model separation, synthetic
+  non-citability, and no minimum-count or product gate;
 - unconditional rejection of real rows with the checked pending authority and
   M0 cohort manifests; and
 - byte-identical schedule and dry-run generation.

--- a/docs/research/readability-benchmark/PROTOCOL.md
+++ b/docs/research/readability-benchmark/PROTOCOL.md
@@ -1,6 +1,7 @@
 # Human-first readability benchmark protocol v1
 
-Status: preregistered design; no human or model outcomes have been collected.
+Status: preregistered design and deterministic evidence mechanics; no human or
+model outcomes have been collected.
 Protocol ID: `readability-protocol-v1`.
 
 This protocol asks what readers can actually understand and change. It keeps a
@@ -269,6 +270,32 @@ not substituted into this human comparison. Synthetic output exercises the
 code as `synthetic-non-citable` and normally lacks enough subjects for a Welch
 interval.
 
+Blinded independent rescoring uses `readability-rescore-packet-v1`. Before
+outcomes are unblinded, the study operator must freeze a reviewed sample seed
+and positive sample count. The tooling does not choose or bless either value,
+and there is no built-in minimum. It SHA-256-ranks only effective rows and
+emits opaque blind IDs with fixture and submitted answer IDs. The packet omits
+carrier, source/effective row IDs, subject IDs, original correctness and error
+fields, time, confidence, ratings, and outcome statistics. An independent
+reviewer returns one decision per blind ID in packet order. Real candidate
+evidence also binds a separately retained reviewer identity/independence
+attestation by SHA-256. The verifier proves exact agreement with the frozen
+answer key; it cannot prove that the reviewer is a particular person or is
+independent. Synthetic self-checks carry no such attestation and remain
+non-citable.
+
+`readability-evidence-bundle-v1` is the publication-lineage boundary. It
+revalidates the complete store, regenerates the exact analysis, descriptive,
+and applicable human comparison objects, regenerates the rescore packet from
+the reviewed seed and count, verifies the returned assessment, and embeds each
+canonical object with its SHA-256. A model bundle remains descriptive and has
+no human carrier comparison. Every number inside the exact bundle therefore
+has checked source-byte lineage. A number copied into a paper, issue, or other
+prose is outside that machine-verified boundary unless it cites the exact
+bundle digest and JSON path. The bundle remains `not-evaluated`; publication
+authority, the reviewer's real independence, and honest interpretation are
+external facts.
+
 There is no automatic product or release gate and no minimum-human-count gate.
 Readability ideas may be proposed, implemented, and reviewed without running
 this study. Any future measured claim about people still requires real approved
@@ -320,6 +347,13 @@ python3 test/readability/readability_benchmark.py analyze-comparative \
   --authority test/readability/authority-manifest.template.json \
   --input .scratch/readability/dry-run.jsonl \
   > .scratch/readability/comparative.json
+python3 test/readability/readability_benchmark.py prepare-rescore \
+  --manifest test/readability/fixture-manifest.json \
+  --schema test/readability/result.schema.json \
+  --authority test/readability/authority-manifest.template.json \
+  --input .scratch/readability/dry-run.jsonl \
+  --sample-seed ux1-rescore-v1 --sample-size 5 \
+  > .scratch/readability/rescore-packet.json
 ```
 
 The dry run emits one synthetic, non-citable row for each of 15 conditions and
@@ -329,7 +363,10 @@ also synthetic, non-citable, and claim-free. The comparative file exercises the
 five accuracy contrasts and aggregate-time availability rules, but its
 synthetic source cannot support a human claim and its single observation per
 carrier leaves aggregate time inference unavailable. It emits no automatic
-verdict. Schedules, renderings, logs, stores, and generated bundles remain under
-`.scratch/`. Generating a schedule is planning evidence, not permission to
-collect outcomes. The
+verdict. The rescore command exercises deterministic selection and the blinded
+packet shape; it does not perform an independent review. The checked protocol
+self-test assembles a synthetic evidence bundle and adversarially verifies its
+lineage, but that output remains non-citable. Schedules, renderings, logs,
+stores, and generated bundles remain under `.scratch/`. Generating a schedule
+is planning evidence, not permission to collect outcomes. The
 [execution gate](EXECUTION.md) records the exact fail-closed boundary.

--- a/test/readability/dune
+++ b/test/readability/dune
@@ -5,6 +5,7 @@
   readability_analysis.py
   readability_comparative.py
   readability_descriptive.py
+  readability_evidence.py
   fixture-manifest.json
   result.schema.json
   model-prompt.txt
@@ -75,6 +76,23 @@
       --authority authority-manifest.template.json
       --input dry-run.jsonl))
     (diff comparative-1.json comparative-2.json)
+    (with-stdout-to rescore-packet-1.json
+     (run %{bin:python3} readability_benchmark.py prepare-rescore
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl
+      --sample-seed ux1-rescore-v1
+      --sample-size 5))
+    (with-stdout-to rescore-packet-2.json
+     (run %{bin:python3} readability_benchmark.py prepare-rescore
+      --manifest fixture-manifest.json
+      --schema result.schema.json
+      --authority authority-manifest.template.json
+      --input dry-run.jsonl
+      --sample-seed ux1-rescore-v1
+      --sample-size 5))
+    (diff rescore-packet-1.json rescore-packet-2.json)
     (with-stdout-to human-schedule.jsonl
      (run %{bin:python3} readability_benchmark.py human-schedule))
     (with-stdout-to model-schedule.jsonl

--- a/test/readability/readability_benchmark.py
+++ b/test/readability/readability_benchmark.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Deterministic readability fixture verifier, planner, scorer, and dry runner.
+"""Deterministic readability planner, scorer, analyzer, and evidence assembler.
 
 The tool uses only the Python standard library.  It never collects participants
-or calls a model.  Its UX.1 schedule commands emit de-identified execution
-plans, not consent or study authority.  Invalid manifests, result rows, or
-fixture evidence fail with a concise message and a nonzero exit status.
+or calls a model.  Its UX.1 schedules and evidence candidates do not create
+consent, study authority, reviewer independence, a readability verdict, or a
+publication claim.  Invalid manifests, rows, or provenance fail with a concise
+message and a nonzero exit status.
 """
 
 from __future__ import annotations
@@ -35,6 +36,20 @@ from readability_descriptive import (
     DescriptiveError,
     encode_descriptive_bundle,
     prepare_descriptive_bundle,
+)
+from readability_evidence import (
+    EVIDENCE_BUNDLE_VERSION,
+    RESCORE_ASSESSMENT_VERSION,
+    RESCORE_PACKET_VERSION,
+    RESCORE_RECORD_VERSION,
+    EvidenceError,
+    encode_evidence_bundle,
+    encode_rescore_packet,
+    encode_rescore_record,
+    prepare_evidence_bundle,
+    prepare_rescore_packet,
+    score_answer,
+    verify_rescore_assessment,
 )
 
 
@@ -745,21 +760,6 @@ def verify_schedule_files(human_path: Path, model_path: Path) -> None:
             raise ProtocolError(
                 f"{label} schedule digest drift: expected {expected_digest}, got {actual_digest}"
             )
-
-
-def score_answer(fixture: dict[str, Any], answer_id: str) -> tuple[bool, str | None]:
-    options = {option["id"] for option in fixture["options"]}
-    if answer_id == "__timeout__":
-        return False, "timeout"
-    if answer_id == "__system_failure__":
-        return False, "system-failure"
-    if answer_id == "__parse_failure__":
-        return False, "prompt-parse-failure"
-    if answer_id not in options:
-        return False, "invalid-answer"
-    if answer_id == fixture["correct_answer"]:
-        return True, None
-    return False, fixture["wrong_answer_errors"][answer_id]
 
 
 def exclusion_codes(subject_kind: str, facts: dict[str, Any], cohort: dict[str, Any]) -> list[str]:
@@ -1802,6 +1802,314 @@ def self_test(
         or '"subject_id"' in synthetic_comparative_bytes
     ):
         raise ProtocolError("comparative bundle bytes or de-identification drifted")
+
+    def rescore_assessment(
+        packet: dict[str, Any], attestation: str | None
+    ) -> dict[str, Any]:
+        indexed = fixture_index(manifest)
+        decisions = []
+        for trial in packet["trials"]:
+            correct, error_code = score_answer(
+                indexed[trial["fixture_id"]], trial["answer_id"]
+            )
+            decisions.append(
+                {
+                    "blind_id": trial["blind_id"],
+                    "correct": correct,
+                    "error_code": error_code,
+                }
+            )
+        return {
+            "assessment_version": RESCORE_ASSESSMENT_VERSION,
+            "decisions": decisions,
+            "independence_attestation_sha256": attestation,
+            "packet_sha256": digest_text(encode_rescore_packet(packet)),
+        }
+
+    def expect_evidence_rejection(
+        label: str, operation: Callable[[], Any]
+    ) -> None:
+        try:
+            operation()
+        except EvidenceError:
+            return
+        raise ProtocolError(f"evidence closure accepted {label}")
+
+    rescore_seed = "ux1-rescore-self-test"
+    synthetic_packet = prepare_rescore_packet(
+        rows,
+        synthetic_digest,
+        synthetic_analysis,
+        manifest,
+        rescore_seed,
+        5,
+    )
+    synthetic_packet_bytes = encode_rescore_packet(synthetic_packet)
+    forbidden_packet_fields = (
+        '"carrier"',
+        '"completion_ms"',
+        '"confidence"',
+        '"correct"',
+        '"error_code"',
+        '"outcome_family"',
+        '"perceived_readability"',
+        '"row_id"',
+        '"subject_id"',
+    )
+    if (
+        synthetic_packet["packet_version"] != RESCORE_PACKET_VERSION
+        or synthetic_packet["evidence_class"] != "synthetic-non-citable"
+        or synthetic_packet["claim_status"] != "not-evaluated"
+        or synthetic_packet["sample"]["requested_row_count"] != 5
+        or len(synthetic_packet["trials"]) != 5
+        or any(field in synthetic_packet_bytes for field in forbidden_packet_fields)
+        or synthetic_packet_bytes
+        != encode_rescore_packet(
+            prepare_rescore_packet(
+                rows,
+                synthetic_digest,
+                synthetic_analysis,
+                manifest,
+                rescore_seed,
+                5,
+            )
+        )
+    ):
+        raise ProtocolError("synthetic rescore packet or blinding contract drifted")
+    if synthetic_packet_bytes == encode_rescore_packet(
+        prepare_rescore_packet(
+            rows,
+            synthetic_digest,
+            synthetic_analysis,
+            manifest,
+            rescore_seed + "-changed",
+            5,
+        )
+    ):
+        raise ProtocolError("rescore packet does not bind its reviewed sample seed")
+
+    synthetic_assessment = rescore_assessment(synthetic_packet, None)
+    synthetic_record = verify_rescore_assessment(
+        synthetic_packet, synthetic_assessment, manifest
+    )
+    if (
+        synthetic_record["record_version"] != RESCORE_RECORD_VERSION
+        or synthetic_record["decision_count"] != 5
+        or synthetic_record["evidence_class"] != "synthetic-non-citable"
+        or synthetic_record["attestation"]["status"]
+        != "not-applicable-synthetic"
+        or synthetic_record["machine_verification"]
+        != "exact-answer-key-agreement"
+    ):
+        raise ProtocolError("synthetic rescore verification boundary drifted")
+
+    synthetic_evidence = prepare_evidence_bundle(
+        rows,
+        synthetic_digest,
+        synthetic_analysis,
+        manifest,
+        rescore_seed,
+        5,
+        synthetic_assessment,
+    )
+    synthetic_evidence_bytes = encode_evidence_bundle(synthetic_evidence)
+    if (
+        synthetic_evidence["bundle_version"] != EVIDENCE_BUNDLE_VERSION
+        or synthetic_evidence["evidence_class"] != "synthetic-non-citable"
+        or synthetic_evidence["claim_status"] != "not-evaluated"
+        or synthetic_evidence["interpretation"]["automatic_product_gate"]
+        != "none"
+        or synthetic_evidence["interpretation"]["minimum_human_count"] is not None
+        or synthetic_evidence_bytes
+        != encode_evidence_bundle(
+            prepare_evidence_bundle(
+                rows,
+                synthetic_digest,
+                synthetic_analysis,
+                manifest,
+                rescore_seed,
+                5,
+                synthetic_assessment,
+            )
+        )
+    ):
+        raise ProtocolError("synthetic evidence bundle determinism or boundary drifted")
+    artifact_encoders: dict[str, Callable[[dict[str, Any]], str]] = {
+        "analysis_input": encode_analysis_bundle,
+        "comparative": encode_comparative_bundle,
+        "descriptive": encode_descriptive_bundle,
+        "rescore_packet": encode_rescore_packet,
+        "rescore_record": encode_rescore_record,
+    }
+    for name, encoder in artifact_encoders.items():
+        artifact = synthetic_evidence["artifacts"][name]
+        if artifact is None or artifact["sha256"] != digest_text(
+            encoder(artifact["value"])
+        ):
+            raise ProtocolError(f"evidence artifact digest drifted: {name}")
+
+    changed_packet_digest = copy.deepcopy(synthetic_assessment)
+    changed_packet_digest["packet_sha256"] = "0" * 64
+    expect_evidence_rejection(
+        "an assessment bound to another packet",
+        lambda: verify_rescore_assessment(
+            synthetic_packet, changed_packet_digest, manifest
+        ),
+    )
+    missing_decision = copy.deepcopy(synthetic_assessment)
+    missing_decision["decisions"].pop()
+    expect_evidence_rejection(
+        "an incomplete blinded assessment",
+        lambda: verify_rescore_assessment(
+            synthetic_packet, missing_decision, manifest
+        ),
+    )
+    duplicate_decision = copy.deepcopy(synthetic_assessment)
+    duplicate_decision["decisions"][1] = copy.deepcopy(
+        duplicate_decision["decisions"][0]
+    )
+    expect_evidence_rejection(
+        "a duplicated blinded decision",
+        lambda: verify_rescore_assessment(
+            synthetic_packet, duplicate_decision, manifest
+        ),
+    )
+    substituted_decision = copy.deepcopy(synthetic_assessment)
+    substituted_decision["decisions"][0]["blind_id"] = "f" * 64
+    expect_evidence_rejection(
+        "a substituted blinded decision",
+        lambda: verify_rescore_assessment(
+            synthetic_packet, substituted_decision, manifest
+        ),
+    )
+    reordered_decisions = copy.deepcopy(synthetic_assessment)
+    reordered_decisions["decisions"][0], reordered_decisions["decisions"][1] = (
+        reordered_decisions["decisions"][1],
+        reordered_decisions["decisions"][0],
+    )
+    expect_evidence_rejection(
+        "reordered blinded decisions",
+        lambda: verify_rescore_assessment(
+            synthetic_packet, reordered_decisions, manifest
+        ),
+    )
+    wrong_score = copy.deepcopy(synthetic_assessment)
+    wrong_score["decisions"][0]["correct"] = not wrong_score["decisions"][0][
+        "correct"
+    ]
+    expect_evidence_rejection(
+        "a rescore that disagrees with the answer key",
+        lambda: verify_rescore_assessment(synthetic_packet, wrong_score, manifest),
+    )
+    false_synthetic_attestation = copy.deepcopy(synthetic_assessment)
+    false_synthetic_attestation["independence_attestation_sha256"] = digest_text(
+        "not-a-real-independent-review"
+    )
+    expect_evidence_rejection(
+        "a synthetic independence assertion",
+        lambda: verify_rescore_assessment(
+            synthetic_packet, false_synthetic_attestation, manifest
+        ),
+    )
+    malformed_packet = copy.deepcopy(synthetic_packet)
+    del malformed_packet["source"]["fixture_manifest_sha256"]
+    malformed_packet_assessment = rescore_assessment(malformed_packet, None)
+    expect_evidence_rejection(
+        "a packet with incomplete source provenance",
+        lambda: verify_rescore_assessment(
+            malformed_packet, malformed_packet_assessment, manifest
+        ),
+    )
+    expect_evidence_rejection(
+        "a zero-sized rescore sample",
+        lambda: prepare_rescore_packet(
+            rows,
+            synthetic_digest,
+            synthetic_analysis,
+            manifest,
+            rescore_seed,
+            0,
+        ),
+    )
+    expect_evidence_rejection(
+        "a rescore sample larger than the effective store",
+        lambda: prepare_rescore_packet(
+            rows,
+            synthetic_digest,
+            synthetic_analysis,
+            manifest,
+            rescore_seed,
+            16,
+        ),
+    )
+    expect_evidence_rejection(
+        "an evidence assessment reused under another sample seed",
+        lambda: prepare_evidence_bundle(
+            rows,
+            synthetic_digest,
+            synthetic_analysis,
+            manifest,
+            rescore_seed + "-changed",
+            5,
+            synthetic_assessment,
+        ),
+    )
+    expect_evidence_rejection(
+        "an evidence assessment reused under another sample count",
+        lambda: prepare_evidence_bundle(
+            rows,
+            synthetic_digest,
+            synthetic_analysis,
+            manifest,
+            rescore_seed,
+            4,
+            synthetic_assessment,
+        ),
+    )
+    expect_evidence_rejection(
+        "a rescore packet paired with a different source digest",
+        lambda: prepare_rescore_packet(
+            rows,
+            digest_text(synthetic_jsonl + "\n"),
+            synthetic_analysis,
+            manifest,
+            rescore_seed,
+            5,
+        ),
+    )
+
+    human_digest = digest_text(encode_jsonl(human_store))
+    human_analysis = prepare_analysis_bundle(human_store, human_digest)
+    human_packet = prepare_rescore_packet(
+        human_store,
+        human_digest,
+        human_analysis,
+        manifest,
+        rescore_seed,
+        5,
+    )
+    unattested_human_assessment = rescore_assessment(human_packet, None)
+    expect_evidence_rejection(
+        "real candidate rescoring without external independence evidence",
+        lambda: verify_rescore_assessment(
+            human_packet, unattested_human_assessment, manifest
+        ),
+    )
+    attested_human_assessment = rescore_assessment(
+        human_packet, digest_text("self-test-independent-review-attestation")
+    )
+    human_rescore_record = verify_rescore_assessment(
+        human_packet, attested_human_assessment, manifest
+    )
+    if (
+        human_rescore_record["evidence_class"] != "human-candidate"
+        or human_rescore_record["attestation"]["status"]
+        != "external-attestation-present-not-machine-verified"
+        or human_rescore_record["reviewer_independence"]
+        != "external-fact-not-machine-proven"
+    ):
+        raise ProtocolError("real rescore attestation boundary drifted")
+
     mismatched_analysis = copy.deepcopy(synthetic_analysis)
     mismatched_analysis["source"]["input_jsonl_sha256"] = digest_text(
         synthetic_jsonl + "\n"
@@ -2183,6 +2491,33 @@ def self_test(
         != expected_model_count
     ):
         raise ProtocolError("model descriptive tables were not kept cohort-separate")
+    model_digest = digest_text(encode_jsonl(model_store))
+    model_packet = prepare_rescore_packet(
+        model_store,
+        model_digest,
+        clean_model_analysis,
+        manifest,
+        rescore_seed,
+        5,
+    )
+    model_assessment = rescore_assessment(
+        model_packet, digest_text("self-test-model-independent-rescore")
+    )
+    model_evidence = prepare_evidence_bundle(
+        model_store,
+        model_digest,
+        clean_model_analysis,
+        manifest,
+        rescore_seed,
+        5,
+        model_assessment,
+    )
+    if (
+        model_evidence["evidence_class"] != "model-candidate"
+        or model_evidence["subject_kind"] != "model"
+        or model_evidence["artifacts"]["comparative"] is not None
+    ):
+        raise ProtocolError("model evidence entered the human comparison bundle")
     try:
         prepare_comparative_bundle(
             model_store,
@@ -2743,6 +3078,29 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     comparative.add_argument("--cohort", type=Path)
     comparative.add_argument("--authority", type=Path, required=True)
 
+    rescore = commands.add_parser(
+        "prepare-rescore",
+        help="emit an outcome-blinded deterministic sample from effective rows",
+    )
+    add_common_paths(rescore)
+    rescore.add_argument("--input", type=Path, required=True)
+    rescore.add_argument("--cohort", type=Path)
+    rescore.add_argument("--authority", type=Path, required=True)
+    rescore.add_argument("--sample-seed", required=True)
+    rescore.add_argument("--sample-size", type=int, required=True)
+
+    evidence = commands.add_parser(
+        "assemble-evidence",
+        help="verify a blinded rescore and emit one checked evidence candidate",
+    )
+    add_common_paths(evidence)
+    evidence.add_argument("--input", type=Path, required=True)
+    evidence.add_argument("--cohort", type=Path)
+    evidence.add_argument("--authority", type=Path, required=True)
+    evidence.add_argument("--sample-seed", required=True)
+    evidence.add_argument("--sample-size", type=int, required=True)
+    evidence.add_argument("--assessment", type=Path, required=True)
+
     assign = commands.add_parser(
         "assign", help="debug one seeded assignment; admitted rows always use the frozen seed"
     )
@@ -2843,6 +3201,8 @@ def main(argv: Iterable[str]) -> int:
             "prepare-analysis",
             "analyze-descriptive",
             "analyze-comparative",
+            "prepare-rescore",
+            "assemble-evidence",
         }:
             authority = load_json(args.authority)
             verify_authority_manifest(authority)
@@ -2884,6 +3244,38 @@ def main(argv: Iterable[str]) -> int:
                     )
                 )
                 return 0
+            if args.command == "prepare-rescore":
+                analysis_input = prepare_analysis_bundle(rows, input_sha256)
+                sys.stdout.write(
+                    encode_rescore_packet(
+                        prepare_rescore_packet(
+                            rows,
+                            input_sha256,
+                            analysis_input,
+                            manifest,
+                            args.sample_seed,
+                            args.sample_size,
+                        )
+                    )
+                )
+                return 0
+            if args.command == "assemble-evidence":
+                analysis_input = prepare_analysis_bundle(rows, input_sha256)
+                assessment = load_json(args.assessment)
+                sys.stdout.write(
+                    encode_evidence_bundle(
+                        prepare_evidence_bundle(
+                            rows,
+                            input_sha256,
+                            analysis_input,
+                            manifest,
+                            args.sample_seed,
+                            args.sample_size,
+                            assessment,
+                        )
+                    )
+                )
+                return 0
             print(f"validated {count} rows across {len(conditions)} conditions")
             return 0
         if args.command == "verify":
@@ -2908,6 +3300,7 @@ def main(argv: Iterable[str]) -> int:
         AnalysisError,
         ComparativeError,
         DescriptiveError,
+        EvidenceError,
     ) as error:
         print(f"readability protocol: FAIL: {error}", file=sys.stderr)
         return 1

--- a/test/readability/readability_evidence.py
+++ b/test/readability/readability_evidence.py
@@ -1,0 +1,612 @@
+"""Blinded rescoring and publication lineage for checked readability evidence.
+
+The public entry points consume rows only after complete result-store
+validation and require the exact ``readability-analysis-input-v1`` selection.
+They can prepare an outcome-blinded rescore packet, verify a returned
+assessment against the frozen answer key, and assemble one deterministic
+candidate-evidence bundle.  They do not collect data, prove reviewer
+independence, authorize publication, or create a readability verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+from readability_analysis import (
+    AnalysisError,
+    encode_analysis_bundle,
+    prepare_analysis_bundle,
+)
+from readability_comparative import (
+    ComparativeError,
+    encode_comparative_bundle,
+    prepare_comparative_bundle,
+)
+from readability_descriptive import (
+    DescriptiveError,
+    encode_descriptive_bundle,
+    prepare_descriptive_bundle,
+)
+
+
+RESCORE_PACKET_VERSION = "readability-rescore-packet-v1"
+RESCORE_ASSESSMENT_VERSION = "readability-rescore-assessment-v1"
+RESCORE_RECORD_VERSION = "readability-rescore-record-v1"
+EVIDENCE_BUNDLE_VERSION = "readability-evidence-bundle-v1"
+HEX_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+class EvidenceError(RuntimeError):
+    """Raised when checked evidence cannot form one exact closure artifact."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _encode(value: dict[str, Any]) -> str:
+    return _canonical_json(value) + "\n"
+
+
+def encode_rescore_packet(packet: dict[str, Any]) -> str:
+    """Return canonical, timestamp-free JSON for a blinded rescore packet."""
+
+    return _encode(packet)
+
+
+def encode_rescore_record(record: dict[str, Any]) -> str:
+    """Return canonical JSON for an answer-key-verified rescore record."""
+
+    return _encode(record)
+
+
+def encode_evidence_bundle(bundle: dict[str, Any]) -> str:
+    """Return canonical JSON for a provenance-complete evidence candidate."""
+
+    return _encode(bundle)
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return _sha256_bytes(value.encode("utf-8"))
+
+
+def _encoded_sha256(encoded: str) -> str:
+    return _sha256_bytes(encoded.encode("utf-8"))
+
+
+def _field(value: dict[str, Any], name: str, context: str) -> Any:
+    if name not in value:
+        raise EvidenceError(f"{context} is missing required field: {name}")
+    return value[name]
+
+
+def _require_sha256(value: Any, context: str) -> str:
+    if not isinstance(value, str) or HEX_SHA256.fullmatch(value) is None:
+        raise EvidenceError(f"{context} must be a lowercase SHA-256")
+    return value
+
+
+def _fixture_index(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    fixtures = manifest.get("fixtures") if isinstance(manifest, dict) else None
+    if not isinstance(fixtures, list) or not fixtures:
+        raise EvidenceError("rescore fixture manifest has no fixtures")
+    indexed: dict[str, dict[str, Any]] = {}
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            raise EvidenceError("rescore fixture entries must be objects")
+        fixture_id = fixture.get("id")
+        if not isinstance(fixture_id, str) or not fixture_id:
+            raise EvidenceError("rescore fixture ID must be a nonempty string")
+        if fixture_id in indexed:
+            raise EvidenceError(f"rescore fixture ID is duplicated: {fixture_id}")
+        indexed[fixture_id] = fixture
+    return indexed
+
+
+def score_answer(fixture: dict[str, Any], answer_id: str) -> tuple[bool, str | None]:
+    """Score one opaque answer ID against a verified fixture answer key.
+
+    Reserved failure sentinels retain their protocol meanings.  A non-option
+    answer is ``invalid-answer``.  Malformed fixture data raises
+    :class:`EvidenceError`; no answer receives a partial or guessed score.
+    """
+
+    options = fixture.get("options") if isinstance(fixture, dict) else None
+    correct_answer = (
+        fixture.get("correct_answer") if isinstance(fixture, dict) else None
+    )
+    wrong_errors = (
+        fixture.get("wrong_answer_errors") if isinstance(fixture, dict) else None
+    )
+    if (
+        not isinstance(options, list)
+        or not isinstance(correct_answer, str)
+        or not isinstance(wrong_errors, dict)
+        or not isinstance(answer_id, str)
+    ):
+        raise EvidenceError("rescore answer key or submitted answer is malformed")
+    option_ids = {
+        option.get("id")
+        for option in options
+        if isinstance(option, dict) and isinstance(option.get("id"), str)
+    }
+    if len(option_ids) != len(options) or correct_answer not in option_ids:
+        raise EvidenceError("rescore answer-key option inventory is malformed")
+    if answer_id == "__timeout__":
+        return False, "timeout"
+    if answer_id == "__system_failure__":
+        return False, "system-failure"
+    if answer_id == "__parse_failure__":
+        return False, "prompt-parse-failure"
+    if answer_id not in option_ids:
+        return False, "invalid-answer"
+    if answer_id == correct_answer:
+        return True, None
+    error_code = wrong_errors.get(answer_id)
+    if not isinstance(error_code, str) or not error_code:
+        raise EvidenceError("rescore wrong-answer taxonomy is incomplete")
+    return False, error_code
+
+
+def _exact_analysis(
+    rows: list[dict[str, Any]], input_sha256: str, analysis: dict[str, Any]
+) -> dict[str, Any]:
+    if not isinstance(rows, list) or not rows or any(
+        not isinstance(row, dict) for row in rows
+    ):
+        raise EvidenceError("rescore requires one validated nonempty object store")
+    _require_sha256(input_sha256, "rescore source digest")
+    if not isinstance(analysis, dict):
+        raise EvidenceError("rescore analysis input must be an object")
+    try:
+        expected = prepare_analysis_bundle(rows, input_sha256)
+    except AnalysisError as error:
+        raise EvidenceError(f"rescore cannot reproduce analysis input: {error}") from error
+    if encode_analysis_bundle(analysis) != encode_analysis_bundle(expected):
+        raise EvidenceError("rescore analysis input is not the exact derived bundle")
+    return expected
+
+
+def _effective_rows(
+    rows: list[dict[str, Any]], analysis: dict[str, Any]
+) -> list[dict[str, Any]]:
+    decisions = analysis.get("subjects")
+    if not isinstance(decisions, list):
+        raise EvidenceError("rescore analysis lacks subject decisions")
+    effective_ids: list[str] = []
+    for decision in decisions:
+        values = (
+            decision.get("effective_row_ids")
+            if isinstance(decision, dict)
+            else None
+        )
+        if not isinstance(values, list):
+            raise EvidenceError("rescore subject decision has malformed effective rows")
+        for row_id in values:
+            effective_ids.append(_require_sha256(row_id, "rescore effective row ID"))
+    if len(effective_ids) != len(set(effective_ids)):
+        raise EvidenceError("rescore effective row IDs are duplicated")
+    row_by_id: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        row_id = _require_sha256(row.get("row_id"), "rescore source row ID")
+        if row_id in row_by_id:
+            raise EvidenceError("rescore source row IDs are duplicated")
+        row_by_id[row_id] = row
+    if any(row_id not in row_by_id for row_id in effective_ids):
+        raise EvidenceError("rescore effective selection names an absent source row")
+    return [row_by_id[row_id] for row_id in effective_ids]
+
+
+def _rank(sample_seed: str, row_id: str) -> str:
+    return _sha256_text(
+        f"{RESCORE_PACKET_VERSION}\0rank\0{sample_seed}\0{row_id}"
+    )
+
+
+def _blind_id(sample_seed: str, row_id: str) -> str:
+    return _sha256_text(
+        f"{RESCORE_PACKET_VERSION}\0blind\0{sample_seed}\0{row_id}"
+    )
+
+
+def prepare_rescore_packet(
+    rows: list[dict[str, Any]],
+    input_sha256: str,
+    analysis: dict[str, Any],
+    manifest: dict[str, Any],
+    sample_seed: str,
+    sample_size: int,
+) -> dict[str, Any]:
+    """Prepare one deterministic, outcome-blinded independent-rescore packet.
+
+    The caller supplies a previously reviewed seed and positive sample count;
+    this function deliberately chooses neither.  Selection ranks exact
+    effective row IDs with domain-separated SHA-256.  Packet trials expose
+    only opaque blind IDs, fixture IDs, and submitted answer IDs.  Carrier,
+    subject/source row identity, original score, time, confidence, rating, and
+    outcome fields are omitted.  Invalid provenance or an oversized sample
+    raises :class:`EvidenceError`.
+    """
+
+    exact_analysis = _exact_analysis(rows, input_sha256, analysis)
+    if not isinstance(sample_seed, str) or not sample_seed:
+        raise EvidenceError("rescore sample seed must be a nonempty string")
+    if (
+        isinstance(sample_size, bool)
+        or not isinstance(sample_size, int)
+        or sample_size < 1
+    ):
+        raise EvidenceError("rescore sample size must be a positive integer")
+    indexed = _fixture_index(manifest)
+    effective = _effective_rows(rows, exact_analysis)
+    if sample_size > len(effective):
+        raise EvidenceError(
+            "rescore sample size exceeds the validated effective-row count"
+        )
+    ranked = sorted(
+        effective,
+        key=lambda row: (
+            _rank(sample_seed, _field(row, "row_id", "rescore row")),
+            _field(row, "row_id", "rescore row"),
+        ),
+    )
+    trials: list[dict[str, Any]] = []
+    for row in ranked[:sample_size]:
+        row_id = _require_sha256(row.get("row_id"), "rescore selected row ID")
+        fixture_id = _field(row, "fixture_id", "rescore selected row")
+        answer_id = _field(row, "answer_id", "rescore selected row")
+        if fixture_id not in indexed or not isinstance(answer_id, str):
+            raise EvidenceError("rescore selected row disagrees with the fixture manifest")
+        trials.append(
+            {
+                "answer_id": answer_id,
+                "blind_id": _blind_id(sample_seed, row_id),
+                "fixture_id": fixture_id,
+            }
+        )
+    blind_ids = [trial["blind_id"] for trial in trials]
+    if len(blind_ids) != len(set(blind_ids)):
+        raise EvidenceError("rescore blind IDs collided")
+    effective_ids = [row["row_id"] for row in effective]
+    source = exact_analysis.get("source")
+    if not isinstance(source, dict):
+        raise EvidenceError("rescore analysis source is malformed")
+    return {
+        "claim_status": "not-evaluated",
+        "evidence_class": exact_analysis.get("evidence_class"),
+        "packet_scope": "outcome-blinded-answer-rescore",
+        "packet_version": RESCORE_PACKET_VERSION,
+        "protocol_version": exact_analysis.get("protocol_version"),
+        "sample": {
+            "effective_row_count": len(effective),
+            "requested_row_count": sample_size,
+            "sample_seed_sha256": _sha256_text(
+                f"{RESCORE_PACKET_VERSION}\0seed\0{sample_seed}"
+            ),
+            "selection_rule": "sha256-rank-over-effective-row-id-v1",
+        },
+        "source": {
+            "analysis_input_sha256": _encoded_sha256(
+                encode_analysis_bundle(exact_analysis)
+            ),
+            "effective_row_sequence_sha256": _sha256_text(
+                "\n".join(effective_ids) + "\n"
+            ),
+            "fixture_manifest_sha256": source.get("fixture_manifest_sha256"),
+            "input_jsonl_sha256": input_sha256,
+        },
+        "subject_kind": exact_analysis.get("subject_kind"),
+        "trials": trials,
+    }
+
+
+def _strict_assessment(assessment: dict[str, Any]) -> None:
+    expected = {
+        "assessment_version",
+        "decisions",
+        "independence_attestation_sha256",
+        "packet_sha256",
+    }
+    if not isinstance(assessment, dict) or set(assessment) != expected:
+        raise EvidenceError("rescore assessment field inventory is malformed")
+    if assessment.get("assessment_version") != RESCORE_ASSESSMENT_VERSION:
+        raise EvidenceError("rescore assessment version drifted")
+    _require_sha256(
+        assessment.get("packet_sha256"), "rescore assessment packet digest"
+    )
+    decisions = assessment.get("decisions")
+    if not isinstance(decisions, list):
+        raise EvidenceError("rescore assessment decisions must be a list")
+
+
+def _strict_packet(packet: dict[str, Any]) -> None:
+    expected = {
+        "claim_status",
+        "evidence_class",
+        "packet_scope",
+        "packet_version",
+        "protocol_version",
+        "sample",
+        "source",
+        "subject_kind",
+        "trials",
+    }
+    if not isinstance(packet, dict) or set(packet) != expected:
+        raise EvidenceError("rescore packet field inventory is malformed")
+    if (
+        packet.get("packet_version") != RESCORE_PACKET_VERSION
+        or packet.get("protocol_version") != "readability-protocol-v1"
+        or packet.get("packet_scope") != "outcome-blinded-answer-rescore"
+        or packet.get("claim_status") != "not-evaluated"
+    ):
+        raise EvidenceError("rescore packet contract or version drifted")
+    expected_classes = {
+        "human": "human-candidate",
+        "model": "model-candidate",
+        "synthetic": "synthetic-non-citable",
+    }
+    subject_kind = packet.get("subject_kind")
+    if expected_classes.get(subject_kind) != packet.get("evidence_class"):
+        raise EvidenceError("rescore subject kind and evidence class disagree")
+    sample = packet.get("sample")
+    if not isinstance(sample, dict) or set(sample) != {
+        "effective_row_count",
+        "requested_row_count",
+        "sample_seed_sha256",
+        "selection_rule",
+    }:
+        raise EvidenceError("rescore packet sample metadata is malformed")
+    effective_count = sample.get("effective_row_count")
+    requested_count = sample.get("requested_row_count")
+    if (
+        isinstance(effective_count, bool)
+        or not isinstance(effective_count, int)
+        or isinstance(requested_count, bool)
+        or not isinstance(requested_count, int)
+        or requested_count < 1
+        or effective_count < requested_count
+        or sample.get("selection_rule")
+        != "sha256-rank-over-effective-row-id-v1"
+    ):
+        raise EvidenceError("rescore packet sample counts or selection rule drifted")
+    _require_sha256(sample.get("sample_seed_sha256"), "rescore sample seed digest")
+    source = packet.get("source")
+    if not isinstance(source, dict) or set(source) != {
+        "analysis_input_sha256",
+        "effective_row_sequence_sha256",
+        "fixture_manifest_sha256",
+        "input_jsonl_sha256",
+    }:
+        raise EvidenceError("rescore packet source metadata is malformed")
+    for name, value in source.items():
+        _require_sha256(value, f"rescore packet {name}")
+    trials = packet.get("trials")
+    if not isinstance(trials, list) or len(trials) != requested_count:
+        raise EvidenceError("rescore packet trial count disagrees with its sample")
+
+
+def verify_rescore_assessment(
+    packet: dict[str, Any],
+    assessment: dict[str, Any],
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    """Verify a returned blinded assessment against the frozen answer key.
+
+    Real candidate evidence requires a SHA-256 binding separately retained
+    reviewer-independence evidence.  The hash proves only byte binding: this
+    function explicitly does not prove the reviewer's identity or
+    independence.  Synthetic assessments must leave that field null and stay
+    non-citable.  Every decision must preserve packet order and agree exactly
+    with the answer key or the whole record is refused.
+    """
+
+    _strict_packet(packet)
+    _strict_assessment(assessment)
+    packet_sha256 = _encoded_sha256(encode_rescore_packet(packet))
+    if assessment.get("packet_sha256") != packet_sha256:
+        raise EvidenceError("rescore assessment is bound to a different packet")
+    evidence_class = packet.get("evidence_class")
+    attestation = assessment.get("independence_attestation_sha256")
+    if evidence_class == "synthetic-non-citable":
+        if attestation is not None:
+            raise EvidenceError("synthetic rescoring cannot assert reviewer independence")
+        attestation_status = "not-applicable-synthetic"
+    else:
+        _require_sha256(attestation, "rescore independence attestation digest")
+        attestation_status = "external-attestation-present-not-machine-verified"
+
+    trials = packet.get("trials")
+    decisions = assessment.get("decisions")
+    if not isinstance(trials, list) or len(trials) != len(decisions):
+        raise EvidenceError("rescore assessment does not cover every packet trial")
+    indexed = _fixture_index(manifest)
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for trial, decision in zip(trials, decisions, strict=True):
+        if not isinstance(trial, dict) or set(trial) != {
+            "answer_id",
+            "blind_id",
+            "fixture_id",
+        }:
+            raise EvidenceError("rescore packet trial field inventory is malformed")
+        if not isinstance(decision, dict) or set(decision) != {
+            "blind_id",
+            "correct",
+            "error_code",
+        }:
+            raise EvidenceError("rescore decision field inventory is malformed")
+        blind_id = _require_sha256(trial.get("blind_id"), "rescore blind ID")
+        if blind_id in seen or decision.get("blind_id") != blind_id:
+            raise EvidenceError("rescore decisions are duplicated, missing, or reordered")
+        seen.add(blind_id)
+        fixture_id = trial.get("fixture_id")
+        answer_id = trial.get("answer_id")
+        if fixture_id not in indexed or not isinstance(answer_id, str):
+            raise EvidenceError("rescore packet trial has an unknown fixture or answer")
+        expected_correct, expected_error = score_answer(
+            indexed[fixture_id], answer_id
+        )
+        correct = decision.get("correct")
+        error_code = decision.get("error_code")
+        if not isinstance(correct, bool) or (
+            error_code is not None and not isinstance(error_code, str)
+        ):
+            raise EvidenceError("rescore decision score fields are malformed")
+        if correct != expected_correct or error_code != expected_error:
+            raise EvidenceError("rescore decision disagrees with the frozen answer key")
+        normalized.append(
+            {
+                "blind_id": blind_id,
+                "correct": correct,
+                "error_code": error_code,
+            }
+        )
+
+    normalized_assessment = {
+        "assessment_version": RESCORE_ASSESSMENT_VERSION,
+        "decisions": normalized,
+        "independence_attestation_sha256": attestation,
+        "packet_sha256": packet_sha256,
+    }
+    return {
+        "assessment_sha256": _sha256_text(_encode(normalized_assessment)),
+        "attestation": {
+            "independence_evidence_sha256": attestation,
+            "status": attestation_status,
+        },
+        "claim_status": "not-evaluated",
+        "decision_count": len(normalized),
+        "decisions_sha256": _sha256_text(_canonical_json(normalized)),
+        "evidence_class": evidence_class,
+        "machine_verification": "exact-answer-key-agreement",
+        "packet_sha256": packet_sha256,
+        "record_version": RESCORE_RECORD_VERSION,
+        "reviewer_independence": (
+            "not-applicable-synthetic"
+            if evidence_class == "synthetic-non-citable"
+            else "external-fact-not-machine-proven"
+        ),
+        "sample": json.loads(_canonical_json(packet.get("sample"))),
+    }
+
+
+def _artifact(encoded: str, value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "sha256": _encoded_sha256(encoded),
+        "value": json.loads(_canonical_json(value)),
+    }
+
+
+def prepare_evidence_bundle(
+    rows: list[dict[str, Any]],
+    input_sha256: str,
+    analysis: dict[str, Any],
+    manifest: dict[str, Any],
+    sample_seed: str,
+    sample_size: int,
+    assessment: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble one deterministic, provenance-complete evidence candidate.
+
+    The bundle regenerates descriptive tables and the applicable human carrier
+    comparison from the exact admitted source and embeds them with canonical
+    byte digests.  A model bundle remains descriptive and cannot enter the
+    human comparison.  The rescore record must agree with the frozen answer
+    key.  The returned object remains ``not-evaluated`` and requires external
+    publication authority, reviewer-independence validation, and honest
+    interpretation before any measured claim can be made.
+    """
+
+    exact_analysis = _exact_analysis(rows, input_sha256, analysis)
+    try:
+        descriptive = prepare_descriptive_bundle(
+            rows, input_sha256, exact_analysis
+        )
+    except DescriptiveError as error:
+        raise EvidenceError(
+            f"evidence bundle cannot derive descriptive tables: {error}"
+        ) from error
+    subject_kind = exact_analysis.get("subject_kind")
+    comparative: dict[str, Any] | None
+    if subject_kind == "model":
+        comparative = None
+    else:
+        try:
+            comparative = prepare_comparative_bundle(
+                rows, input_sha256, exact_analysis
+            )
+        except ComparativeError as error:
+            raise EvidenceError(
+                f"evidence bundle cannot derive carrier comparison: {error}"
+            ) from error
+    packet = prepare_rescore_packet(
+        rows,
+        input_sha256,
+        exact_analysis,
+        manifest,
+        sample_seed,
+        sample_size,
+    )
+    rescore = verify_rescore_assessment(packet, assessment, manifest)
+
+    artifacts: dict[str, Any] = {
+        "analysis_input": _artifact(
+            encode_analysis_bundle(exact_analysis), exact_analysis
+        ),
+        "descriptive": _artifact(
+            encode_descriptive_bundle(descriptive), descriptive
+        ),
+        "rescore_packet": _artifact(encode_rescore_packet(packet), packet),
+        "rescore_record": _artifact(encode_rescore_record(rescore), rescore),
+    }
+    artifacts["comparative"] = (
+        None
+        if comparative is None
+        else _artifact(encode_comparative_bundle(comparative), comparative)
+    )
+    return {
+        "artifacts": artifacts,
+        "bundle_scope": "checked-readability-evidence-candidate",
+        "bundle_version": EVIDENCE_BUNDLE_VERSION,
+        "claim_status": "not-evaluated",
+        "evidence_class": exact_analysis.get("evidence_class"),
+        "interpretation": {
+            "automatic_product_gate": "none",
+            "external_required": [
+                "reviewer-identity-and-independence-validation",
+                "publication-authority-and-license",
+                "actual-sample-exclusions-uncertainty-and-limitations",
+            ],
+            "machine_verified_scope": (
+                "exact embedded artifact bytes derive from the admitted source; "
+                "rescore decisions agree with the frozen answer key"
+            ),
+            "minimum_human_count": None,
+            "prose_number_rule": (
+                "external prose is outside this verification unless it cites this "
+                "exact bundle and JSON path"
+            ),
+        },
+        "protocol_version": exact_analysis.get("protocol_version"),
+        "source": {
+            "fixture_manifest_sha256": exact_analysis.get("source", {}).get(
+                "fixture_manifest_sha256"
+            ),
+            "input_jsonl_sha256": input_sha256,
+            "source_row_count": len(rows),
+        },
+        "subject_kind": subject_kind,
+    }


### PR DESCRIPTION
## Context

The readability benchmark could already admit checked result stores and produce descriptive and `.jac`/`.jqd` comparison summaries. It could not yet hand a second reviewer an outcome-blinded sample or package every reported number with exact source-byte lineage.

No human or model outcomes exist. This change finishes those mechanics without pretending a study happened and without making readability research a language or release gate.

## What changed

- Added a deterministic blinded-rescore packet over validated effective rows. A reviewed caller supplies the seed and positive sample count; the tool does not choose a threshold.
- Added strict assessment verification against the frozen answer key. Real candidate evidence must bind a separately retained independence attestation, while the output states that software cannot prove the reviewer's identity or independence.
- Added one atomic evidence candidate that internally regenerates the analysis, packet, tables, applicable human comparison, and rescore record, then embeds every canonical object with its SHA-256.
- Kept model bundles descriptive and separate from the human `.jac`/`.jqd` comparison.
- Added CLI commands, deterministic Dune exercises, adversarial mutation coverage, and plain-language protocol/execution documentation.

## Contract and limits

- Complete existing store admission and exact analyzability selection run first.
- Packet trials expose only an opaque blind ID, fixture ID, and submitted answer ID; carrier, subject/row identity, prior score, timing, confidence, ratings, and outcomes are omitted.
- Missing, duplicated, reordered, substituted, wrongly scored, or cross-packet decisions fail closed.
- Synthetic output remains non-citable. Every bundle remains `not-evaluated` and has no automatic verdict or minimum human count.
- The historical 141-person figure remains power-planning context only. It is not a prerequisite for language ideas, implementation, or release work.
- Actual collection, a real independent reviewer, publication authority/license, and honest interpretation remain external. Numbers copied into prose need an exact bundle and JSON-path citation or separate lineage.

This does not change Jacquard syntax or semantics, the result schema, fixtures, schedules, admission rules, estimators, release claims, HASH_V0 identity, or the 27-form kernel.

## Validation

Exact head: `3f75f464f10537cce27f38bd79e891cf184bd8ca`

- regression-first focused gate: failed because the evidence module was absent;
- readability protocol gate: passed all five jobs, 15 synthetic conditions, 480 human assignments, and 450 M0 model trials;
- duplicate packet SHA-256: `c7deef22477d8651c98d6c45238766a8a053cb81f64d29ef41802c5573cca685`;
- duplicate assembled candidate SHA-256 through the real CLI: `ffef15d90b2ea1970738d875d4e6c01cfc3c35822b0aedcaa5d3a3555f1c9fcd`;
- historical-manifest attestation and its mutation suite: passed;
- clean `dune build @all`: passed;
- full sanitizer-bearing `dune runtest`: passed, 847 tests in 324.8s;
- `dune fmt` with a clean diff, version `0.1.0`, and `dune build @doc`: passed.

Independent Fable 5 review of the exact head: `PASS`, with no blockers, architecture conflicts, or disputed reruns. The 1,202-line diff is one fail-closed contract: splitting generation from verification/assembly would put a misleading half-capability on `main`.

Closes #86.
