### PR TITLE
Add canonical interpreter run transcripts

### DIFF
--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,8 +6,8 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `847`
-- Cram transcript files: `51`
+- Alcotest/QCheck cases: `853`
+- Cram transcript files: `52`
 - Doctest examples: `28` across 8 documents
 
 The test count includes six DX.2 filesystem-boundary cases and six DX.5/DX.7

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -759,8 +759,8 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `847`
-- Cram transcript files: `51`
+- Alcotest/QCheck cases: `853`
+- Cram transcript files: `52`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
 `channel-contract` cases plus the `store/9` Channel-private-hash case took the

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -116,6 +116,7 @@ type mutable_graph_snapshot = {
 type mutable_snapshot = { snapshot_root : Value.t; snapshot_graph : mutable_graph_snapshot }
 type native_snapshot_entry = { snapshot : mutable_snapshot; mutable last_used : int }
 type native_snapshot_lru = { entries : native_snapshot_entry option array; mutable clock : int }
+type root_observer = { on_operation : Hash.t -> unit; on_output : Hash.t -> string -> unit }
 
 type ctx = {
   store : Store.t;
@@ -141,6 +142,8 @@ type ctx = {
   root_handlers : (Hash.t, Value.t list -> (Value.t, Runtime_err.t) result) Hashtbl.t;
       (** op hash -> granted native handler; shallow (the op resumes exactly once with the native
           result), installed only by explicit grants *)
+  mutable root_observer : root_observer option;
+      (** disabled-by-default, dynamically scoped recorder seam for root-reaching operations *)
   mutable capture_ops : bool;
       (** when set (by {!run_state_capturing}), an op that reaches the root with no handler and no
           grant is CAPTURED — returned with its continuation — instead of dying [Unhandled]; this is
@@ -182,6 +185,7 @@ let make_ctx store =
     evaluator_mutable_snapshots = Hashtbl.create 64;
     native_mutable_snapshots = { entries = Array.make 64 None; clock = 0 };
     root_handlers = Hashtbl.create 8;
+    root_observer = None;
     capture_ops = false;
     capture_root_handlers = false;
     track_coverage = true;
@@ -330,6 +334,19 @@ let reject_task_escape ctx ~scope_path root =
 (** [register_root_handler ctx op handler] installs one explicitly granted root handler. Arguments,
     continuation state, callback mutation, and callback results are guarded at dispatch time. *)
 let register_root_handler ctx op handler = Hashtbl.replace ctx.root_handlers op handler
+
+(** [with_root_observer] scopes a root-operation observer to one caller-controlled evaluation
+    extent. The saved observer is restored even across an internal runtime exception. *)
+let with_root_observer ctx ~on_operation ~on_output operation =
+  let previous = ctx.root_observer in
+  ctx.root_observer <- Some { on_operation; on_output };
+  Fun.protect ~finally:(fun () -> ctx.root_observer <- previous) operation
+
+let note_root_output ctx ~operation bytes =
+  match ctx.root_observer with Some { on_output; _ } -> on_output operation bytes | None -> ()
+
+let notify_root_operation ctx operation =
+  match ctx.root_observer with None -> () | Some observer -> observer.on_operation operation
 
 (** [set_coverage_tracking ctx enabled] controls semantic term-reference collection. Disabling it
     avoids bookkeeping when callers will not inspect coverage. *)
@@ -939,6 +956,7 @@ let perform_unchecked ctx (op : Hash.t) ~name ~effect_ (args : Value.t list) (k 
         SEval ({ h.hscope with env }, obody, outer)
     | f :: outer -> split (f :: inner_rev) outer
     | [] -> (
+        notify_root_operation ctx op;
         match Hashtbl.find_opt ctx.root_handlers op with
         | Some native when not ctx.capture_root_handlers ->
             invoke_untrusted_native ctx (VOp { op; name; effect_ }) native args k

--- a/src/eval.mli
+++ b/src/eval.mli
@@ -51,6 +51,21 @@ val register_root_handler :
     Its arguments, continuation mutation, and result are guarded at dispatch; callback failures are
     returned as runtime errors. *)
 
+val with_root_observer :
+  ctx -> on_operation:(Hash.t -> unit) -> on_output:(Hash.t -> string -> unit) -> (unit -> 'a) -> 'a
+(** [with_root_observer ctx ~on_operation ~on_output f] installs an observation hook only for the
+    dynamic extent of [f]. [on_operation] runs exactly when an operation has crossed every language
+    handler and reached the root; [on_output] is reserved for trusted root adapters and receives
+    their explicit operation hash. The prior observer is restored even if [f] raises. Observers do
+    not participate in handler selection or scheduling; exceptions from [f] or either callback
+    propagate unchanged. *)
+
+val note_root_output : ctx -> operation:Hash.t -> string -> unit
+(** [note_root_output ctx ~operation bytes] attaches bytes accepted by a trusted root adapter to its
+    explicit operation identity, if an observer is active. It must not be used by untrusted or
+    language-level handlers. It is a no-op without an observer; an observer callback exception
+    propagates unchanged. *)
+
 val set_coverage_tracking : ctx -> bool -> unit
 (** [set_coverage_tracking ctx enabled] enables or disables term-reference coverage bookkeeping. *)
 

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -791,6 +791,7 @@ let install_console ?(read_line = fun () -> try Stdlib.read_line () with End_of_
       match args with
       | [ Value.VText s ] ->
           out s;
+          Eval.note_root_output ctx ~operation:print_op s;
           Ok Value.unit_v
       | args ->
           Error

--- a/src/run_transcript.ml
+++ b/src/run_transcript.ml
@@ -1,0 +1,117 @@
+(** Explicit, interpreter-only recording for the frozen [run-transcript-v1] observation format. This
+    module only constructs and serializes canonical values; parsing and comparison belong to the
+    successor RW.2 task. *)
+
+let format_version = 1
+
+type event = { operation : Hash.t; output : string }
+type observation = { value : string; trace : event list }
+type transcript = Transcript of observation list
+type pending_event = { operation : Hash.t; output : string option }
+
+type recorder = {
+  mutable completed_rev : observation list;
+  mutable current_rev : pending_event list;
+  mutable active : bool;
+}
+
+exception Bug_run_transcript of string
+
+let bug format = Printf.ksprintf (fun message -> raise (Bug_run_transcript message)) format
+
+(** [create ()] starts an empty, non-reentrant transcript builder. *)
+let create () = { completed_rev = []; current_rev = []; active = false }
+
+let on_operation recorder operation =
+  if not recorder.active then bug "root operation arrived outside an active recording";
+  recorder.current_rev <- { operation; output = None } :: recorder.current_rev
+
+let on_output recorder operation output =
+  if not recorder.active then bug "root output arrived outside an active recording";
+  let rec attach seen = function
+    | [] -> bug "root output for %s has no pending root operation" (Hash.to_hex operation)
+    | ({ operation = current; output = None } as event) :: rest when Hash.equal current operation ->
+        List.rev_append seen ({ event with output = Some output } :: rest)
+    | event :: rest -> attach (event :: seen) rest
+  in
+  recorder.current_rev <- attach [] recorder.current_rev
+
+(** [record_expression recorder ctx run] observes one caller-supplied evaluator or scheduler run.
+    The original result is preserved exactly; only a successful [Value.t] adds an observation. *)
+let record_expression recorder ctx run =
+  if recorder.active then bug "a recorder cannot record overlapping expressions";
+  recorder.active <- true;
+  recorder.current_rev <- [];
+  Fun.protect
+    ~finally:(fun () ->
+      recorder.current_rev <- [];
+      recorder.active <- false)
+    (fun () ->
+      Eval.with_root_observer ctx ~on_operation:(on_operation recorder)
+        ~on_output:(on_output recorder) (fun () ->
+          match run () with
+          | Ok value as result ->
+              let observation =
+                {
+                  value = Value.show value ^ "\n";
+                  trace =
+                    List.rev_map
+                      (fun (pending : pending_event) ->
+                        let output = Option.value ~default:"" pending.output in
+                        ({ operation = pending.operation; output } : event))
+                      recorder.current_rev;
+                }
+              in
+              recorder.completed_rev <- observation :: recorder.completed_rev;
+              result
+          | Error _ as result -> result))
+
+(** [transcript recorder] snapshots completed observations. In-progress observations are never
+    exposed because they are discarded on a failed or abandoned expression. *)
+let transcript recorder =
+  if recorder.active then bug "cannot inspect a recorder while an expression is active";
+  Transcript (List.rev recorder.completed_rev)
+
+let observations (Transcript observations) = observations
+
+let decimal value =
+  if value < 0 then bug "negative canonical count or byte length";
+  string_of_int value
+
+let add_header buffer index observation =
+  Buffer.add_string buffer "observation index=";
+  Buffer.add_string buffer (decimal index);
+  Buffer.add_string buffer " value-bytes=";
+  Buffer.add_string buffer (decimal (String.length observation.value));
+  Buffer.add_string buffer " trace-events=";
+  Buffer.add_string buffer (decimal (List.length observation.trace));
+  Buffer.add_char buffer '\n';
+  Buffer.add_string buffer observation.value
+
+let add_event buffer index (event : event) =
+  Buffer.add_string buffer "trace index=";
+  Buffer.add_string buffer (decimal index);
+  Buffer.add_string buffer " operation=";
+  Buffer.add_string buffer (Hash.to_hex event.operation);
+  Buffer.add_string buffer " output-bytes=";
+  Buffer.add_string buffer (decimal (String.length event.output));
+  Buffer.add_char buffer '\n';
+  Buffer.add_string buffer event.output
+
+(** [serialize] writes one header and length-framed raw result/output payloads. All indices are
+    generated from immutable list order, so callers cannot construct noncontiguous encodings. *)
+let serialize (Transcript completed) =
+  let buffer = Buffer.create 256 in
+  Buffer.add_string buffer "jacquard-run-transcript format=";
+  Buffer.add_string buffer (decimal format_version);
+  Buffer.add_string buffer " observations=";
+  Buffer.add_string buffer (decimal (List.length completed));
+  Buffer.add_char buffer '\n';
+  List.iteri
+    (fun observation_index observation ->
+      add_header buffer observation_index observation;
+      List.iteri (add_event buffer) observation.trace)
+    completed;
+  Buffer.contents buffer
+
+let serialize_recorder recorder = serialize (transcript recorder)

--- a/src/run_transcript.mli
+++ b/src/run_transcript.mli
@@ -1,0 +1,41 @@
+(** Immutable [run-transcript-v1] observations collected by an explicit interpreter hook. *)
+
+val format_version : int
+(** The only run-transcript format emitted by this implementation. *)
+
+type event = { operation : Hash.t; output : string }
+(** One operation that reached the evaluator root. [output] contains only bytes accepted by the
+    trusted Console adapter; all other root operations have the empty string. *)
+
+type observation = { value : string; trace : event list }
+(** One successful top-level expression: [value] is exactly [Value.show result ^ "\\n"]. *)
+
+type transcript
+(** An ordered immutable sequence of successful expression observations. *)
+
+type recorder
+(** A mutable, non-reentrant builder for one {!type-transcript}. *)
+
+val create : unit -> recorder
+(** [create ()] returns an empty recorder. *)
+
+val record_expression :
+  recorder -> Eval.ctx -> (unit -> (Value.t, 'error) result) -> (Value.t, 'error) result
+(** [record_expression recorder ctx run] executes [run] under a scoped root observer and returns its
+    result unchanged. Only [Ok value] commits one immutable observation; [Error _] and raised
+    exceptions leave the transcript unchanged. Re-entering a recorder or receiving output for a
+    different root operation raises [Bug_run_transcript]. *)
+
+val transcript : recorder -> transcript
+(** [transcript recorder] snapshots the completed observations in evaluation order. It raises
+    [Bug_run_transcript] while an expression is actively being recorded. *)
+
+val observations : transcript -> observation list
+(** [observations transcript] returns its observations in canonical order. *)
+
+val serialize : transcript -> string
+(** [serialize transcript] emits the canonical byte-oriented [run-transcript-v1] encoding. *)
+
+val serialize_recorder : recorder -> string
+(** [serialize_recorder recorder] snapshots and serializes completed observations. It raises the
+    internal [Bug_run_transcript] invariant exception while an expression is active. *)

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -69,7 +69,9 @@
   ../test_jacquard.exe
   ../scope_policy_trace.exe
   ../round_robin_trace.exe
+  ../run_transcript_trace.exe
   concurrency-evidence.t
+  run-transcript.t
   ../../demos/concurrency/concurrency_evidence.exe
   ../../demos/governed-workspace/live_evidence.exe
   (source_tree ../native-parallel)

--- a/test/cli/run-transcript.t
+++ b/test/cli/run-transcript.t
@@ -1,0 +1,11 @@
+RW.1 keeps run transcripts internal to interpreter tooling. This cram invokes the
+internal fixture and pins every emitted [run-transcript-v1] byte, including the
+length-framed Console payload.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ ../run_transcript_trace.exe; echo
+  jacquard-run-transcript format=1 observations=1
+  observation index=0 value-bytes=2 trace-events=1
+  0
+  trace index=0 operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output-bytes=5
+  hello

--- a/test/dune
+++ b/test/dune
@@ -68,6 +68,11 @@
  (modules round_robin_trace)
  (libraries jacquard))
 
+(executable
+ (name run_transcript_trace)
+ (modules run_transcript_trace)
+ (libraries jacquard unix))
+
 ; the fuzz lane (task 74): seeded random pure programs through both engines.
 ; Not in the default runtest — run `dune build @native-fuzz` (1000 cases) or
 ; the executable directly with a count for the 10k pre-merge sweep.
@@ -99,7 +104,7 @@
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace test_governance_review_diff governance_review_diff_focused))
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused))
  (libraries jacquard governance_review_diff_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)

--- a/test/run_transcript_trace.ml
+++ b/test/run_transcript_trace.ml
@@ -1,0 +1,56 @@
+(** Internal cram fixture for the exact [run-transcript-v1] bytes. It intentionally has no CLI
+    surface: RW.1 keeps recording as an interpreter-tooling API. *)
+
+open Jacquard
+
+let fail_diagnostics diagnostics =
+  failwith (String.concat "; " (List.map Diag.to_string diagnostics))
+
+let prelude_dir () = Option.value (Sys.getenv_opt "JACQUARD_PRELUDE") ~default:"../prelude"
+
+let fresh_store_root () =
+  let root =
+    Filename.concat ".scratch" (Printf.sprintf "run-transcript-cram-%d.store" (Unix.getpid ()))
+  in
+  if not (Sys.file_exists ".scratch") then Sys.mkdir ".scratch" 0o700;
+  if Sys.file_exists root then failwith "run-transcript cram store already exists";
+  Sys.mkdir root 0o700;
+  root
+
+let expression store source =
+  match Reader.parse_one ~file:"run-transcript-cram.jqd" source with
+  | Error diagnostics -> fail_diagnostics diagnostics
+  | Ok form -> (
+      match Kernel.expr_of_form form with
+      | Error diagnostics -> fail_diagnostics diagnostics
+      | Ok expression -> (
+          match Resolve.resolve_expr (Store.names_view store) expression with
+          | Ok expression -> expression
+          | Error diagnostics -> fail_diagnostics diagnostics))
+
+let () =
+  let root = fresh_store_root () in
+  let store =
+    match Store.open_store root with
+    | Ok store -> store
+    | Error diagnostics -> fail_diagnostics diagnostics
+  in
+  (match Prelude.load ~dir:(prelude_dir ()) store with
+  | Ok _ -> ()
+  | Error diagnostics -> fail_diagnostics diagnostics);
+  let ctx = Eval.make_ctx store in
+  (match Prelude.wire_builtins ctx with
+  | Ok () -> ()
+  | Error diagnostics -> fail_diagnostics diagnostics);
+  (match Prelude.install_console ctx ~out:ignore with
+  | Ok () -> ()
+  | Error diagnostics -> fail_diagnostics diagnostics);
+  let recorder = Run_transcript.create () in
+  let result =
+    Run_transcript.record_expression recorder ctx (fun () ->
+        Eval.run_expr ctx
+          (expression store "(let nonrec (pwild) (app (var print) (lit \"hello\")) (lit 0))"))
+  in
+  match result with
+  | Ok _ -> print_string (Run_transcript.serialize_recorder recorder)
+  | Error error -> failwith (Runtime_err.to_string error)

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -29,6 +29,7 @@ let () =
       ("cancellation", Test_cancellation.suite);
       ("scope-policy", Test_scope_policy.suite);
       ("round-robin", Test_round_robin.suite);
+      ("run-transcript", Test_run_transcript.suite);
       ("exhaustive-schedule", Test_exhaustive_schedule.suite);
       ("schedule-trace", Test_schedule_trace.suite);
       ("audit", Test_audit.suite);

--- a/test/test_run_transcript.ml
+++ b/test/test_run_transcript.ml
@@ -1,0 +1,228 @@
+open Jacquard
+
+let fail_runtime label = function
+  | Ok value -> Alcotest.failf "%s unexpectedly succeeded with %s" label (Value.show value)
+  | Error _ -> ()
+
+let expression store source =
+  match Reader.parse_one ~file:"run-transcript.jqd" source with
+  | Error diagnostics -> Eval_support.fail_diags "parse run-transcript fixture" diagnostics
+  | Ok form -> (
+      match Kernel.expr_of_form form with
+      | Error diagnostics -> Eval_support.fail_diags "validate run-transcript fixture" diagnostics
+      | Ok expression -> (
+          match Resolve.resolve_expr (Store.names_view store) expression with
+          | Ok expression -> expression
+          | Error diagnostics ->
+              Eval_support.fail_diags "resolve run-transcript fixture" diagnostics))
+
+let recorded ?(install = fun _ -> ()) source run =
+  let store, ctx = Eval_support.make_prelude_ctx () in
+  install ctx;
+  let recorder = Run_transcript.create () in
+  let result =
+    Run_transcript.record_expression recorder ctx (fun () -> run ctx (expression store source))
+  in
+  (result, Run_transcript.transcript recorder)
+
+let direct ctx expression = Eval.run_expr ctx expression
+
+let console ctx =
+  let output = Buffer.create 16 in
+  (match Prelude.install_console ctx ~out:(Buffer.add_string output) with
+  | Ok () -> ()
+  | Error diagnostics -> Eval_support.fail_diags "install console" diagnostics);
+  output
+
+let test_pure_is_canonical_and_deterministic () =
+  let first, first_transcript = recorded "(lit 7)" direct in
+  let second, second_transcript = recorded "(lit 7)" direct in
+  (match (first, second) with Ok _, Ok _ -> () | _ -> Alcotest.fail "pure recording failed");
+  let first_bytes = Run_transcript.serialize first_transcript in
+  Alcotest.(check string)
+    "fresh pure runs are byte-identical" first_bytes
+    (Run_transcript.serialize second_transcript);
+  Alcotest.(check string)
+    "pure transcript exact bytes"
+    "jacquard-run-transcript format=1 observations=1\n\
+     observation index=0 value-bytes=2 trace-events=0\n\
+     7\n"
+    first_bytes;
+  match Run_transcript.observations first_transcript with
+  | [ { value; trace = [] } ] -> Alcotest.(check string) "rendered value" "7\n" value
+  | _ -> Alcotest.fail "pure run should have one trace-free observation"
+
+let test_console_output_is_attached_to_print () =
+  let source = "(let nonrec (pwild) (app (var print) (lit \"hello\")) (lit 0))" in
+  let result, transcript = recorded ~install:(fun ctx -> ignore (console ctx)) source direct in
+  let second_result, second_transcript =
+    recorded ~install:(fun ctx -> ignore (console ctx)) source direct
+  in
+  (match result with
+  | Ok _ -> ()
+  | Error error -> Alcotest.failf "console run failed: %s" (Runtime_err.to_string error));
+  (match second_result with
+  | Ok _ -> ()
+  | Error error -> Alcotest.failf "second console run failed: %s" (Runtime_err.to_string error));
+  Alcotest.(check string)
+    "fresh Console runs are byte-identical"
+    (Run_transcript.serialize transcript)
+    (Run_transcript.serialize second_transcript);
+  let store, _ = Eval_support.make_prelude_ctx () in
+  let print =
+    match Store.lookup_kind store "print" Resolve.KOp with
+    | Some entry -> entry.hash
+    | None -> Alcotest.fail "missing Console.print"
+  in
+  match Run_transcript.observations transcript with
+  | [ { value = "0\n"; trace = [ { operation; output } ] } ] ->
+      Alcotest.(check bool) "Console print identity" true (Hash.equal print operation);
+      Alcotest.(check string) "exact Console output" "hello" output
+  | _ -> Alcotest.fail "Console recording did not produce the expected single event"
+
+let test_reentrant_console_output_stays_with_its_operation () =
+  let store, ctx = Eval_support.make_prelude_ctx () in
+  let recorder = Run_transcript.create () in
+  let output = Buffer.create 16 in
+  let reentered = ref false in
+  let nested = expression store "(app (var print) (lit \"nested\"))" in
+  (match
+     Prelude.install_console ctx ~out:(fun bytes ->
+         Buffer.add_string output bytes;
+         if String.equal bytes "outer" && not !reentered then (
+           reentered := true;
+           match Eval.run_expr ctx nested with
+           | Ok _ -> ()
+           | Error error ->
+               Alcotest.failf "reentrant Console run failed: %s" (Runtime_err.to_string error)))
+   with
+  | Ok () -> ()
+  | Error diagnostics -> Eval_support.fail_diags "install reentrant console" diagnostics);
+  let result =
+    Run_transcript.record_expression recorder ctx (fun () ->
+        Eval.run_expr ctx (expression store "(app (var print) (lit \"outer\"))"))
+  in
+  (match result with
+  | Ok _ -> ()
+  | Error error -> Alcotest.failf "outer Console run failed: %s" (Runtime_err.to_string error));
+  Alcotest.(check string) "both trusted callbacks ran" "outernested" (Buffer.contents output);
+  match Run_transcript.observations (Run_transcript.transcript recorder) with
+  | [ { trace = [ first; second ]; _ } ] ->
+      Alcotest.(check string) "outer output remains on outer event" "outer" first.output;
+      Alcotest.(check string) "nested output remains on nested event" "nested" second.output
+  | _ -> Alcotest.fail "reentrant Console output should produce two routed events"
+
+let channel_source =
+  "(match (app (var channel.open) (lit 0))\n\
+  \  (clause (pcon ok (pvar channel))\n\
+  \    (let nonrec (pvar sender)\n\
+  \      (app (var async.spawn)\n\
+  \        (lam () (app (var channel.send) (var channel) (lit 9))))\n\
+  \      (let nonrec (pvar received) (app (var channel.recv) (var channel))\n\
+  \        (tuple (var received) (app (var async.await) (var sender))))))\n\
+  \  (clause (pcon err (pvar error)) (var error)))"
+
+let seeded ctx expression =
+  Round_robin.run_expr_scheduled ctx ~mode:(Round_robin.Seeded_schedule { seed = 193 }) expression
+  |> Result.map (fun scheduled -> scheduled.Round_robin.value)
+
+let test_seeded_spawn_await_channel_is_deterministic () =
+  let first, first_transcript = recorded channel_source seeded in
+  let second, second_transcript = recorded channel_source seeded in
+  (match (first, second) with
+  | Ok value, Ok other ->
+      Alcotest.(check string) "same result" (Value.show value) (Value.show other)
+  | Error error, _ | _, Error error ->
+      Alcotest.failf "seeded scheduler run failed: %s" (Runtime_err.to_string error));
+  Alcotest.(check string)
+    "seeded spawn/await/channel transcript bytes"
+    (Run_transcript.serialize first_transcript)
+    (Run_transcript.serialize second_transcript);
+  match Run_transcript.observations first_transcript with
+  | [ { trace; _ } ] ->
+      let pinned name entries = List.assoc name entries in
+      let expected =
+        [
+          pinned "channel.open" Channel_contract.channel_operation_hashes;
+          pinned "async.spawn" Concurrency_contract.async_operation_hashes;
+          pinned "channel.recv" Channel_contract.channel_operation_hashes;
+          pinned "channel.send" Channel_contract.channel_operation_hashes;
+          pinned "async.await" Concurrency_contract.async_operation_hashes;
+        ]
+      in
+      Alcotest.(check (list string))
+        "exact scheduler operation members in routed order" expected
+        (List.map (fun (event : Run_transcript.event) -> Hash.to_hex event.operation) trace);
+      Alcotest.(check bool)
+        "non-Console scheduler events carry no output" true
+        (List.for_all (fun (event : Run_transcript.event) -> String.equal event.output "") trace)
+  | _ -> Alcotest.fail "scheduled expression should commit exactly one observation"
+
+let test_multiple_expressions_keep_order () =
+  let record_pair () =
+    let store, ctx = Eval_support.make_prelude_ctx () in
+    let recorder = Run_transcript.create () in
+    let run source =
+      Run_transcript.record_expression recorder ctx (fun () ->
+          Eval.run_expr ctx (expression store source))
+    in
+    (match (run "(lit 1)", run "(lit 2)") with
+    | Ok _, Ok _ -> ()
+    | _ -> Alcotest.fail "sequential run failed");
+    Run_transcript.transcript recorder
+  in
+  let transcript = record_pair () in
+  let second_transcript = record_pair () in
+  Alcotest.(check string)
+    "fresh multiple-expression runs are byte-identical"
+    (Run_transcript.serialize transcript)
+    (Run_transcript.serialize second_transcript);
+  match Run_transcript.observations transcript with
+  | [ { value = "1\n"; _ }; { value = "2\n"; _ } ] -> ()
+  | _ -> Alcotest.fail "sequential expressions were not retained in order"
+
+let test_failures_commit_no_partial_observation () =
+  let source =
+    "(let nonrec (pwild) (app (var print) (lit \"visible-but-not-committed\")) (app (var add) (lit \
+     \"x\") (lit 1)))"
+  in
+  let store, ctx = Eval_support.make_prelude_ctx () in
+  let output = console ctx in
+  let recorder = Run_transcript.create () in
+  let result =
+    Run_transcript.record_expression recorder ctx (fun () ->
+        Eval.run_expr ctx (expression store source))
+  in
+  let transcript = Run_transcript.transcript recorder in
+  fail_runtime "failed expression" result;
+  Alcotest.(check string)
+    "failed expression did reach the Console adapter" "visible-but-not-committed"
+    (Buffer.contents output);
+  Alcotest.(check int)
+    "failed result adds no observation" 0
+    (List.length (Run_transcript.observations transcript));
+  Alcotest.(check string)
+    "failure leaves only the empty header" "jacquard-run-transcript format=1 observations=0\n"
+    (Run_transcript.serialize transcript);
+  let _store, ctx = Eval_support.make_prelude_ctx () in
+  let recorder = Run_transcript.create () in
+  (try
+     ignore (Run_transcript.record_expression recorder ctx (fun () -> raise Exit));
+     Alcotest.fail "host exception should escape unchanged"
+   with Exit -> ());
+  Alcotest.(check int)
+    "host exception adds no observation" 0
+    (List.length (Run_transcript.observations (Run_transcript.transcript recorder)))
+
+let suite =
+  [
+    Alcotest.test_case "pure canonical determinism" `Quick test_pure_is_canonical_and_deterministic;
+    Alcotest.test_case "Console output is attached" `Quick test_console_output_is_attached_to_print;
+    Alcotest.test_case "reentrant Console output is attributed" `Quick
+      test_reentrant_console_output_stays_with_its_operation;
+    Alcotest.test_case "seeded spawn await channel determinism" `Quick
+      test_seeded_spawn_await_channel_is_deterministic;
+    Alcotest.test_case "multiple expressions" `Quick test_multiple_expressions_keep_order;
+    Alcotest.test_case "failure has no partial observation" `Quick
+      test_failures_commit_no_partial_observation;
+  ]


### PR DESCRIPTION
## Summary

Relational Warp needs a deterministic observation artifact before parsing,
comparison, or CLI work can be built safely. This change adds the opt-in
interpreter recorder for the frozen `run-transcript-v1` contract.

- add a context-owned, dynamically scoped root-operation observer that is off
  by default and restored across success, error, and host exceptions
- record canonical operation-member hashes in evaluator/scheduler order and
  attach raw output only through the trusted Console `print` adapter
- commit one immutable observation only after a successful top-level
  expression, using the existing `Value.show value ^ "\n"` rendering
- serialize canonical byte-length-framed transcripts with generated indices
- pin pure, Console, seeded spawn/await/channel, multi-expression,
  reentrancy, failure-atomicity, and exact-byte cram behavior
- update the mechanically checked release inventories from 847 to 853 cases
  and from 51 to 52 cram files

## Invariants and scope

- ordinary `jacquard run` behavior is unchanged unless a caller explicitly
  installs a recorder
- language-handled operations remain excluded; only operation members that
  reach the root are observed
- `schedule-trace-v1`, the 27-form kernel, lowering, `HASH_V0`, stores,
  native code, and existing operation identities are unchanged
- transcript parsing, comparison, divergence rendering, CLI wiring, and
  redaction remain separate follow-up slices

## Verification

- [x] `opam exec -- dune build --root "$PWD" @all @doc`
- [x] `opam exec -- dune fmt --root "$PWD"` with a clean tracked tree
- [x] full direct Alcotest/QCheck runner: 853/853 cases
- [x] focused `run-transcript.*`: 6/6 cases
- [x] new exact-byte `test/cli/run-transcript.t`
- [x] existing `test/cli/run.t` and `test/cli/schedule-replay.t`
- [x] focused release-inventory guard after the count update
- [x] `scripts/release/check-historical-manifests.sh --commit 17bd94ac3814b57fef17c7888d98315977d4918f --require-history`
- [x] independent Claude Fable 5 review at xhigh effort: PASS on exact commit
  `6dcf1e75c8e303c84ad4536ba8ba9430b684355e`, with no blockers,
  architecture conflicts, or disputed tests

The forced Dune alias exercised the full repository graph locally. The host's
ptrace wrapper prevents LeakSanitizer from initializing in the native sanitizer
lanes; all ordinary tests and doctests passed after the mechanically required
inventory correction. The required GitHub native-parity jobs remain the merge
authority for those lanes.

## Risk and follow-up

The observer is additive, per-context, and disabled by default. Its only output
hook is the existing trusted Console adapter. The next slice will add strict
parsing and comparison against this frozen byte format; this PR deliberately
does not expose a new command or claim native transcript support.
