### PR TITLE
RW.2: compare canonical run transcripts

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -185,6 +185,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 |------|---------|---------|
 | E1001 | expression at top level of a test file | `jacquard test file.jqd` where the file ends with `(app (var main))` |
 | E1002 | eval under --dry-run | a program whose row includes `eval` run with `--dry-run` |
+| E1004 | malformed, unsupported, or noncanonical run-transcript-v1 bytes | a transcript with a noncontiguous observation index or truncated payload |
 
 ## Native compilation (E11xx)
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `853`
+- Alcotest/QCheck cases: `858`
 - Cram transcript files: `52`
 - Doctest examples: `28` across 8 documents
 
@@ -40,6 +40,9 @@ SX.26 adds five compiled marked-text interpolation cases, one documentation
 example, and one explicit lowering-parity twin.
 The explicit-dictionary successor adds four compiled contract cases and extends
 the existing native transcript without changing the cram or doctest counts.
+Relational Warp transcript recording adds six compiled cases and one internal
+tooling transcript; strict transcript parsing and semantic comparison add five
+compiled cases while extending that existing transcript.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 847 compiled Alcotest/QCheck cases, 51 recursive
+The current successor inventory is exactly 858 compiled Alcotest/QCheck cases, 52 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,7 +759,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `853`
+- Alcotest/QCheck cases: `858`
 - Cram transcript files: `52`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -797,7 +797,11 @@ formatter-width work adds two boundary cases, and SX.25a adds one
 colon-continuation contract case. SX.26 adds five marked-text interpolation
 cases and one doctest, producing the then-current `843 / 51 / 28` inventory.
 The explicit-dictionary successor adds four compiled contract cases and extends
-an existing native transcript, producing the current `847 / 51 / 28` inventory.
+an existing native transcript, producing the then-current `847 / 51 / 28`
+inventory. Relational Warp transcript recording adds six compiled cases and one
+internal tooling transcript, producing `853 / 52 / 28`; strict transcript
+parsing and semantic comparison add five compiled cases without adding another
+cram file, producing the current `858 / 52 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/src/run_transcript.ml
+++ b/src/run_transcript.ml
@@ -1,12 +1,27 @@
-(** Explicit, interpreter-only recording for the frozen [run-transcript-v1] observation format. This
-    module only constructs and serializes canonical values; parsing and comparison belong to the
-    successor RW.2 task. *)
+(** Explicit, interpreter-only recording plus strict parsing and semantic comparison for the frozen
+    [run-transcript-v1] observation format. *)
 
 let format_version = 1
 
 type event = { operation : Hash.t; output : string }
 type observation = { value : string; trace : event list }
 type transcript = Transcript of observation list
+
+type position =
+  | Observation_position of int
+  | Value_position of int
+  | Trace_position of { observation_index : int; trace_index : int }
+
+type divergence_kind = Value_divergence | Trace_divergence | Length_divergence
+
+type side =
+  | Value_side of string
+  | Trace_side of event
+  | Observation_side of observation
+  | Missing_side
+
+type divergence = { position : position; kind : divergence_kind; left : side; right : side }
+type verdict = Equal | Divergence of divergence
 type pending_event = { operation : Hash.t; output : string option }
 
 type recorder = {
@@ -18,6 +33,16 @@ type recorder = {
 exception Bug_run_transcript of string
 
 let bug format = Printf.ksprintf (fun message -> raise (Bug_run_transcript message)) format
+
+(* [run-transcript-v1] admits output bytes only on the frozen Console.print member. This identity is
+   already pinned by the 0.1 prelude goldens and by schedule/transcript evidence; keeping it beside
+   the versioned decoder lets parsing remain pure while rejecting forged output attribution. *)
+let console_print_operation =
+  match
+    Hash.of_canonical_hex "28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e"
+  with
+  | Some operation -> operation
+  | None -> bug "the frozen Console.print operation hash is malformed"
 
 (** [create ()] starts an empty, non-reentrant transcript builder. *)
 let create () = { completed_rev = []; current_rev = []; active = false }
@@ -115,3 +140,231 @@ let serialize (Transcript completed) =
   Buffer.contents buffer
 
 let serialize_recorder recorder = serialize (transcript recorder)
+
+type cursor = { bytes : string; mutable offset : int }
+
+let invalid_at offset detail =
+  Error
+    [
+      Diag.error ~domain:Warp ~code:"E1004" ~summary:"The run transcript is invalid."
+        ~cause:(Printf.sprintf "Invalid run transcript at byte offset %d: %s" offset detail)
+        ~next_step:"Use canonical run-transcript-v1 bytes recorded by this Jacquard version."
+        ~contrast:None ();
+    ]
+
+let expect_literal cursor literal =
+  let input_length = String.length cursor.bytes in
+  let literal_length = String.length literal in
+  let rec check index =
+    if index = literal_length then (
+      cursor.offset <- cursor.offset + literal_length;
+      Ok ())
+    else
+      let input_index = cursor.offset + index in
+      if input_index >= input_length then invalid_at input_index "a structural field is truncated"
+      else if cursor.bytes.[input_index] <> literal.[index] then
+        invalid_at input_index "a structural field is misspelled, reordered, or incorrectly spaced"
+      else check (index + 1)
+  in
+  check 0
+
+let parse_unsigned cursor =
+  let input_length = String.length cursor.bytes in
+  let start = cursor.offset in
+  let digit_at index =
+    if index >= input_length then None
+    else
+      match cursor.bytes.[index] with
+      | '0' .. '9' as char -> Some (Char.code char - Char.code '0')
+      | _ -> None
+  in
+  match digit_at start with
+  | None -> invalid_at start "an unsigned decimal field has no digits"
+  | Some _ ->
+      let rec scan index value =
+        match digit_at index with
+        | None -> Ok (index, value)
+        | Some digit ->
+            if value > (max_int - digit) / 10 then
+              invalid_at index "an unsigned decimal field exceeds the supported range"
+            else scan (index + 1) ((value * 10) + digit)
+      in
+      let ( let* ) = Result.bind in
+      let* stop, value = scan start 0 in
+      if cursor.bytes.[start] = '0' && stop - start > 1 then
+        invalid_at start "an unsigned decimal field has a leading zero"
+      else (
+        cursor.offset <- stop;
+        Ok value)
+
+let read_payload cursor byte_length =
+  let available = String.length cursor.bytes - cursor.offset in
+  if byte_length > available then invalid_at cursor.offset "a declared payload is truncated"
+  else
+    let payload = String.sub cursor.bytes cursor.offset byte_length in
+    cursor.offset <- cursor.offset + byte_length;
+    Ok payload
+
+let parse_hash cursor =
+  let hash_length = 2 * Hash.digest_size in
+  let available = String.length cursor.bytes - cursor.offset in
+  if hash_length > available then invalid_at cursor.offset "an operation hash is truncated"
+  else
+    let raw = String.sub cursor.bytes cursor.offset hash_length in
+    match Hash.of_canonical_hex raw with
+    | None -> invalid_at cursor.offset "an operation hash is not canonical lowercase HASH_V0"
+    | Some hash ->
+        cursor.offset <- cursor.offset + hash_length;
+        Ok hash
+
+let parse_event cursor ~expected_index =
+  let ( let* ) = Result.bind in
+  let* () = expect_literal cursor "trace index=" in
+  let* index = parse_unsigned cursor in
+  let* () =
+    if index = expected_index then Ok ()
+    else invalid_at cursor.offset "trace indices are not contiguous from zero"
+  in
+  let* () = expect_literal cursor " operation=" in
+  let* operation = parse_hash cursor in
+  let* () = expect_literal cursor " output-bytes=" in
+  let* output_length = parse_unsigned cursor in
+  let* () =
+    if output_length = 0 || Hash.equal operation console_print_operation then Ok ()
+    else invalid_at cursor.offset "a non-Console operation declares output bytes"
+  in
+  let* () = expect_literal cursor "\n" in
+  let* output = read_payload cursor output_length in
+  Ok ({ operation; output } : event)
+
+let parse_observation cursor ~expected_index =
+  let ( let* ) = Result.bind in
+  let* () = expect_literal cursor "observation index=" in
+  let* index = parse_unsigned cursor in
+  let* () =
+    if index = expected_index then Ok ()
+    else invalid_at cursor.offset "observation indices are not contiguous from zero"
+  in
+  let* () = expect_literal cursor " value-bytes=" in
+  let* value_length = parse_unsigned cursor in
+  let* () = expect_literal cursor " trace-events=" in
+  let* trace_length = parse_unsigned cursor in
+  let* () = expect_literal cursor "\n" in
+  let* value = read_payload cursor value_length in
+  let* () =
+    if String.length value > 0 && value.[String.length value - 1] = '\n' then Ok ()
+    else invalid_at cursor.offset "a value payload does not end in its required LF"
+  in
+  let rec events index remaining reversed =
+    if remaining = 0 then Ok (List.rev reversed)
+    else
+      let* event = parse_event cursor ~expected_index:index in
+      events (index + 1) (remaining - 1) (event :: reversed)
+  in
+  let* trace = events 0 trace_length [] in
+  Ok { value; trace }
+
+(** [parse bytes] advances a byte cursor through exact structural literals and length-framed raw
+    payloads. Every failed branch reports only its structural location, never attacker-controlled
+    transcript bytes. *)
+let parse bytes =
+  let ( let* ) = Result.bind in
+  let cursor = { bytes; offset = 0 } in
+  let* () = expect_literal cursor "jacquard-run-transcript format=" in
+  let* version = parse_unsigned cursor in
+  let* () =
+    if version = format_version then Ok ()
+    else invalid_at cursor.offset "the format version is unsupported"
+  in
+  let* () = expect_literal cursor " observations=" in
+  let* observation_count = parse_unsigned cursor in
+  let* () = expect_literal cursor "\n" in
+  let rec observations index remaining reversed =
+    if remaining = 0 then Ok (List.rev reversed)
+    else
+      let* observation = parse_observation cursor ~expected_index:index in
+      observations (index + 1) (remaining - 1) (observation :: reversed)
+  in
+  let* completed = observations 0 observation_count [] in
+  if cursor.offset <> String.length bytes then
+    invalid_at cursor.offset "bytes remain after the final declared payload"
+  else
+    let transcript = Transcript completed in
+    if String.equal (serialize transcript) bytes then Ok transcript
+    else invalid_at cursor.offset "the decoded bytes are not canonical run-transcript-v1"
+
+let first_divergence position kind left right = Divergence { position; kind; left; right }
+
+let rec compare_trace observation_index trace_index (left : event list) (right : event list) =
+  match (left, right) with
+  | [], [] -> None
+  | left_event :: left_rest, right_event :: right_rest ->
+      if
+        (not (Hash.equal left_event.operation right_event.operation))
+        || not (String.equal left_event.output right_event.output)
+      then
+        Some
+          (first_divergence
+             (Trace_position { observation_index; trace_index })
+             Trace_divergence (Trace_side left_event) (Trace_side right_event))
+      else compare_trace observation_index (trace_index + 1) left_rest right_rest
+  | left_event :: _, [] ->
+      Some
+        (first_divergence
+           (Trace_position { observation_index; trace_index })
+           Length_divergence (Trace_side left_event) Missing_side)
+  | [], right_event :: _ ->
+      Some
+        (first_divergence
+           (Trace_position { observation_index; trace_index })
+           Length_divergence Missing_side (Trace_side right_event))
+
+(** [compare] walks decoded logical structure rather than serialized byte offsets. Complete field
+    comparison establishes the same equality relation as canonical serialization. *)
+let compare (Transcript left) (Transcript right) =
+  let rec observations index left right =
+    match (left, right) with
+    | [], [] -> Equal
+    | left_observation :: left_rest, right_observation :: right_rest -> (
+        if not (String.equal left_observation.value right_observation.value) then
+          first_divergence (Value_position index) Value_divergence
+            (Value_side left_observation.value) (Value_side right_observation.value)
+        else
+          match compare_trace index 0 left_observation.trace right_observation.trace with
+          | Some divergence -> divergence
+          | None -> observations (index + 1) left_rest right_rest)
+    | left_observation :: _, [] ->
+        first_divergence (Observation_position index) Length_divergence
+          (Observation_side left_observation) Missing_side
+    | [], right_observation :: _ ->
+        first_divergence (Observation_position index) Length_divergence Missing_side
+          (Observation_side right_observation)
+  in
+  observations 0 left right
+
+let position_path = function
+  | Observation_position index -> Printf.sprintf "observation[%d]" index
+  | Value_position index -> Printf.sprintf "observation[%d].value" index
+  | Trace_position { observation_index; trace_index } ->
+      Printf.sprintf "observation[%d].trace[%d]" observation_index trace_index
+
+let divergence_kind_name = function
+  | Value_divergence -> "value-divergence"
+  | Trace_divergence -> "trace-divergence"
+  | Length_divergence -> "length-divergence"
+
+let render_side = function
+  | Value_side value -> Printf.sprintf "%S" value
+  | Trace_side event ->
+      Printf.sprintf "operation=%s output=%S" (Hash.to_hex event.operation) event.output
+  | Observation_side observation ->
+      Printf.sprintf "observation value=%S value-bytes=%d trace-events=%d" observation.value
+        (String.length observation.value) (List.length observation.trace)
+  | Missing_side -> "<missing>"
+
+(** [render divergence] uses the same indented [at]/[-]/[+] frame as the repository semantic differ
+    while keeping classification and redaction-capable sides structured. *)
+let render divergence =
+  Printf.sprintf "  at %s:\n    - %s\n    + %s"
+    (position_path divergence.position)
+    (render_side divergence.left) (render_side divergence.right)

--- a/src/run_transcript.mli
+++ b/src/run_transcript.mli
@@ -4,14 +4,39 @@ val format_version : int
 (** The only run-transcript format emitted by this implementation. *)
 
 type event = { operation : Hash.t; output : string }
-(** One operation that reached the evaluator root. [output] contains only bytes accepted by the
-    trusted Console adapter; all other root operations have the empty string. *)
+(** One operation that reached the evaluator root. Nonempty [output] is structurally valid only for
+    the frozen Console.print operation; recorder-produced bytes are exactly those accepted by its
+    trusted adapter. All other root operations have the empty string. *)
 
 type observation = { value : string; trace : event list }
 (** One successful top-level expression: [value] is exactly [Value.show result ^ "\\n"]. *)
 
 type transcript
 (** An ordered immutable sequence of successful expression observations. *)
+
+(** A logical first-divergence position. Indices are zero-based and paths are ordered first by
+    observation, then by value, then by trace event. *)
+type position =
+  | Observation_position of int
+  | Value_position of int
+  | Trace_position of { observation_index : int; trace_index : int }
+
+(** Stable semantic classification of a completed-run difference. *)
+type divergence_kind = Value_divergence | Trace_divergence | Length_divergence
+
+(** One structured side of a divergence. Raw values and Console outputs remain available so a caller
+    can redact them before rendering; [Missing_side] marks a strict prefix. *)
+type side =
+  | Value_side of string
+  | Trace_side of event
+  | Observation_side of observation
+  | Missing_side
+
+type divergence = { position : position; kind : divergence_kind; left : side; right : side }
+(** The first logical difference between two canonical transcripts. *)
+
+(** Complete comparison result for two successfully decoded transcripts. *)
+type verdict = Equal | Divergence of divergence
 
 type recorder
 (** A mutable, non-reentrant builder for one {!type-transcript}. *)
@@ -32,6 +57,32 @@ val transcript : recorder -> transcript
 
 val observations : transcript -> observation list
 (** [observations transcript] returns its observations in canonical order. *)
+
+val parse : string -> (transcript, Diag.t list) result
+(** [parse bytes] accepts exactly canonical [run-transcript-v1] bytes. It rejects unknown versions,
+    misspelled or reordered fields, noncanonical unsigned decimals or hashes, noncontiguous indices,
+    incorrect counts, output attributed to a non-Console operation, truncated payloads, values
+    without their required final LF, and trailing bytes with E1004. Malformed input never raises and
+    no input payload is copied into a diagnostic. *)
+
+val compare : transcript -> transcript -> verdict
+(** [compare left right] returns the first logical divergence in observation/value/trace order.
+    Within an event the operation identity precedes its output. It is pure and total, and returns
+    [Equal] exactly when [serialize left] and [serialize right] are byte-equal. *)
+
+val position_path : position -> string
+(** [position_path position] returns the stable [observation[I]]-style path used by the renderer. *)
+
+val divergence_kind_name : divergence_kind -> string
+(** [divergence_kind_name kind] returns [value-divergence], [trace-divergence], or
+    [length-divergence]. *)
+
+val render : divergence -> string
+(** [render divergence] emits the canonical three-line semantic-diff frame. Arbitrary payload bytes
+    use escaped string syntax, trace events use stable hash/output rows, missing sides render as
+    [<missing>], and observation-prefix rows use one compact observation summary without recursively
+    rendering its trace. The function adds no diagnostic header, labels, ANSI escapes, or terminal
+    LF. *)
 
 val serialize : transcript -> string
 (** [serialize transcript] emits the canonical byte-oriented [run-transcript-v1] encoding. *)

--- a/test/cli/run-transcript.t
+++ b/test/cli/run-transcript.t
@@ -9,3 +9,20 @@ length-framed Console payload.
   0
   trace index=0 operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output-bytes=5
   hello
+
+RW.2 keeps comparison in the same internal tooling module. This pins the complete
+canonical semantic-diff text for value, trace, and strict-prefix divergences.
+
+  $ ../run_transcript_trace.exe render-divergences
+  value-divergence
+    at observation[0].value:
+      - "0\n"
+      + "1\n"
+  trace-divergence
+    at observation[0].trace[0]:
+      - operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output="left\n"
+      + operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output="right\t"
+  length-divergence
+    at observation[1]:
+      - observation value="0\n" value-bytes=2 trace-events=0
+      + <missing>

--- a/test/run_transcript_trace.ml
+++ b/test/run_transcript_trace.ml
@@ -28,7 +28,7 @@ let expression store source =
           | Ok expression -> expression
           | Error diagnostics -> fail_diagnostics diagnostics))
 
-let () =
+let record () =
   let root = fresh_store_root () in
   let store =
     match Store.open_store root with
@@ -54,3 +54,42 @@ let () =
   match result with
   | Ok _ -> print_string (Run_transcript.serialize_recorder recorder)
   | Error error -> failwith (Runtime_err.to_string error)
+
+let parsed bytes =
+  match Run_transcript.parse bytes with
+  | Ok transcript -> transcript
+  | Error ds -> fail_diagnostics ds
+
+let console_print_hash = "28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e"
+
+let transcript ~value ~operation ~output ~observations =
+  Printf.sprintf
+    "jacquard-run-transcript format=1 observations=%d\n\
+     observation index=0 value-bytes=2 trace-events=1\n\
+     %s\n\
+     trace index=0 operation=%s output-bytes=%d\n\
+     %s%s"
+    observations value operation (String.length output) output
+    (if observations = 2 then "observation index=1 value-bytes=2 trace-events=0\n0\n" else "")
+
+let render_one left right =
+  match Run_transcript.compare (parsed left) (parsed right) with
+  | Run_transcript.Equal -> failwith "render fixture unexpectedly compared equal"
+  | Run_transcript.Divergence divergence ->
+      print_endline (Run_transcript.divergence_kind_name divergence.kind);
+      print_endline (Run_transcript.render divergence)
+
+let render_divergences () =
+  let left = transcript ~value:"0" ~operation:console_print_hash ~output:"left\n" ~observations:2 in
+  render_one left
+    (transcript ~value:"1" ~operation:console_print_hash ~output:"left\n" ~observations:2);
+  render_one left
+    (transcript ~value:"0" ~operation:console_print_hash ~output:"right\t" ~observations:2);
+  render_one left
+    (transcript ~value:"0" ~operation:console_print_hash ~output:"left\n" ~observations:1)
+
+let () =
+  match Array.to_list Sys.argv with
+  | [ _ ] -> record ()
+  | [ _; "render-divergences" ] -> render_divergences ()
+  | _ -> failwith "usage: run_transcript_trace.exe [render-divergences]"

--- a/test/test_run_transcript.ml
+++ b/test/test_run_transcript.ml
@@ -68,6 +68,14 @@ let test_console_output_is_attached_to_print () =
     "fresh Console runs are byte-identical"
     (Run_transcript.serialize transcript)
     (Run_transcript.serialize second_transcript);
+  (match Run_transcript.parse (Run_transcript.serialize transcript) with
+  | Ok parsed ->
+      Alcotest.(check string)
+        "recorded Console identity is accepted by strict parsing"
+        (Run_transcript.serialize transcript)
+        (Run_transcript.serialize parsed)
+  | Error diagnostics ->
+      Eval_support.fail_diags "parse recorder-produced Console transcript" diagnostics);
   let store, _ = Eval_support.make_prelude_ctx () in
   let print =
     match Store.lookup_kind store "print" Resolve.KOp with
@@ -214,6 +222,307 @@ let test_failures_commit_no_partial_observation () =
     "host exception adds no observation" 0
     (List.length (Run_transcript.observations (Run_transcript.transcript recorder)))
 
+let zero_hash = String.make (2 * Hash.digest_size) '0'
+let one_hash = String.make ((2 * Hash.digest_size) - 1) '0' ^ "1"
+let console_print_hash = "28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e"
+
+let canonical observations =
+  let body = String.concat "" observations in
+  Printf.sprintf "jacquard-run-transcript format=1 observations=%d\n%s" (List.length observations)
+    body
+
+let observation ?(index = 0) ?(value = "0\n") events =
+  Printf.sprintf "observation index=%d value-bytes=%d trace-events=%d\n%s%s" index
+    (String.length value) (List.length events) value (String.concat "" events)
+
+let event ?(index = 0) ?(operation = console_print_hash) ?(output = "") () =
+  Printf.sprintf "trace index=%d operation=%s output-bytes=%d\n%s" index operation
+    (String.length output) output
+
+let parse_ok label bytes =
+  match Run_transcript.parse bytes with
+  | Ok transcript -> transcript
+  | Error diagnostics -> Eval_support.fail_diags label diagnostics
+
+let expect_invalid label bytes =
+  let contains needle haystack =
+    let needle_length = String.length needle in
+    let rec search index =
+      index + needle_length <= String.length haystack
+      && (String.sub haystack index needle_length = needle || search (index + 1))
+    in
+    search 0
+  in
+  match Run_transcript.parse bytes with
+  | Ok _ -> Alcotest.failf "%s: malformed transcript was accepted" label
+  | Error diagnostics ->
+      Alcotest.(check (list string))
+        (label ^ " code") [ "E1004" ]
+        (List.map Diag.code_or_uncoded diagnostics);
+      Alcotest.(check bool)
+        (label ^ " Warp domain") true
+        (List.for_all (fun diagnostic -> Diag.domain diagnostic = Diag.Warp) diagnostics);
+      List.iter
+        (fun diagnostic ->
+          Alcotest.(check bool)
+            (label ^ " does not echo hostile payload")
+            false
+            (String.contains (Diag.cause diagnostic) '\255'
+            || contains "hostile-payload" (Diag.cause diagnostic)))
+        diagnostics
+
+let expect_divergence label ~kind ~path ~rendered verdict =
+  match verdict with
+  | Run_transcript.Equal -> Alcotest.failf "%s: expected a divergence" label
+  | Run_transcript.Divergence divergence ->
+      Alcotest.(check string)
+        (label ^ " kind") kind
+        (Run_transcript.divergence_kind_name divergence.kind);
+      Alcotest.(check string)
+        (label ^ " path") path
+        (Run_transcript.position_path divergence.position);
+      Alcotest.(check string) (label ^ " rendering") rendered (Run_transcript.render divergence)
+
+let test_parse_roundtrip_and_payload_framing () =
+  let bytes =
+    canonical
+      [
+        observation ~value:"header-looking\nvalue\n"
+          [ event ~output:"raw\ntrace index=999 operation=not-a-header\n\255" () ];
+      ]
+  in
+  let transcript = parse_ok "framed payload parse" bytes in
+  Alcotest.(check string)
+    "parse then serialize is identity" bytes
+    (Run_transcript.serialize transcript);
+  match Run_transcript.observations transcript with
+  | [ { value = "header-looking\nvalue\n"; trace = [ { output; _ } ] } ] ->
+      Alcotest.(check string)
+        "Console payload remains exact raw bytes"
+        "raw\ntrace index=999 operation=not-a-header\n\255" output
+  | _ -> Alcotest.fail "framed transcript decoded unexpected observations"
+
+let test_parser_rejects_every_noncanonical_class () =
+  let valid = canonical [ observation [ event () ] ] in
+  let replace_once needle replacement source =
+    let needle_length = String.length needle in
+    let rec find index =
+      if index + needle_length > String.length source then
+        Alcotest.failf "test fixture lacks %S" needle
+      else if String.sub source index needle_length = needle then
+        String.sub source 0 index ^ replacement
+        ^ String.sub source (index + needle_length) (String.length source - index - needle_length)
+      else find (index + 1)
+    in
+    find 0
+  in
+  let cases =
+    [
+      ("unknown version", replace_once "format=1" "format=2" valid);
+      ("field spelling", replace_once "observations=" "observationz=" valid);
+      ( "field order",
+        replace_once "value-bytes=2 trace-events=1" "trace-events=1 value-bytes=2" valid );
+      ("alternate whitespace", replace_once "format=1 observations" "format=1  observations" valid);
+      ("CRLF", replace_once "observations=1\n" "observations=1\r\n" valid);
+      ("noncanonical count", replace_once "observations=1" "observations=01" valid);
+      ("signed count", replace_once "observations=1" "observations=+1" valid);
+      ("empty count", replace_once "observations=1" "observations=" valid);
+      ("nondigit count", replace_once "observations=1" "observations=x" valid);
+      ("noncanonical length", replace_once "value-bytes=2" "value-bytes=02" valid);
+      ("uppercase hash", replace_once console_print_hash (String.make 63 '0' ^ "A") valid);
+      ("short hash", replace_once console_print_hash (String.make 63 '0') valid);
+      ("long hash", replace_once console_print_hash (String.make 65 '0') valid);
+      ("nonhex hash", replace_once console_print_hash (String.make 63 '0' ^ "g") valid);
+      ("observation index", replace_once "observation index=0" "observation index=1" valid);
+      ("trace index", replace_once "trace index=0" "trace index=1" valid);
+      ("incorrect observation count", replace_once "observations=1" "observations=0" valid);
+      ("incorrect trace count", replace_once "trace-events=1" "trace-events=0" valid);
+      ("truncated value", replace_once "value-bytes=2" "value-bytes=999" valid);
+      ("truncated output", replace_once "output-bytes=0" "output-bytes=1" valid);
+      ("value without LF", replace_once "trace-events=1\n0\ntrace" "trace-events=1\n00trace" valid);
+      ("trailing bytes", valid ^ "\255hostile-payload");
+      ("empty input", "");
+    ]
+  in
+  List.iter (fun (label, bytes) -> expect_invalid label bytes) cases;
+  expect_invalid "non-Console output attribution"
+    (canonical [ observation [ event ~operation:zero_hash ~output:"hostile-payload" () ] ]);
+  expect_invalid "overflowing decimal"
+    ("jacquard-run-transcript format=1 observations=" ^ String.make 128 '9' ^ "\n")
+
+let test_compare_outcomes_and_exact_rendering () =
+  let base =
+    parse_ok "base comparison transcript"
+      (canonical [ observation [ event ~output:"left\n" () ]; observation ~index:1 [] ])
+  in
+  Alcotest.(check bool)
+    "equal transcript" true
+    (match Run_transcript.compare base base with Run_transcript.Equal -> true | _ -> false);
+  let value =
+    parse_ok "value comparison transcript"
+      (canonical
+         [ observation ~value:"1\n" [ event ~output:"left\n" () ]; observation ~index:1 [] ])
+  in
+  expect_divergence "value" ~kind:"value-divergence" ~path:"observation[0].value"
+    ~rendered:"  at observation[0].value:\n    - \"0\\n\"\n    + \"1\\n\""
+    (Run_transcript.compare base value);
+  let value_and_trace =
+    parse_ok "value-before-trace comparison transcript"
+      (canonical
+         [ observation ~value:"1\n" [ event ~output:"right\t" () ]; observation ~index:1 [] ])
+  in
+  expect_divergence "value precedes trace" ~kind:"value-divergence" ~path:"observation[0].value"
+    ~rendered:"  at observation[0].value:\n    - \"0\\n\"\n    + \"1\\n\""
+    (Run_transcript.compare base value_and_trace);
+  let operation_base =
+    parse_ok "operation base transcript"
+      (canonical [ observation [ event ~operation:zero_hash () ]; observation ~index:1 [] ])
+  in
+  let trace_operation =
+    parse_ok "operation comparison transcript"
+      (canonical [ observation [ event ~operation:one_hash () ]; observation ~index:1 [] ])
+  in
+  expect_divergence "trace operation" ~kind:"trace-divergence" ~path:"observation[0].trace[0]"
+    ~rendered:
+      (Printf.sprintf
+         "  at observation[0].trace[0]:\n\
+         \    - operation=%s output=\"\"\n\
+         \    + operation=%s output=\"\""
+         zero_hash one_hash)
+    (Run_transcript.compare operation_base trace_operation);
+  let trace_output =
+    parse_ok "output comparison transcript"
+      (canonical [ observation [ event ~output:"right\t" () ]; observation ~index:1 [] ])
+  in
+  expect_divergence "trace output" ~kind:"trace-divergence" ~path:"observation[0].trace[0]"
+    ~rendered:
+      (Printf.sprintf
+         "  at observation[0].trace[0]:\n\
+         \    - operation=%s output=\"left\\n\"\n\
+         \    + operation=%s output=\"right\\t\""
+         console_print_hash console_print_hash)
+    (Run_transcript.compare base trace_output);
+  let observation_prefix =
+    parse_ok "observation prefix" (canonical [ observation [ event ~output:"left\n" () ] ])
+  in
+  expect_divergence "observation prefix" ~kind:"length-divergence" ~path:"observation[1]"
+    ~rendered:
+      "  at observation[1]:\n\
+      \    - observation value=\"0\\n\" value-bytes=2 trace-events=0\n\
+      \    + <missing>"
+    (Run_transcript.compare base observation_prefix);
+  let trace_prefix =
+    parse_ok "trace prefix" (canonical [ observation []; observation ~index:1 [] ])
+  in
+  expect_divergence "trace prefix" ~kind:"length-divergence" ~path:"observation[0].trace[0]"
+    ~rendered:
+      (Printf.sprintf
+         "  at observation[0].trace[0]:\n    - operation=%s output=\"left\\n\"\n    + <missing>"
+         console_print_hash)
+    (Run_transcript.compare base trace_prefix)
+
+let test_equal_iff_canonical_bytes_equal () =
+  let samples =
+    [
+      canonical [];
+      canonical [ observation [] ];
+      canonical [ observation [ event () ] ];
+      canonical [ observation ~value:"line one\nline two\n" [ event ~output:"raw\000bytes" () ] ];
+      canonical
+        [ observation []; observation ~index:1 ~value:"last\n" [ event ~operation:one_hash () ] ];
+    ]
+  in
+  let transcripts = List.map (parse_ok "byte-equivalence sample") samples in
+  List.iteri
+    (fun left_index left ->
+      List.iteri
+        (fun right_index right ->
+          let equal =
+            match Run_transcript.compare left right with Run_transcript.Equal -> true | _ -> false
+          in
+          let byte_equal =
+            String.equal (Run_transcript.serialize left) (Run_transcript.serialize right)
+          in
+          Alcotest.(check bool)
+            (Printf.sprintf "pair %d/%d structural iff byte equality" left_index right_index)
+            byte_equal equal)
+        transcripts)
+    transcripts
+
+type mutation = { base : string; changed : string; expected_path : string }
+
+let generated_mutation ~trace_mutation ~observation_count ~observation_choice ~trace_count
+    ~trace_choice =
+  let observation_index = observation_choice mod observation_count in
+  let trace_index = trace_choice mod trace_count in
+  let observations ~mutated =
+    List.init observation_count (fun index ->
+        let value =
+          if mutated && (not trace_mutation) && index = observation_index then
+            Printf.sprintf "value-%d-mutated\n" index
+          else Printf.sprintf "value-%d\n" index
+        in
+        let events =
+          List.init trace_count (fun event_index ->
+              let output =
+                if
+                  mutated && trace_mutation && index = observation_index
+                  && event_index = trace_index
+                then Printf.sprintf "output-%d-%d-mutated" index event_index
+                else Printf.sprintf "output-%d-%d" index event_index
+              in
+              event ~index:event_index ~output ())
+        in
+        observation ~index ~value events)
+  in
+  {
+    base = canonical (observations ~mutated:false);
+    changed = canonical (observations ~mutated:true);
+    expected_path =
+      (if not trace_mutation then Printf.sprintf "observation[%d].value" observation_index
+       else Printf.sprintf "observation[%d].trace[%d]" observation_index trace_index);
+  }
+
+let test_seeded_single_mutation_reports_position () =
+  let seen_later_observation = ref false in
+  let seen_later_trace = ref false in
+  let check_one ~trace_mutation ~observation_count ~observation_choice ~trace_count ~trace_choice =
+    let mutation =
+      generated_mutation ~trace_mutation ~observation_count ~observation_choice ~trace_count
+        ~trace_choice
+    in
+    match (Run_transcript.parse mutation.base, Run_transcript.parse mutation.changed) with
+    | Ok base, Ok changed ->
+        let copy_is_equal =
+          match Run_transcript.compare base base with Run_transcript.Equal -> true | _ -> false
+        in
+        let mutation_position =
+          match Run_transcript.compare base changed with
+          | Run_transcript.Equal -> None
+          | Run_transcript.Divergence divergence ->
+              Some (Run_transcript.position_path divergence.position)
+        in
+        copy_is_equal && mutation_position = Some mutation.expected_path
+    | Error _, _ | _, Error _ -> false
+  in
+  let property =
+    QCheck.Test.make ~count:200
+      ~name:"value and trace transcript mutations report their logical positions"
+      QCheck.(quad (int_range 1 5) nat_small (int_range 1 4) nat_small)
+      (fun (observation_count, observation_choice, trace_count, trace_choice) ->
+        let observation_index = observation_choice mod observation_count in
+        let trace_index = trace_choice mod trace_count in
+        if observation_index > 0 then seen_later_observation := true;
+        if trace_index > 0 then seen_later_trace := true;
+        check_one ~trace_mutation:false ~observation_count ~observation_choice ~trace_count
+          ~trace_choice
+        && check_one ~trace_mutation:true ~observation_count ~observation_choice ~trace_count
+             ~trace_choice)
+  in
+  QCheck.Test.check_exn ~rand:(Random.State.make [| 0x194; 0x52; 0x1004 |]) property;
+  Alcotest.(check bool) "fixed seed reaches a later observation" true !seen_later_observation;
+  Alcotest.(check bool) "fixed seed reaches a later trace event" true !seen_later_trace
+
 let suite =
   [
     Alcotest.test_case "pure canonical determinism" `Quick test_pure_is_canonical_and_deterministic;
@@ -225,4 +534,13 @@ let suite =
     Alcotest.test_case "multiple expressions" `Quick test_multiple_expressions_keep_order;
     Alcotest.test_case "failure has no partial observation" `Quick
       test_failures_commit_no_partial_observation;
+    Alcotest.test_case "parse roundtrip and payload framing" `Quick
+      test_parse_roundtrip_and_payload_framing;
+    Alcotest.test_case "parser strict malformed coverage" `Quick
+      test_parser_rejects_every_noncanonical_class;
+    Alcotest.test_case "compare outcomes and exact rendering" `Quick
+      test_compare_outcomes_and_exact_rendering;
+    Alcotest.test_case "Equal iff canonical bytes equal" `Quick test_equal_iff_canonical_bytes_equal;
+    Alcotest.test_case "seeded single mutation reports position" `Quick
+      test_seeded_single_mutation_reports_position;
   ]


### PR DESCRIPTION
## Summary

Relational Warp now needs to consume the canonical `run-transcript-v1`
artifacts added by RW.1 without weakening their byte contract. This change adds
strict decoding and a pure first-divergence comparator while leaving CLI and
presentation policy to later slices.

- decode the frozen transcript grammar with exact literals, canonical decimal
  and hash spellings, contiguous indices, byte-length framing, and full-input
  consumption
- return typed Warp `E1004` diagnostics for malformed transcripts without
  reflecting untrusted payload bytes
- reject attributed output on every operation except the already-frozen
  Console `print` member
- compare decoded observations deterministically by value, then trace operation
  and output, reporting value, trace, or strict-prefix length divergence
- render the first structured divergence with the existing diff frame and
  escaped payloads, while retaining structured sides for RW.4 redaction
- pin hostile framing, binary payloads, exact divergence text, fixed-seed
  mutation positions, and canonical-byte equality equivalence
- update the mechanically checked release inventories from 853 to 858 cases

## Invariants and scope

- parsing and comparison are pure and perform no workspace or user-data I/O
- `Equal` is equivalent to byte equality for accepted canonical transcripts
- value comparison precedes trace comparison, and only the first divergence is
  returned
- `schedule-trace-v1`, the 27-form kernel, lowering, `HASH_V0`, stores, native
  code, prelude identities, and the RW.1 transcript bytes are unchanged
- the `jacquard relate` command, `E1003` CLI failure boundary, redaction, and
  native transcript support remain separate follow-up slices

## Verification

- [x] `opam exec -- dune build --root "$PWD" @all @doc`
- [x] `opam exec -- dune fmt --root "$PWD"` with a clean tracked tree
- [x] full direct Alcotest/QCheck runner: 858/858 cases
- [x] focused `run-transcript.*` and errors-catalog coverage
- [x] exact value, trace, and length divergence cram output
- [x] existing `test/cli/run.t` and `test/cli/schedule-replay.t`
- [x] focused release-inventory guard after the count update
- [x] historical release manifests against base
  `b9cffa6cf95bd8bf3ebed6b357fc995cf46b0c63`
- [x] independent Claude Fable 5 review at xhigh effort: PASS on exact commit
  `fed0b58ccce3f73088b264a17d23785e32d3b30c`, with no blockers,
  architecture conflicts, or disputed tests

The forced Dune alias exercised the full repository graph locally. The host's
ptrace wrapper prevents LeakSanitizer from initializing in the native sanitizer
lanes; all ordinary tests and doctests passed. The required GitHub native-parity
jobs remain the merge authority for those lanes.

## Risk and follow-up

The parser deliberately pins the already-frozen Console `print` hash so a
forged transcript cannot attribute raw output to another operation. The final
canonical re-serialization check adds one linear pass and directly enforces the
accepted-input round-trip law; transcripts are evidence artifacts, not a native
hot path. RW.3 will add the CLI and `E1003` boundary, and RW.4 will redact the
structured sides before presentation.
