### PR TITLE
feat: add schedule relational runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 794
-Alcotest/QCheck cases, 48 cram transcripts, 27 documentation examples, native
+semantic boundary remains historical; the current successor is pinned by 859
+Alcotest/QCheck cases, 54 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
 runtime/output license exception and packages the native runtime. The current
@@ -369,6 +369,7 @@ The main commands are:
 
 ```bash
 jac run FILE.jac [--allow fs] [--allow net] [--dry-run]
+jac relate FILE.jac --vary schedule=N --seed S [--allow EFFECT ...]
 jac check FILE.jac [--print-sigs] [--manifest fs,net,console]
 jac hash FILE.jac
 jac fmt FILE.jac

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -51,6 +51,7 @@ let diagnostic_summary = function
   | "E0608" -> "Store operation could not complete"
   | "E0609" -> "Semantic diff input could not be read"
   | "E0610" -> "Semantic diff input is invalid"
+  | "E0611" -> "Relational constituent store could not be prepared"
   | "E0702" -> "Required prelude contents are unavailable"
   | "E0704" -> "Store add accepts declarations only"
   | "E0801" -> "Compared model result types do not agree"
@@ -59,6 +60,7 @@ let diagnostic_summary = function
   | "E0908" -> "Schedule configuration or trace is invalid"
   | "E1001" -> "Test file has an expression at top level"
   | "E1002" -> "Dry-run cannot sandbox eval"
+  | "E1003" -> "Relational runs diverged"
   | "E1101" -> "Program is outside the native v1 compilation subset"
   | "E1102" -> "Program requires the interpreter tier"
   | "E1103" -> "Native build could not complete"
@@ -75,6 +77,7 @@ let diagnostic_next_step = function
   | "E0606" -> "Pass the path to an existing Jacquard store."
   | "E0608" -> "Correct the store state described here and try again."
   | "E0609" | "E0610" -> "Pass readable, valid semantic-diff inputs."
+  | "E0611" -> "Choose a writable temporary directory and try again."
   | "E0702" -> "Load the complete prelude and try again."
   | "E0704" -> "Pass declarations to `store add`, not a top-level expression."
   | "E0801" -> "Compare models whose result types agree."
@@ -83,6 +86,7 @@ let diagnostic_next_step = function
   | "E0908" -> "Correct the schedule option or trace described here."
   | "E1001" -> "Keep test files declaration-only."
   | "E1002" -> "Run this program without --dry-run or remove eval from its authority row."
+  | "E1003" -> "Review the first divergence and make the result and routed effects invariant."
   | "E1101" -> "Run the program with the interpreter or rewrite the unsupported construct."
   | "E1102" -> "Run this program with the interpreter."
   | "E1103" -> "Correct the native toolchain or build input and try again."
@@ -143,6 +147,20 @@ let fresh_governance_analysis_dir () =
   in
   at_exit (fun () -> try unlink_tree dir with Unix.Unix_error _ | Sys_error _ -> ());
   dir
+
+(* Relational constituents need collision-free stores even when several begin in one millisecond.
+   Cleanup follows no links and remains confined to the exact private directory supplied here. *)
+let fresh_relate_store_dir () = Filename.temp_dir ~perms:0o700 "jacquard-relate-" ".store"
+
+let remove_relate_store_dir dir =
+  let rec unlink_tree path =
+    match (Unix.lstat path).Unix.st_kind with
+    | Unix.S_DIR ->
+        Array.iter (fun name -> unlink_tree (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+  in
+  try unlink_tree dir with Unix.Unix_error _ | Sys_error _ -> ()
 
 let prelude_dir_of = function
   | Some d -> d
@@ -224,11 +242,12 @@ let open_ctx ~prelude ~store_dir =
 
 (* Process a file's top-level forms in order: declarations go into the store; expressions
    are handed to [on_expr]. *)
-let process_forms ?origin ?(on_decl = fun _ _ -> ()) ~syntax store ~file src ~on_expr =
+let process_forms ?origin ?(on_decl = fun _ _ -> ()) ?(emit_warnings = true) ~syntax store ~file src
+    ~on_expr =
   match parse_tops ~syntax ~names:(Store.names_view store) ~file src with
   | Error ds -> Error ds
   | Ok (tops, warnings) ->
-      print_warnings warnings;
+      if emit_warnings then print_warnings warnings;
       let rec go = function
         | [] -> Ok ()
         | parsed :: rest -> (
@@ -519,6 +538,158 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
                           List.iter print_diagnostic ds;
                           exit_unhandled
                       | Error ds -> print_diags ds)))))
+
+(* --- relate --- *)
+
+type relate_failure =
+  | Relate_diagnostics of Diag.t list
+  | Relate_runtime of Runtime_err.t
+  | Relate_refused of Diag.t list
+
+let relate_store_failure action error =
+  Relate_diagnostics
+    [
+      cli_diagnostic ~code:"E0611"
+        (Printf.sprintf "relate could not %s its private constituent store: %s" action
+           (Printexc.to_string error));
+    ]
+
+let protect_relate_store_operation action operation =
+  try Ok (operation ())
+  with (Sys_error _ | Unix.Unix_error _) as error -> Error (relate_store_failure action error)
+
+let relate_constituent ~file ~source ~allows ~prelude ~root_seed ~schedule_seed ~syntax
+    ~console_read ~emit_warnings =
+  match protect_relate_store_operation "create" fresh_relate_store_dir with
+  | Error failure -> Error failure
+  | Ok store_dir ->
+      Fun.protect
+        ~finally:(fun () -> remove_relate_store_dir store_dir)
+        (fun () ->
+          match
+            protect_relate_store_operation "initialize" (fun () ->
+                open_ctx ~prelude ~store_dir:(Some store_dir))
+          with
+          | Error failure -> Error failure
+          | Ok (Error diagnostics) -> Error (Relate_diagnostics diagnostics)
+          | Ok (Ok (store, ctx)) -> (
+              Eval.set_coverage_tracking ctx false;
+              let rec grant_all = function
+                | [] -> Ok ()
+                | allow :: rest -> (
+                    match
+                      Prelude.grant ~console_read ctx allow ~infer_cache:None
+                        ~out:(fun _ -> ())
+                        ~seed:root_seed
+                    with
+                    | Ok () -> grant_all rest
+                    | Error diagnostics -> Error diagnostics)
+              in
+              match grant_all allows with
+              | Error diagnostics -> Error (Relate_diagnostics diagnostics)
+              | Ok () -> (
+                  match make_checker store with
+                  | Error diagnostics -> Error (Relate_diagnostics diagnostics)
+                  | Ok checker -> (
+                      let granted = granted_hashes store allows in
+                      let recorder = Run_transcript.create () in
+                      let refused = ref None in
+                      let runtime_failure = ref None in
+                      let on_expr expression =
+                        match Check.check_top checker (Kernel.Expr expression) with
+                        | Error diagnostics -> Error diagnostics
+                        | Ok { Check.row; warnings; _ } -> (
+                            if emit_warnings then List.iter print_diagnostic warnings;
+                            match
+                              Check.manifest_errors checker ~grantable:Prelude.grantable_names
+                                ~granted
+                                (Option.value row ~default:Types.empty_row)
+                            with
+                            | _ :: _ as diagnostics ->
+                                refused := Some diagnostics;
+                                Error diagnostics
+                            | [] -> (
+                                match
+                                  Run_transcript.record_expression recorder ctx (fun () ->
+                                      Result.map
+                                        (fun (scheduled : Round_robin.scheduled) -> scheduled.value)
+                                        (Round_robin.run_expr_scheduled ctx
+                                           ~mode:
+                                             (Round_robin.Seeded_schedule { seed = schedule_seed })
+                                           expression))
+                                with
+                                | Ok _ -> Ok ()
+                                | Error error ->
+                                    runtime_failure := Some error;
+                                    Error []))
+                      in
+                      match process_forms ~emit_warnings ~syntax store ~file source ~on_expr with
+                      | Ok () -> Ok (Run_transcript.transcript recorder)
+                      | Error _ when Option.is_some !runtime_failure ->
+                          Error (Relate_runtime (Option.get !runtime_failure))
+                      | Error _ when Option.is_some !refused ->
+                          Error (Relate_refused (Option.get !refused))
+                      | Error diagnostics -> Error (Relate_diagnostics diagnostics)))))
+
+let print_relate_failure = function
+  | Relate_diagnostics diagnostics -> print_diags diagnostics
+  | Relate_refused diagnostics ->
+      List.iter print_diagnostic diagnostics;
+      exit_unhandled
+  | Relate_runtime error -> (
+      print_runtime_error error;
+      match error with Runtime_err.Unhandled _ -> exit_unhandled | _ -> exit_runtime)
+
+let relate_cmd file runs seed allows prelude syntax =
+  let source = read_file file in
+  let schedule_seeds = Relate.schedule_seeds ~root_seed:seed ~count:runs in
+  let captured_console_input = ref None in
+  let rec compare_runs baseline run_index = function
+    | [] ->
+        Printf.printf "relate runs=%d seed=%d verdict=equal\n" runs seed;
+        ok
+    | schedule_seed :: rest -> (
+        let console_read, finish_console_input =
+          match !captured_console_input with
+          | None ->
+              let reversed = ref [] in
+              ( (fun () ->
+                  let line = try Stdlib.read_line () with End_of_file -> "" in
+                  reversed := line :: !reversed;
+                  line),
+                fun () -> captured_console_input := Some (List.rev !reversed) )
+          | Some captured ->
+              let remaining = ref captured in
+              ( (fun () ->
+                  match !remaining with
+                  | line :: rest ->
+                      remaining := rest;
+                      line
+                  | [] -> ""),
+                fun () -> () )
+        in
+        match
+          relate_constituent ~file ~source ~allows ~prelude ~root_seed:seed ~schedule_seed ~syntax
+            ~console_read ~emit_warnings:(run_index = 1)
+        with
+        | Error failure -> print_relate_failure failure
+        | Ok transcript -> (
+            finish_console_input ();
+            match baseline with
+            | None -> compare_runs (Some transcript) (run_index + 1) rest
+            | Some first -> (
+                match Run_transcript.compare first transcript with
+                | Run_transcript.Equal -> compare_runs baseline (run_index + 1) rest
+                | Run_transcript.Divergence divergence ->
+                    print_diags
+                      [
+                        cli_diagnostic ~code:"E1003"
+                          (Printf.sprintf "Runs 1 and %d diverged with %s:\n%s" run_index
+                             (Run_transcript.divergence_kind_name divergence.kind)
+                             (Run_transcript.render divergence));
+                      ])))
+  in
+  compare_runs None 1 schedule_seeds
 
 (* --- check --- *)
 
@@ -1908,6 +2079,44 @@ let seed_arg =
     & info [ "seed" ] ~docv:"SEED"
         ~doc:"Seed for the dist sampling handler (default: OS entropy); use for reproducible runs.")
 
+let required_seed_arg =
+  Arg.(
+    required
+    & opt (some int) None
+    & info [ "seed" ] ~docv:"SEED"
+        ~doc:"Required root seed for reproducible relational runs and Dist sampling.")
+
+let schedule_variation =
+  let expected () = Error (`Msg "expected schedule=N with N > 0") in
+  let parse value =
+    let prefix = "schedule=" in
+    if not (String.starts_with ~prefix value) then expected ()
+    else
+      let count =
+        String.sub value (String.length prefix) (String.length value - String.length prefix)
+      in
+      let rec decimal index =
+        index = String.length count
+        || match count.[index] with '0' .. '9' -> decimal (index + 1) | _ -> false
+      in
+      if String.equal count "" || not (decimal 0) then expected ()
+      else
+        match int_of_string_opt count with
+        | Some count when count > 0 -> Ok count
+        | _ -> expected ()
+  in
+  let print formatter count = Format.fprintf formatter "schedule=%d" count in
+  Arg.conv (parse, print)
+
+let vary_arg =
+  Arg.(
+    required
+    & opt (some schedule_variation) None
+    & info [ "vary" ] ~docv:"KIND"
+        ~doc:
+          "Required variation; RW.3 supports only schedule=N with N > 0. Run 1 uses the root seed; \
+           later runs use successive SplitMix64 outputs, skipping already accepted seeds.")
+
 let infer_cache_arg =
   Arg.(
     value
@@ -1950,6 +2159,18 @@ let run_t =
       $ diagnostic_format_arg $ file_arg $ allows_arg $ prelude_arg $ store_dir_opt_arg $ seed_arg
       $ infer_cache_arg $ origin_arg $ dry_run_arg $ schedule_record_arg $ schedule_replay_arg
       $ schedule_fork_arg $ syntax_arg)
+
+let relate_t =
+  Cmd.v
+    (Cmd.info "relate"
+       ~doc:
+         "Run a .jac surface or .jqd bootstrap file under distinct deterministic schedules and \
+          compare complete result and routed-root transcripts. Console input is captured in run 1 \
+          and replayed by ordinal in later runs.")
+    Term.(
+      const (configure_diagnostics relate_cmd)
+      $ diagnostic_format_arg $ file_arg $ vary_arg $ required_seed_arg $ allows_arg $ prelude_arg
+      $ syntax_arg)
 
 let print_sigs_arg =
   Arg.(
@@ -2669,6 +2890,7 @@ let main =
     (Cmd.info "jacquard" ~version:Version.version ~doc:"The Jacquard language toolchain")
     [
       run_t;
+      relate_t;
       check_t;
       hash_t;
       fmt_t;

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,8 @@ project shape from file names alone.
   deferred to C4+.
 - `warp-testing.md`: Warp test model, rows, handlers, cache, properties, and
   world lanes.
+- `relational-warp.md`: relational observation contract, canonical run
+  transcripts, and the shipped deterministic schedule-variation CLI lane.
 - `errors.md`: diagnostic code catalog.
 
 ## Release 0.1 Evidence

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -75,6 +75,10 @@ jac run PROGRAM.jac
 jac run PROGRAM.jac --allow console --allow net
 jac run PROGRAM.jac --dry-run
 
+# Compare complete results and routed root effects under distinct schedules.
+jac relate PROGRAM.jac --vary schedule=8 --seed 42
+jac relate PROGRAM.jac --vary schedule=8 --seed 42 --allow console
+
 # Format and identify code.
 jac fmt PROGRAM.jac
 jac fmt PROGRAM.jac --write
@@ -122,6 +126,12 @@ syntactically tail-resumptive clause.
 
 Use stderr for diagnostics and stdout for successful program output. Always
 provide an explicit seed for reproducible sampling and property tests.
+`relate` success stdout is one verdict line; constituent values and Console
+output are captured rather than printed. Console input is read from the process
+only during run 1, captured by call ordinal, and replayed from a fresh cursor in
+every later run; calls beyond the captured list receive EOF (`""`). A completed
+transcript difference is Warp diagnostic E1003 and status 1. Constituent
+diagnostic, runtime, and authority failures retain statuses 1, 2, and 3.
 
 ## Surface Syntax
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -117,6 +117,7 @@ malformed source, path, or host-message byte in a string field is replaced with 
 | E0608 | unknown --kind value | `jacquard store rename --kind bogus` |
 | E0609 | invalid, mismatched, or unreadable diff operands | diffing a file against a store |
 | E0610 | diff source contains a top-level expression | diffing a runnable script instead of declarations |
+| E0611 | relational constituent store cannot be created or initialized | running `jacquard relate` with an unusable temporary directory |
 
 ## Prelude and grants (E07xx)
 
@@ -185,6 +186,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 |------|---------|---------|
 | E1001 | expression at top level of a test file | `jacquard test file.jqd` where the file ends with `(app (var main))` |
 | E1002 | eval under --dry-run | a program whose row includes `eval` run with `--dry-run` |
+| E1003 | completed relational runs have different result or routed-root transcripts | `jacquard relate program.jac --vary schedule=8 --seed 42` finds a schedule-dependent result |
 | E1004 | malformed, unsupported, or noncanonical run-transcript-v1 bytes | a transcript with a noncontiguous observation index or truncated payload |
 
 ## Native compilation (E11xx)

--- a/docs/relational-warp.md
+++ b/docs/relational-warp.md
@@ -1,9 +1,10 @@
 # Relational Warp lanes: testable hyperproperties
 
-Status: **RW.0 frozen for v0 (2026-08-12).** This document fixes the
-observation and variation contract for implementation tasks RW.1 through RW.7.
-It does not claim that the `SameUnder` form or `jacquard relate` command has
-shipped.
+Status: **RW.0 frozen for v0 (2026-08-12); RW.1-RW.3 schedule tooling
+shipped.** This document fixes the observation and variation contract for
+implementation tasks RW.1 through RW.7. `run-transcript-v1`, its canonical
+comparator, and `jacquard relate FILE --vary schedule=N --seed S` now ship.
+`SameUnder` and the other variation kinds remain future work.
 
 Read this document with [Warp testing](warp-testing.md),
 [structured concurrency](concurrency.md), and the
@@ -152,14 +153,44 @@ authority or an unhandled effect into a misleading equivalence result.
 ### 6. CLI exit and diagnostic contract
 
 A relational divergence is diagnostic `E1003`, written to stderr, and exits
-with status 1. The row is added to `docs/errors.md` when `relate` ships; RW.0
-reserves the code but remains a one-document design freeze. Equality exits 0.
+with status 1. RW.0 reserved the code; RW.3 now ships its row in
+`docs/errors.md`. Equality exits 0.
 
 Existing classifications remain in force: invalid command syntax uses
 Cmdliner's status 124, evaluation/runtime failure uses status 2, and an
 unhandled effect or grant refusal uses status 3. A failed constituent run
 keeps its existing diagnostic and status. `E1003` reports only a successful
 pair or set of runs whose frozen observations differ.
+
+### RW.3 shipped schedule command
+
+The shipped layer-2 surface is:
+
+    jacquard relate FILE --vary schedule=N --seed S [--allow EFFECT ...]
+
+`FILE`, `--vary`, and `--seed` are required. RW.3 accepts only positive
+`schedule=N`; malformed, non-positive, and future variation spellings are
+Cmdliner usage errors. Run 1 uses scheduler seed `S`. Later scheduler seeds are
+successive distinct `Int64.to_int` outputs from the existing SplitMix64 stream
+rooted at `S`. Dist and every other input keep root seed `S`.
+
+Each constituent gets a fresh ephemeral store, evaluator, checker, recorder,
+and seeded scheduler. Declarations and all top-level expressions run in source
+order. Grants are forwarded unchanged, authority is checked before each
+expression, and only successful expressions commit observations. Surface and
+checker warnings are emitted only for run 1. Constituent values and Console
+output do not reach success stdout; equality prints exactly
+`relate runs=N seed=S verdict=equal`.
+
+Console input is made reproducible without changing ordinary `jacquard run`.
+Run 1 reads the process Console and captures each `read-line` result by ordinal.
+Every later run gets a fresh cursor over that exact list. A later call beyond
+the captured list returns EOF (`""`) and never consumes more process input.
+
+Runs 2 through N compare with run 1 in order and stop at the first difference.
+E1003 names one-based run indices and embeds the canonical zero-based RW.2
+first-divergence frame. A constituent failure retains its ordinary status and
+is never reclassified as E1003.
 
 ## Two layers
 
@@ -186,7 +217,8 @@ than reusing an ordinary-case entry.
 
 ### Layer 2: root-driven CLI variation
 
-The CLI can vary inputs and authority available only at the root:
+The CLI can vary inputs and authority available only at the root. Schedule
+variation ships in RW.3; the other two lines remain planned:
 
     jacquard relate FILE --vary schedule=N --seed S [--allow EFFECT ...]
     jacquard relate FILE --vary secret=NAME --seed S [--allow EFFECT ...]

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,8 +6,8 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `858`
-- Cram transcript files: `52`
+- Alcotest/QCheck cases: `859`
+- Cram transcript files: `54`
 - Doctest examples: `28` across 8 documents
 
 The test count includes six DX.2 filesystem-boundary cases and six DX.5/DX.7
@@ -43,6 +43,9 @@ the existing native transcript without changing the cram or doctest counts.
 Relational Warp transcript recording adds six compiled cases and one internal
 tooling transcript; strict transcript parsing and semantic comparison add five
 compiled cases while extending that existing transcript.
+The RW.3 schedule relation adds one compiled deterministic seed-law case and
+two CLI transcripts covering equality, exact divergence, and preserved
+constituent failure classes.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 858 compiled Alcotest/QCheck cases, 52 recursive
+The current successor inventory is exactly 859 compiled Alcotest/QCheck cases, 54 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,8 +759,8 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `858`
-- Cram transcript files: `52`
+- Alcotest/QCheck cases: `859`
+- Cram transcript files: `54`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
 `channel-contract` cases plus the `store/9` Channel-private-hash case took the
@@ -801,7 +801,9 @@ an existing native transcript, producing the then-current `847 / 51 / 28`
 inventory. Relational Warp transcript recording adds six compiled cases and one
 internal tooling transcript, producing `853 / 52 / 28`; strict transcript
 parsing and semantic comparison add five compiled cases without adding another
-cram file, producing the current `858 / 52 / 28` inventory.
+cram file, producing `858 / 52 / 28`. RW.3 schedule relation adds one compiled
+seed-law case and two CLI transcripts, producing the current `859 / 54 / 28`
+inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -1236,13 +1236,18 @@ let install_dry (ctx : Eval.ctx) ~(audit : string list ref) : (unit, Diag.t list
     this so it never suggests granting a pure effect. *)
 let grantable_names = [ "clock"; "console"; "dist"; "eval"; "fs"; "infer"; "net"; "secret" ]
 
-(** [grant ctx name ~out ~seed] installs the root handler for effect [name] (case-insensitive:
-    "Eval" and "eval" both work); [seed] feeds the dist sampling handler only. Returns E0703 for
-    effects that exist but are not grantable (e.g. [abort]) and unknown effect names alike; keep the
+(** [grant ?console_read ctx name ~out ~seed] installs the root handler for effect [name]
+    (case-insensitive: "Eval" and "eval" both work); [seed] feeds the dist sampling handler only.
+    [console_read] replaces Console's default stdin reader when supplied, allowing multi-run tools
+    to capture and replay input without changing ordinary run behavior. Returns E0703 for effects
+    that exist but are not grantable (e.g. [abort]) and unknown effect names alike; keep the
     dispatch in sync with {!grantable_names}. *)
-let grant (ctx : Eval.ctx) name ~infer_cache ~out ~seed : (unit, Diag.t list) result =
+let grant ?console_read (ctx : Eval.ctx) name ~infer_cache ~out ~seed : (unit, Diag.t list) result =
   match String.lowercase_ascii name with
-  | "console" -> install_console ctx ~out
+  | "console" -> (
+      match console_read with
+      | None -> install_console ctx ~out
+      | Some read_line -> install_console ~read_line ctx ~out)
   | "eval" -> install_eval ctx
   | "net" -> install_net ctx
   | "dist" -> install_dist ctx ~seed

--- a/src/relate.ml
+++ b/src/relate.ml
@@ -1,0 +1,18 @@
+(** Pure deterministic input derivation shared by relational execution lanes. *)
+
+module Int_set = Set.Make (Int)
+
+(** [schedule_seeds] keeps the root seed as run one and rejects duplicate SplitMix64 candidates so
+    every accepted constituent schedule has a distinct seed. *)
+let schedule_seeds ~root_seed ~count =
+  if count <= 0 then []
+  else
+    let generator = Infer_dist.Rng.make root_seed in
+    let rec accept remaining seen reversed =
+      if remaining = 0 then List.rev reversed
+      else
+        let candidate = Int64.to_int (Infer_dist.Rng.next_int64 generator) in
+        if Int_set.mem candidate seen then accept remaining seen reversed
+        else accept (remaining - 1) (Int_set.add candidate seen) (candidate :: reversed)
+    in
+    accept (count - 1) (Int_set.singleton root_seed) [ root_seed ]

--- a/src/relate.mli
+++ b/src/relate.mli
@@ -1,0 +1,8 @@
+(** Deterministic input derivation for relational execution lanes. *)
+
+val schedule_seeds : root_seed:int -> count:int -> int list
+(** [schedule_seeds ~root_seed ~count] returns exactly [count] pairwise-distinct scheduler seeds
+    when [count] is positive. The first seed is [root_seed]; later seeds are successive distinct
+    SplitMix64 outputs derived from that root. A non-positive [count] returns the empty list. The
+    derivation is deterministic on Jacquard's supported 64-bit OCaml runtime and does not mutate
+    caller-visible state. *)

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -72,6 +72,8 @@
   ../run_transcript_trace.exe
   concurrency-evidence.t
   run-transcript.t
+  relate.t
+  relate-divergence.t
   ../../demos/concurrency/concurrency_evidence.exe
   ../../demos/governed-workspace/live_evidence.exe
   (source_tree ../native-parallel)

--- a/test/cli/relate-divergence.t
+++ b/test/cli/relate-divergence.t
@@ -1,0 +1,41 @@
+RW.3 compares each complete run with run 1. This rendezvous fixture makes its
+result contain both receive order and child-completion results. Root seed 4 and
+its first derived schedule agree, while the second derived schedule deliberately
+disagrees. E1003 therefore proves compare-all-to-baseline order, one-based run
+indices, and the canonical zero-based RW.2 frame for the second top-level result.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ cat > receive-order.jac <<'EOF'
+  > receive-order() =
+  >   match channel.open(0) {
+  >     | Ok(channel) -> {
+  >         let first = async.spawn(fn () -> channel.send(channel, 1))
+  >         let second = async.spawn(fn () -> channel.send(channel, 2))
+  >         -- Deliberately schedule-dependent: the returned pair embeds child send/completion order.
+  >         let left = channel.recv(channel)
+  >         let right = channel.recv(channel)
+  >         Ok((left, right, async.await(first), async.await(second)))
+  >       }
+  >     | Err(error) -> Err(error)
+  >   }
+  > 
+  > 0
+  > receive-order()
+  > EOF
+  $ jacquard relate receive-order.jac --vary schedule=3 --seed 4 > divergence.out 2> divergence.err; exit_code=$?; wc -c < divergence.out; cat divergence.err; echo "exit $exit_code"
+  0
+  error[E1003]: Relational runs diverged
+    Cause: Runs 1 and 3 diverged with value-divergence:
+             at observation[1].value:
+               - "ok((ok(2), ok(1), done(ok(())), done(ok(()))))\n"
+               + "ok((ok(1), ok(2), done(ok(())), done(ok(()))))\n"
+    Next step: Review the first divergence and make the result and routed effects invariant.
+  exit 1
+
+The structured diagnostic renderer keeps the same divergence in one JSON-v1
+object on stderr, with stdout empty.
+
+  $ jacquard relate receive-order.jac --vary schedule=3 --seed 4 --diagnostic-format=json-v1 > divergence-json.out 2> divergence-json.err; exit_code=$?; wc -c < divergence-json.out; cat divergence-json.err; echo "exit $exit_code"
+  0
+  {"schema":"jacquard-diagnostic-v1","domain":"warp","code":"E1003","severity":"error","span":null,"summary":"Relational runs diverged","cause":"Runs 1 and 3 diverged with value-divergence:\n  at observation[1].value:\n    - \"ok((ok(2), ok(1), done(ok(())), done(ok(()))))\\n\"\n    + \"ok((ok(1), ok(2), done(ok(())), done(ok(()))))\\n\"","next_step":"Review the first divergence and make the result and routed effects invariant."}
+  exit 1

--- a/test/cli/relate.t
+++ b/test/cli/relate.t
@@ -1,0 +1,178 @@
+RW.3 exposes deterministic schedule relation as a narrow root-driven command.
+Its help keeps FILE, --vary, and --seed required and does not inherit unrelated
+run options.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ jacquard relate --help=plain
+  NAME
+         jacquard-relate - Run a .jac surface or .jqd bootstrap file under
+         distinct deterministic schedules and compare complete result and
+         routed-root transcripts. Console input is captured in run 1 and
+         replayed by ordinal in later runs.
+  
+  SYNOPSIS
+         jacquard relate [OPTION]… FILE
+  
+  OPTIONS
+         --allow=EFFECT
+             Grant an effect at the root (repeatable), e.g. --allow console
+             --allow eval.
+  
+         --diagnostic-format=FORMAT (absent=text)
+             Diagnostic rendering contract: text (default) or json-v1 (one
+             canonical JSON object per line on the existing diagnostic stream).
+  
+         --prelude=DIR
+             Prelude directory (default: $JACQUARD_PRELUDE or ./prelude).
+  
+         --seed=SEED (required)
+             Required root seed for reproducible relational runs and Dist
+             sampling.
+  
+         --syntax=SYNTAX (absent=auto)
+             Source or rendering syntax: auto selects surface for .jac files
+             and bootstrap otherwise; explicit values are surface/jac or
+             bootstrap/jqd.
+  
+         --vary=KIND (required)
+             Required variation; RW.3 supports only schedule=N with N > 0. Run
+             1 uses the root seed; later runs use successive SplitMix64
+             outputs, skipping already accepted seeds.
+  
+  COMMON OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         jacquard relate exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         jacquard(1)
+  
+
+The stable fixture enters a structured scope with one competing pure child,
+awaits it, and then emits Console bytes from the parent. The bytes are observed
+but never leak to success stdout; the redundancy warning is emitted once
+across all eight constituents.
+
+  $ cat > stable.jac <<'EOF'
+  > worker() = {
+  >   let child = async.spawn(fn () -> 7)
+  >   let result = async.await(child)
+  >   `op:print`("hidden")
+  >   match True {
+  >     | _ -> result
+  >     | _ -> result
+  >   }
+  > }
+  > 
+  > async.scope(fn () -> worker())
+  > EOF
+  $ jacquard relate stable.jac --vary schedule=8 --seed 42 --allow console > stable.out 2> stable.err
+  $ cat stable.out
+  relate runs=8 seed=42 verdict=equal
+  $ grep -c 'warning\[W0801\]' stable.err
+  1
+  $ cat stable.out stable.err | awk '/hidden/{count++} END{print count+0}'
+  0
+
+Console input is captured by ordinal during run 1 and replayed from a fresh
+cursor in every later run. One physical input line therefore feeds all three
+constituents instead of either later run consuming process EOF.
+
+  $ echo '`op:read-line`()' > console-input.jac
+  $ printf 'replayed\n' | jacquard relate console-input.jac --vary schedule=3 --seed 1 --allow console
+  relate runs=3 seed=1 verdict=equal
+
+Scheduler seeds never replace the fixed root seed used by Dist grants.
+
+  $ echo '`op:sample`(Bernoulli(0.9))' > fixed-dist.jac
+  $ jacquard relate fixed-dist.jac --vary schedule=4 --seed 42 --allow dist
+  relate runs=4 seed=42 verdict=equal
+
+Private-store acquisition failures remain structured store diagnostics instead
+of escaping through the CLI's unexpected-internal-error boundary.
+
+  $ touch not-a-directory
+  $ TMPDIR="$PWD/not-a-directory" jacquard relate stable.jac --vary schedule=1 --seed 1 > bad-store.out 2>&1; exit_code=$?; grep 'error\[E0611\]' bad-store.out; echo $exit_code
+  error[E0611]: Relational constituent store could not be prepared
+  1
+
+Every malformed, non-positive, or unsupported variation is a Cmdliner usage
+error and names the only supported schedule=N form.
+
+  $ jacquard relate stable.jac --vary nope --seed 1
+  Usage: jacquard relate [--help] [OPTION]… FILE
+  jacquard: option '--vary': expected schedule=N with N > 0
+  [124]
+  $ jacquard relate stable.jac --vary schedule=0 --seed 1
+  Usage: jacquard relate [--help] [OPTION]… FILE
+  jacquard: option '--vary': expected schedule=N with N > 0
+  [124]
+  $ jacquard relate stable.jac --vary secret=name --seed 1
+  Usage: jacquard relate [--help] [OPTION]… FILE
+  jacquard: option '--vary': expected schedule=N with N > 0
+  [124]
+  $ jacquard relate stable.jac --seed 1
+  Usage: jacquard relate [--help] [OPTION]… FILE
+  jacquard: required option --vary is missing
+  [124]
+  $ jacquard relate stable.jac --vary schedule=2
+  Usage: jacquard relate [--help] [OPTION]… FILE
+  jacquard: required option --seed is missing
+  [124]
+  $ jacquard relate --vary schedule=2 --seed 1
+  Usage: jacquard relate [--help] [OPTION]… FILE
+  jacquard: required argument FILE is missing
+  [124]
+
+Constituent failures keep the ordinary diagnostic, runtime, and authority
+classes instead of becoming E1003.
+
+  $ cat > malformed.jac <<'EOF'
+  > not-valid(
+  > EOF
+  $ jacquard relate malformed.jac --vary schedule=2 --seed 1
+  malformed.jac:2:1-1: error[E1220]: Surface syntax is invalid
+    Cause: expected an expression, found eof
+    Next step: Correct the syntax at this location and parse the file again.
+  malformed.jac:2:1-1: error[E1220]: Surface syntax is invalid
+    Cause: expected `,` or `)`, found eof
+    Next step: Correct the syntax at this location and parse the file again.
+  [1]
+  $ echo 'div(1, 0)' > runtime.jac
+  $ jacquard relate runtime.jac --vary schedule=2 --seed 1
+  error: Arithmetic operation failed
+    Cause: arithmetic error: division by zero
+    Next step: Correct the arithmetic inputs and run the program again.
+  [2]
+
+Private constituent stores are removed after both successful and failed runs.
+
+  $ mkdir cleanup-tmp
+  $ TMPDIR="$PWD/cleanup-tmp" jacquard relate stable.jac --vary schedule=2 --seed 1 --allow console > /dev/null 2>&1
+  $ TMPDIR="$PWD/cleanup-tmp" jacquard relate runtime.jac --vary schedule=2 --seed 1 > /dev/null 2>&1; test $? = 2
+  $ find cleanup-tmp -mindepth 1 -print | wc -l
+  0
+
+Authority refusal remains status 3.
+
+  $ echo '`op:print`("refused")' > refused.jac
+  $ jacquard relate refused.jac --vary schedule=2 --seed 1
+  error[E0814]: The program requires an effect that was not granted
+    Cause: This program requires console [world/low] — talk to the process terminal, which is not granted (performed via `print`).
+    Next step: grant it with --allow console, or handle the effect in the program
+  [3]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -30,6 +30,7 @@ let () =
       ("scope-policy", Test_scope_policy.suite);
       ("round-robin", Test_round_robin.suite);
       ("run-transcript", Test_run_transcript.suite);
+      ("relate", Test_relate.suite);
       ("exhaustive-schedule", Test_exhaustive_schedule.suite);
       ("schedule-trace", Test_schedule_trace.suite);
       ("audit", Test_audit.suite);

--- a/test/test_relate.ml
+++ b/test/test_relate.ml
@@ -1,0 +1,29 @@
+open Jacquard
+
+let test_schedule_seed_law () =
+  let expected =
+    [
+      42;
+      4_456_085_495_900_499_605;
+      2_949_826_092_126_892_291;
+      -4_084_088_288_392_011_950;
+      -2_874_173_976_596_520_044;
+      701_532_786_141_963_250;
+      -2_430_762_948_046_562_554;
+      4_028_864_712_777_624_925;
+    ]
+  in
+  let first = Relate.schedule_seeds ~root_seed:42 ~count:8 in
+  let second = Relate.schedule_seeds ~root_seed:42 ~count:8 in
+  Alcotest.(check (list int)) "exact SplitMix64 vector" expected first;
+  Alcotest.(check (list int)) "repeated derivation is identical" first second;
+  Alcotest.(check int) "requested cardinality" 8 (List.length first);
+  Alcotest.(check int) "pairwise uniqueness" 8 (List.length (List.sort_uniq Int.compare first));
+  Alcotest.(check (list int))
+    "zero count is empty" []
+    (Relate.schedule_seeds ~root_seed:42 ~count:0);
+  Alcotest.(check (list int))
+    "negative count is empty" []
+    (Relate.schedule_seeds ~root_seed:42 ~count:(-1))
+
+let suite = [ Alcotest.test_case "schedule seed vector and laws" `Quick test_schedule_seed_law ]


### PR DESCRIPTION
## Summary

Relational Warp now has its first root-driven execution lane. This change adds
the narrow `jacquard relate FILE --vary schedule=N --seed S` command and uses
the canonical RW.1/RW.2 transcript boundary to compare complete interpreter
runs under distinct deterministic schedules.

- derive pairwise-distinct scheduler seeds with root-first SplitMix64 ordering
- keep the root seed fixed for Dist and all nonscheduler inputs
- isolate every constituent in a fresh store, evaluator, checker, recorder,
  and seeded scheduler
- capture Console input in run 1 and replay it from a fresh ordinal cursor in
  every later run while retaining routed Console output in the transcript
- compare each complete transcript with run 1 and stop at the first divergence
- emit exact one-line equality output or a structured Warp E1003 diagnostic
  with the canonical RW.2 first-divergence frame
- preserve ordinary constituent diagnostic, runtime, and authority statuses
- map private constituent-store preparation failures to the new cataloged
  E0611 diagnostic and clean private stores on success and failure
- update live evidence inventories from 858 to 859 compiled cases and 52 to 54
  cram transcripts

## Invariants and scope

- only positive decimal `schedule=N` variation ships; FILE, vary, and seed are
  required, and unsupported spellings are status-124 usage errors
- scheduler-derived seeds reach only `Round_robin.Seeded_schedule`;
  `Prelude.grant` always receives the root seed
- source is read once, all top-level expressions run in source order, and only
  successful expressions commit observations
- constituent values and Console output never leak into equality stdout
- runs 2 through N compare to the run-1 baseline in order; scheduler-control
  traces are not part of the relational observation
- warnings are emitted only for constituent 1
- ordinary `jacquard run` retains its existing Console reader and warning path
- SameUnder, secret/grant variation, native relational execution, kernel/hash/
  store-format changes, and schedule-trace changes remain outside this slice
- frozen historical manifests, registries, and release checkers are unchanged

## Verification

- [x] `opam exec -- dune fmt --root "$PWD"` with a clean tracked tree
- [x] `opam exec -- dune build --root "$PWD" @all @doc`
- [x] full direct Alcotest/QCheck runner: 859/859 cases
- [x] focused `relate` seed-law and `errors-doc` cases
- [x] forced `test/cli/relate.t` and `test/cli/relate-divergence.t`
- [x] exact text and JSON-v1 E1003 rendering with empty stdout
- [x] Console replay, fixed Dist seed, warning-once, failure-status, E0611,
  and private-store cleanup evidence
- [x] history-backed manifest verification and drift-rejection probes on exact
  candidate `00db5868b4dccffc019196ef1f6dbf8a4a34c07b`
- [x] independent Claude Fable 5 review at xhigh effort: PASS on exact commit
  `00db5868b4dccffc019196ef1f6dbf8a4a34c07b`, with no blockers,
  architecture conflicts, or disputed tests

A forced full Dune graph reproduced only the repository's known local
LeakSanitizer startup failure under this host's ptrace wrapper. Direct compiled
tests, documentation, and relate crams are green; required GitHub native-parity
jobs remain merge authority for sanitizer evidence.

## Risk and follow-up

Fable's nonblocking notes were dispositioned without changing the reviewed
tree: leading-zero positive decimals are within the frozen accepted spelling,
E0611 shares the already-pinned stderr renderer, and README's live inventory
also corrects older staleness. Beyond-capture EOF and the infeasible true
63-bit projection-collision path remain directly inspectable, while their
observable cursor-freshness and uniqueness laws are dynamically pinned.

RW.4 and later tasks retain secret redaction, SameUnder, other variation kinds,
and higher-level discovery/execution work.
