### PR TITLE
feat: compare runs across secret payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 859
-Alcotest/QCheck cases, 54 cram transcripts, 28 documentation examples, native
+semantic boundary remains historical; the current successor is pinned by 861
+Alcotest/QCheck cases, 56 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
 runtime/output license exception and packages the native runtime. The current
@@ -370,6 +370,7 @@ The main commands are:
 ```bash
 jac run FILE.jac [--allow fs] [--allow net] [--dry-run]
 jac relate FILE.jac --vary schedule=N --seed S [--allow EFFECT ...]
+jac relate FILE.jac --vary secret=NAME --seed S [--allow EFFECT ...]
 jac check FILE.jac [--print-sigs] [--manifest fs,net,console]
 jac hash FILE.jac
 jac fmt FILE.jac

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -20,12 +20,15 @@ type diagnostic_format = Text | Json_v1
 type output_format = Output_text | Output_json_v1
 
 let selected_diagnostic_format = ref Text
+let selected_output_sanitizer = ref Fun.id
+let sanitize_output output = !selected_output_sanitizer output
 
 let print_diagnostic diagnostic =
   prerr_endline
-    (match !selected_diagnostic_format with
-    | Text -> Diag.to_string diagnostic
-    | Json_v1 -> Diag.to_json_string diagnostic)
+    (sanitize_output
+       (match !selected_diagnostic_format with
+       | Text -> Diag.to_string diagnostic
+       | Json_v1 -> Diag.to_json_string diagnostic))
 
 let print_runtime_error error = print_diagnostic (Runtime_err.to_diag error)
 
@@ -541,6 +544,9 @@ let run_cmd file allows prelude store_dir seed infer_cache origin dry_run schedu
 
 (* --- relate --- *)
 
+type relate_variation = Schedule_variation of int | Secret_variation of string
+type relate_run = { schedule_seed : int; secret_getenv : (string -> string option) option }
+
 type relate_failure =
   | Relate_diagnostics of Diag.t list
   | Relate_runtime of Runtime_err.t
@@ -558,8 +564,8 @@ let protect_relate_store_operation action operation =
   try Ok (operation ())
   with (Sys_error _ | Unix.Unix_error _) as error -> Error (relate_store_failure action error)
 
-let relate_constituent ~file ~source ~allows ~prelude ~root_seed ~schedule_seed ~syntax
-    ~console_read ~emit_warnings =
+let relate_constituent ~file ~source ~allows ~prelude ~root_seed ~schedule_seed ~secret_getenv
+    ~syntax ~console_read ~emit_warnings =
   match protect_relate_store_operation "create" fresh_relate_store_dir with
   | Error failure -> Error failure
   | Ok store_dir ->
@@ -578,7 +584,7 @@ let relate_constituent ~file ~source ~allows ~prelude ~root_seed ~schedule_seed 
                 | [] -> Ok ()
                 | allow :: rest -> (
                     match
-                      Prelude.grant ~console_read ctx allow ~infer_cache:None
+                      Prelude.grant ~console_read ?secret_getenv ctx allow ~infer_cache:None
                         ~out:(fun _ -> ())
                         ~seed:root_seed
                     with
@@ -640,15 +646,34 @@ let print_relate_failure = function
       print_runtime_error error;
       match error with Runtime_err.Unhandled _ -> exit_unhandled | _ -> exit_runtime)
 
-let relate_cmd file runs seed allows prelude syntax =
+let relate_cmd file variation seed allows prelude syntax =
+  let runs, secrets, run_specs =
+    match variation with
+    | Schedule_variation count ->
+        ( count,
+          [],
+          List.map
+            (fun schedule_seed -> { schedule_seed; secret_getenv = None })
+            (Relate.schedule_seeds ~root_seed:seed ~count) )
+    | Secret_variation name ->
+        let first, second = Relate.secret_payloads ~root_seed:seed in
+        let target_key = Prelude.secret_environment_key ~name ~version:None in
+        let run payload =
+          let secret_getenv requested =
+            if String.equal requested target_key then Some payload else Sys.getenv_opt requested
+          in
+          { schedule_seed = seed; secret_getenv = Some secret_getenv }
+        in
+        (2, [ first; second ], [ run first; run second ])
+  in
+  selected_output_sanitizer := Relate.redact ~secrets;
   let source = read_file file in
-  let schedule_seeds = Relate.schedule_seeds ~root_seed:seed ~count:runs in
   let captured_console_input = ref None in
   let rec compare_runs baseline run_index = function
     | [] ->
         Printf.printf "relate runs=%d seed=%d verdict=equal\n" runs seed;
         ok
-    | schedule_seed :: rest -> (
+    | ({ schedule_seed; secret_getenv } : relate_run) :: rest -> (
         let console_read, finish_console_input =
           match !captured_console_input with
           | None ->
@@ -669,8 +694,8 @@ let relate_cmd file runs seed allows prelude syntax =
                 fun () -> () )
         in
         match
-          relate_constituent ~file ~source ~allows ~prelude ~root_seed:seed ~schedule_seed ~syntax
-            ~console_read ~emit_warnings:(run_index = 1)
+          relate_constituent ~file ~source ~allows ~prelude ~root_seed:seed ~schedule_seed
+            ~secret_getenv ~syntax ~console_read ~emit_warnings:(run_index = 1)
         with
         | Error failure -> print_relate_failure failure
         | Ok transcript -> (
@@ -686,10 +711,11 @@ let relate_cmd file runs seed allows prelude syntax =
                         cli_diagnostic ~code:"E1003"
                           (Printf.sprintf "Runs 1 and %d diverged with %s:\n%s" run_index
                              (Run_transcript.divergence_kind_name divergence.kind)
-                             (Run_transcript.render divergence));
+                             (Run_transcript.render_redacted ~redact:(Relate.redact ~secrets)
+                                divergence));
                       ])))
   in
-  compare_runs None 1 schedule_seeds
+  compare_runs None 1 run_specs
 
 (* --- check --- *)
 
@@ -2086,14 +2112,15 @@ let required_seed_arg =
     & info [ "seed" ] ~docv:"SEED"
         ~doc:"Required root seed for reproducible relational runs and Dist sampling.")
 
-let schedule_variation =
-  let expected () = Error (`Msg "expected schedule=N with N > 0") in
+let relate_variation =
+  let expected () = Error (`Msg "expected schedule=N with N > 0 or secret=NAME") in
   let parse value =
-    let prefix = "schedule=" in
-    if not (String.starts_with ~prefix value) then expected ()
-    else
+    let schedule_prefix = "schedule=" in
+    let secret_prefix = "secret=" in
+    if String.starts_with ~prefix:schedule_prefix value then
       let count =
-        String.sub value (String.length prefix) (String.length value - String.length prefix)
+        String.sub value (String.length schedule_prefix)
+          (String.length value - String.length schedule_prefix)
       in
       let rec decimal index =
         index = String.length count
@@ -2102,20 +2129,32 @@ let schedule_variation =
       if String.equal count "" || not (decimal 0) then expected ()
       else
         match int_of_string_opt count with
-        | Some count when count > 0 -> Ok count
+        | Some count when count > 0 -> Ok (Schedule_variation count)
         | _ -> expected ()
+    else if String.starts_with ~prefix:secret_prefix value then
+      let name =
+        String.sub value (String.length secret_prefix)
+          (String.length value - String.length secret_prefix)
+      in
+      if String.equal name "" then expected () else Ok (Secret_variation name)
+    else expected ()
   in
-  let print formatter count = Format.fprintf formatter "schedule=%d" count in
+  let print formatter = function
+    | Schedule_variation count -> Format.fprintf formatter "schedule=%d" count
+    | Secret_variation name -> Format.fprintf formatter "secret=%s" name
+  in
   Arg.conv (parse, print)
 
 let vary_arg =
   Arg.(
     required
-    & opt (some schedule_variation) None
+    & opt (some relate_variation) None
     & info [ "vary" ] ~docv:"KIND"
         ~doc:
-          "Required variation; RW.3 supports only schedule=N with N > 0. Run 1 uses the root seed; \
-           later runs use successive SplitMix64 outputs, skipping already accepted seeds.")
+          "Required variation. schedule=N with N > 0 uses the root scheduler seed for run 1 and \
+           successive distinct SplitMix64 outputs thereafter. secret=NAME runs twice at the root \
+           schedule, injects two deterministic payloads for the named latest Secret, and redacts \
+           either payload from every diagnostic boundary.")
 
 let infer_cache_arg =
   Arg.(
@@ -2164,9 +2203,10 @@ let relate_t =
   Cmd.v
     (Cmd.info "relate"
        ~doc:
-         "Run a .jac surface or .jqd bootstrap file under distinct deterministic schedules and \
-          compare complete result and routed-root transcripts. Console input is captured in run 1 \
-          and replayed by ordinal in later runs.")
+         "Run a .jac surface or .jqd bootstrap file under deterministic schedule or secret \
+          variation and compare complete result and routed-root transcripts. Console input is \
+          captured in run 1 and replayed by ordinal in later runs; derived secret payloads are \
+          redacted from diagnostics without weakening raw comparison.")
     Term.(
       const (configure_diagnostics relate_cmd)
       $ diagnostic_format_arg $ file_arg $ vary_arg $ required_seed_arg $ allows_arg $ prelude_arg
@@ -2915,5 +2955,5 @@ let render_selected_diagnostic diagnostic =
 
 let () =
   exit
-    (Cli_entry.run ~program:"jacquard" ~render_diagnostic:render_selected_diagnostic (fun () ->
-         Cmd.eval' ~catch:false main))
+    (Cli_entry.run ~program:"jacquard" ~render_diagnostic:render_selected_diagnostic
+       ~sanitize_output (fun () -> Cmd.eval' ~catch:false main))

--- a/demos/README.md
+++ b/demos/README.md
@@ -37,6 +37,10 @@ in one program.
 - `case-studies/release-risk/`: one release policy under concrete and
   probabilistic telemetry handlers, with a conditioned risk posterior and a
   Warp safety proof over all 18 worlds.
+- `case-studies/night-shift/`: one unattended maintenance shift spanning exact
+  risk, concurrent probes, approval-bound code, an opaque deploy token, and a
+  relational lane proving that two derived token payloads leave the complete
+  observable run unchanged without entering its transcript.
 - `governed-workspace/`: one unchanged Workspace-only deployment agent under
   pure dry simulation, nested live policies, a durable approval-queue denial,
   a verified audit chain, and the existing exhaustive hostile fault space.

--- a/demos/case-studies/night-shift/README.md
+++ b/demos/case-studies/night-shift/README.md
@@ -1,0 +1,28 @@
+# Night-shift
+
+Night-shift is an unattended maintenance bot working a low-traffic window. One
+program chains most of the shipped language: exact enumeration forecasts the
+risk of the night, three concurrent probe tasks (each carrying its own
+simulated `Net`/`Clock` world) preflight the fleet through a typed channel, a
+watchdog task is cancelled as the *expected* calm outcome, a scripted approver
+consents to a proposal that names the migration's exact `Code`, the deploy
+token is read as a `Secret` and stays redacted in every transcript, and the
+final lever is a `once`-mode operation the checker guarantees cannot fire
+twice, discharged only through the granted `eval` capability.
+
+The launcher runs five lanes: the inferred authority signatures, an ungranted
+run that refuses with `E0814` after the authority-free forecast completes, the
+granted run with a leak check on the token, a `jacquard relate` noninterference
+check over two deterministically derived deploy-token payloads, and the Warp
+suite of deterministic cases plus two properties that `--exhaustive` turns
+into proofs over all 27 fleet worlds. The Warp cases stay hermetic by using
+the preflight's sequential twin and a stubbed `eval`; the concurrent channel
+schedule and the real evaluation are pinned by the granted lane's transcript.
+
+```sh
+sh demos/case-studies/night-shift/run.sh
+```
+
+Not exercised here: the governance gate, Judge, and audit chain run under
+their own test lanes (`test/cli/props.t`, `jac governance verify-log`) rather
+than public `jac run` programs.

--- a/demos/case-studies/night-shift/model.jac
+++ b/demos/case-studies/night-shift/model.jac
@@ -1,0 +1,318 @@
+-- NIGHT-SHIFT: an unattended maintenance bot widens a service fleet's worker
+-- pool during a low-traffic window. The run is a chain of custody: exact
+-- enumeration forecasts the risk, concurrent probe tasks preflight the fleet
+-- inside a simulated world, a scripted approver consents to the exact
+-- migration code hash, the deploy token stays redacted end to end, and the
+-- final lever is a once-mode operation that fires the quoted migration only
+-- through the granted `eval` capability. Net, Clock, State, Dist, Async, and
+-- Approval are all discharged in-language; what remains in the signatures is
+-- either grantable authority (Eval, Secret) or ungrantable plumbing the
+-- interpreter's deterministic scheduler routes (Channel).
+--
+-- Steps the transcript proves:
+--   1. `jacquard check --print-sigs`: probe.run comes out PURE because each
+--      task carries its own simulated world, and ship.live visibly trades the
+--      once-mode Ship effect for Eval. Grantable authority: Eval and Secret.
+--   2. Ungranted `run`: the authority-free forecast still completes, then the
+--      decision step refuses with E0814 at exit 3. Nothing ships.
+--   3. Granted `run` completes the whole shift; the token prints redacted and
+--      the transcript provably never contains its plaintext.
+--   4. Warp cases pin the deterministic schedule; --exhaustive proves the
+--      preflight and window claims over all 27 fleet worlds.
+
+-- --- the domain ---
+
+--| a service's condition in one possible world
+type Mood = | Ready | Lagging | Wedged
+
+--| the three services the night shift must not break
+type Fleet = | MkFleet(api: Mood, db: Mood, cache: Mood)
+
+--| one probe task's verdict: which service, healthy?, simulated ms spent
+type Reading = | MkReading(name: Text, ok: Bool, ms: Int)
+
+-- --- the simulated world: each probe task carries its own weather ---
+
+mood.latency(m) = match m {
+  | Ready -> 40
+  | Lagging -> 700
+  | Wedged -> 90
+}
+
+mood.answer(m) = match m {
+  | Ready -> MkResponse(200, "ok")
+  | Lagging -> MkResponse(200, "ok")
+  | Wedged -> MkResponse(503, "unavailable")
+}
+
+fleet.mood-of(f, name) = match f {
+  | MkFleet(a, d, c) ->
+      if text.eq?(name, "api") then a
+      else if text.eq?(name, "db") then d
+      else c
+}
+
+--| a deep handler that answers `fetch` from one service's mood and charges a
+--| simulated clock: `now` reads elapsed ms from a State cell, `sleep` charges
+--| time instead of waiting. Effects are routed per task, so each probe task
+--| installs this lab around its own body -- three private worlds, one fleet.
+lab : (Mood, () ->{State, Net, Clock | e} a) ->{State | e} a
+lab(m, thunk) =
+  handle thunk() {
+    | return x -> x
+    | fetch(req) resume k -> {
+        let t = get()
+        put(add(t, mood.latency(m)))
+        k(mood.answer(m))
+      }
+    | now() resume k -> k(get())
+    | sleep(d) resume k -> {
+        put(add(get(), d))
+        k(())
+      }
+  }
+
+resp.ok?(r) = match r {
+  | MkResponse(st, _) -> eq(st, 200)
+}
+
+--| one probe: fetch the health endpoint, retry once after a beat if it looks
+--| bad, and report what the simulated clock charged. Ordinary {Net, Clock}
+--| code -- it cannot tell the lab from production.
+probe.check : (Text) ->{Net, Clock} (Bool, Int)
+probe.check(name) = {
+  let t0 = now()
+  let first = fetch(MkRequest(text.concat("http://", name), ""))
+  let healthy =
+    if resp.ok?(first) then True
+    else {
+      sleep(120)
+      resp.ok?(fetch(MkRequest(text.concat("http://", name), "")))
+    }
+  (healthy, sub(now(), t0))
+}
+
+--| run one probe as a pure value: the lab discharges Net/Clock, state.run
+--| discharges State, so a spawned probe task has the empty row.
+probe.run(f, name) =
+  match state.run(fn () -> lab(fleet.mood-of(f, name), fn () -> probe.check(name)), 0) {
+    | ((healthy, _), ms) -> MkReading(name, healthy, ms)
+  }
+
+--| the sequential twin of the preflight: the same three probes, no
+--| scheduler. The Warp suite and the forecast use this hermetic form; the
+--| live shift runs the concurrent channel form below, and the transcript
+--| shows both produce identical readings.
+preflight.solo(f) =
+  [probe.run(f, "api"), probe.run(f, "db"), probe.run(f, "cache")]
+
+-- --- concurrent preflight: three probe tasks, one typed channel ---
+
+drain(ch) = match channel.recv(ch) {
+  | Ok(v) -> Cons(v, drain(ch))
+  | Err(_) -> Nil
+}
+
+--| spawn one task per service; each sends its Reading into a bounded channel;
+--| the coordinator awaits the senders, closes, and drains. Under the default
+--| deterministic round-robin scheduler the drained order is pinned -- the
+--| granted lane of the run.sh transcript shows it, byte for byte.
+preflight(f) = {
+  let outcome = async.scope(fn () ->
+    match channel.open(3) {
+      | Err(_) -> Nil
+      | Ok(ch) -> {
+          let p-api = async.spawn(fn () -> channel.send(ch, probe.run(f, "api")))
+          let p-db = async.spawn(fn () -> channel.send(ch, probe.run(f, "db")))
+          let p-cache = async.spawn(fn () -> channel.send(ch, probe.run(f, "cache")))
+          let _ = async.await(p-api)
+          let _ = async.await(p-db)
+          let _ = async.await(p-cache)
+          let _ = channel.close(ch)
+          drain(ch)
+        }
+    })
+  match outcome {
+    | Done(readings) -> readings
+    | _ -> Nil
+  }
+}
+
+reading.ok?(r) = match r { | MkReading(_, healthy, _) -> healthy }
+reading.ms(r) = match r { | MkReading(_, _, ms) -> ms }
+
+--| green means every service answered and the whole preflight fit the budget
+preflight.green?(readings) = {
+  let all-ok = list.fold(readings, True, fn (acc, r) -> bool.and(acc, reading.ok?(r)))
+  let total = list.fold(readings, 0, fn (acc, r) -> add(acc, reading.ms(r)))
+  bool.and(all-ok, bool.and(eq(list.length(readings), 3), int.lt?(total, 2500)))
+}
+
+-- --- the watchdog: a cancelled task is a first-class, expected outcome ---
+
+stand-watch() = {
+  let _ = async.yield()
+  stand-watch()
+}
+
+--| the watchdog yields forever, ready to page a human; a quiet preflight
+--| cancels it. Under the fail-fast policy the cancelled child becomes the
+--| scope's own result, so `Cancelled` here MEANS "nobody was paged".
+watch.report() = {
+  let shift = async.scope(fn () -> {
+    let watchdog = async.spawn(fn () -> stand-watch())
+    let _ = async.cancel(watchdog)
+    async.await(watchdog)
+  })
+  match shift {
+    | Cancelled -> "watchdog stood down; no page sent"
+    | _ -> "watchdog escaped its shift"
+  }
+}
+
+-- --- the migration: quoted code, hash-bound consent, a once-mode lever ---
+
+--| the migration is DATA until the lever fires: a quoted expression that
+--| computes the widened pool size. Quoting costs nothing and needs no grant.
+migration = quote { mul(8, 2) }
+
+must-hash(text) = match hash.parse(text) {
+  | Ok(value) -> value
+  | Err(message) -> throw(message)
+}
+
+--| consent is bound to content: the proposal carries the exact migration
+--| Code and asks for the Eval authority by name.
+night-proposal() = approval.make-proposal(
+  must-hash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+  must-hash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+  must-hash("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+  [Effect("Eval")],
+  migration,
+  "widen worker pool during tonight's window?",
+  None)
+
+--| the final lever. `once` is load-bearing: the checker rejects any handler
+--| that could resume this operation twice, so the migration cannot be
+--| double-applied by construction.
+once effect Ship where {
+  apply : (Code) -> Int
+}
+
+--| fire the lever through the granted `eval` capability -- exactly once
+ship.live(thunk) =
+  handle thunk() {
+    | return x -> x
+    | apply(code) resume k -> k(`op:eval-code`(code))
+  }
+
+--| the shift's decision spine: a green preflight earns a scripted approval
+--| bound to this proposal's id; anything else escalates and ships nothing.
+decide(readings) = {
+  let p = night-proposal()
+  let id = approval.proposal-id(p)
+  if preflight.green?(readings) then
+    match approval.scripted(fn () -> `op:ask`(p), [Approved(id, "night-shift-bot", quote { ticket("NS-1") })]) {
+      | Approved(_, actor, _) ->
+          ship.live(fn () ->
+            (text.concat("shipped by ", actor), `op:apply`(migration)))
+      | _ -> ("approver refused; pool unchanged", 8)
+    }
+  else
+    match approval.policy-auto(fn () -> `op:ask`(p), fn (ignored) -> Ask) {
+      | _ -> ("escalated to a human; pool unchanged", 8)
+    }
+}
+
+-- --- the forecast: exact risk, and a multi-shot A/B of two rollout plans ---
+
+sky(p-ready, p-lagging, p-wedged) =
+  Categorical([
+    MkPair(Ready, p-ready),
+    MkPair(Lagging, p-lagging),
+    MkPair(Wedged, p-wedged)])
+
+forecast : () ->{Dist} Fleet
+forecast() = {
+  let a = sample(sky(0.90, 0.08, 0.02))
+  let d = sample(sky(0.94, 0.04, 0.02))
+  let c = sample(sky(0.80, 0.15, 0.05))
+  MkFleet(a, d, c)
+}
+
+--| would tonight's preflight come back green in this world? The forecast
+--| projects each world through the sequential twin so enumeration stays
+--| hermetic -- same probes, same readings, no schedule dependence.
+world.green?(f) = preflight.green?(preflight.solo(f))
+
+--| a multi-shot choice: ONE pass explores BOTH rollout plans. The handler
+--| resumes the continuation twice -- the m1-choose move doing real work.
+multi effect Rollout where {
+  pick : () -> Bool
+}
+
+plan.label(big-bang) = if big-bang then "big-bang" else "rolling"
+
+--| big-bang pays every wedged service at once; rolling pays a fixed per-step
+--| overhead but never more than the worst single service.
+plan.window(big-bang, f) = match f {
+  | MkFleet(a, d, c) -> {
+      let worst = list.fold([a, d, c], 0, fn (acc, m) ->
+        if int.lt?(acc, mood.latency(m)) then mood.latency(m) else acc)
+      let total = list.fold([a, d, c], 0, fn (acc, m) -> add(acc, mood.latency(m)))
+      if big-bang then total else add(worst, 180)
+    }
+}
+
+both-plans(f) =
+  handle {
+    let big-bang = `op:pick`()
+    Cons((plan.label(big-bang), plan.window(big-bang, f)), Nil)
+  } {
+    | return x -> x
+    | pick() resume k -> list.append(k(True), k(False))
+  }
+
+--| P(a green preflight) -- exact, over all 27 worlds, weighted by the sky
+risk.green() =
+  dist.enumerate(fn () -> if world.green?(forecast()) then "green" else "red")
+  |> dist.tally(text.eq)
+
+--| the counterfactual: given the window overran, which plan was running?
+--| `observe` conditions the enumeration; nothing is sampled approximately.
+risk.overrun-blame() =
+  dist.enumerate(fn () -> {
+    let f = forecast()
+    let windows = both-plans(f)
+    let overran = list.filter(windows, fn (entry) ->
+      match entry { | (_, w) -> int.lt?(900, w) })
+    observe(Bernoulli(if int.lt?(0, list.length(overran)) then 1.0 else 0.0), True)
+    list.map(overran, fn (entry) -> match entry { | (label, _) -> label })
+      |> list.fold("", fn (acc, label) ->
+           if text.empty?(acc) then label else text.concat(acc, text.concat("+", label)))
+  })
+  |> dist.tally(text.eq)
+  |> list.filter(fn (entry) -> match entry { | MkPair(_, mass) -> real.lt?(0.0, mass) })
+
+-- --- the deploy token: readable by the program, redacted in every transcript ---
+
+--| `secret.read` needs the root `secret` grant; the value it returns renders
+--| as <secret redacted> everywhere. `secret.expose` yields the plaintext to
+--| the program -- here only to check its shape, which exposes one boolean.
+token.report() = {
+  let token = secret.read(secret-ref("night-shift-token", None))
+  (token, text.contains?(secret.expose(token), "nsk-"))
+}
+
+-- --- demo driver ---
+
+risk.green()
+risk.overrun-blame()
+
+throw.to-result(fn () -> {
+  let readings = preflight(MkFleet(Ready, Ready, Ready))
+  (readings, decide(readings))
+})
+
+watch.report()
+token.report()

--- a/demos/case-studies/night-shift/run.sh
+++ b/demos/case-studies/night-shift/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+JACQUARD_DEMO_ROOT=$(CDPATH= cd -- "$here/../.." && pwd)
+. "$JACQUARD_DEMO_ROOT/lib/demo-env.sh"
+suite=$(mktemp "$TMPDIR/jacquard-night-shift-tests.XXXXXX.jac")
+shift_out=$(mktemp "$TMPDIR/jacquard-night-shift-run.XXXXXX.out")
+relate_out=$(mktemp "$TMPDIR/jacquard-night-shift-relate.XXXXXX.out")
+trap 'rm -f "$suite" "$shift_out" "$relate_out"' EXIT
+
+echo "== the shift's authority, inferred from the source =="
+jacquard_demo check "$here/model.jac" --print-sigs
+
+echo "== ungranted: the forecast still runs, the lever refuses (expect E0814) =="
+if jacquard_demo run "$here/model.jac"; then
+  echo "night-shift demo bug: ungranted run must refuse" >&2
+  exit 1
+else
+  echo "refused with exit $?"
+fi
+
+echo "== granted: the whole shift, token redacted end to end =="
+# The exact latest-version key for the SecretRef name `night-shift-token`
+# (JACQUARD_SECRET_V0_ + lowercase hex of the name). The payload is assembled
+# so its literal spelling appears nowhere in this script or the transcript.
+token_key=JACQUARD_SECRET_V0_6e696768742d73686966742d746f6b656e_LATEST
+token_payload="nsk-$(printf live)-7788"
+export "$token_key=$token_payload"
+jacquard_demo run "$here/model.jac" --allow eval --allow secret > "$shift_out"
+unset "$token_key"
+cat "$shift_out"
+if grep -F "$token_payload" "$shift_out" >/dev/null; then
+  echo "night-shift demo bug: the deploy token leaked into the transcript" >&2
+  exit 1
+else
+  echo "token stayed redacted"
+fi
+
+echo "== relational: two deploy tokens, one observable shift =="
+if jacquard_demo relate "$here/model.jac" --vary secret=night-shift-token --seed 42 \
+    --allow eval --allow secret > "$relate_out" 2>&1; then
+  :
+else
+  relate_status=$?
+  cat "$relate_out"
+  exit "$relate_status"
+fi
+cat "$relate_out"
+if grep -F "rw-secret-v0-" "$relate_out" >/dev/null; then
+  echo "night-shift demo bug: a relational payload leaked into the transcript" >&2
+  exit 1
+else
+  echo "secret variation stayed redacted"
+fi
+
+awk '/^-- --- demo driver ---$/ { exit } { print }' "$here/model.jac" > "$suite"
+printf '\n' >> "$suite"
+cat "$here/tests.jac" >> "$suite"
+
+echo "== Warp: pinned schedules, stubbed lever, sampled properties =="
+jacquard_demo test "$suite" --seed 42 --no-cache
+
+echo "== Warp: exhaustive proof over all 27 fleet worlds =="
+jacquard_demo test "$suite" --seed 42 --no-cache --exhaustive

--- a/demos/case-studies/night-shift/tests.jac
+++ b/demos/case-studies/night-shift/tests.jac
@@ -1,0 +1,124 @@
+-- Warp suite for night-shift. The cases close hermetically: the lab
+-- discharges Net/Clock/State per probe task, a stub handler discharges Eval,
+-- and throw.to-result discharges Throw, so no case needs a grant. Under
+-- --exhaustive the props are proofs over all 27 fleet worlds. This file
+-- expects model.jac's definitions; run.sh assembles the two.
+
+--| a test double for the eval capability: resumes the once-mode lever with a
+--| sentinel so the decision spine can be proven without granting `eval`.
+--| The real evaluation is pinned by run.sh's granted lane instead.
+eval-stub(thunk) =
+  handle thunk() {
+    | return x -> x
+    | eval-code(code) resume k -> k(99)
+  }
+
+wedged?(m) = match m { | Wedged -> True | _ -> False }
+
+fleet.any-wedged?(f) = match f {
+  | MkFleet(a, d, c) -> bool.or(wedged?(a), bool.or(wedged?(d), wedged?(c)))
+}
+
+--| total probability mass a tallied table assigns one label
+mass-of(table, label) =
+  list.fold(table, 0.0, fn (acc, e) ->
+    match e {
+      | MkPair(x, p) ->
+          if eq.fn(text.eq)(x, label) then real.add(acc, p) else acc
+    })
+
+night-shift-suite =
+  Group("night-shift", [
+
+    -- the pinned calm night: every simulated millisecond is exact. The
+    -- concurrent channel form of these same probes is pinned by run.sh's
+    -- transcript; Warp cases stay hermetic and use the sequential twin.
+    Case("calm preflight is deterministic to the millisecond", fn () -> {
+      let readings = preflight.solo(MkFleet(Ready, Ready, Ready))
+      check.eq(list.length(readings), 3, int.eq, int.show, "three readings")
+      check.eq(
+        list.fold(readings, 0, fn (acc, r) -> add(acc, reading.ms(r))),
+        120, int.eq, int.show, "total simulated ms")
+      check.true(preflight.green?(readings), "calm fleet is green")
+      match readings {
+        | Cons(first, _) ->
+            check.eq(reading.ms(first), 40, int.eq, int.show, "api probe ms")
+        | Nil -> check.true(False, "readings must not be empty")
+      }
+    }),
+
+    -- the retry path: a wedged service costs two fetches plus the 120ms beat
+    Case("a wedged db is probed twice and caught", fn () -> {
+      let readings = preflight.solo(MkFleet(Ready, Wedged, Ready))
+      check.true(bool.not(preflight.green?(readings)), "wedged fleet is red")
+      check.eq(
+        list.fold(readings, 0, fn (acc, r) -> add(acc, reading.ms(r))),
+        380, int.eq, int.show, "retry charges 90+120+90 for db")
+    }),
+
+    -- the decision spine, Eval stubbed: green ships once, red escalates
+    Case("green preflight ships through the once-mode lever", fn () ->
+      match throw.to-result(fn () ->
+        eval-stub(fn () -> decide(preflight.solo(MkFleet(Ready, Ready, Ready))))) {
+        | Ok((verdict, pool)) -> {
+            check.eq(verdict, "shipped by night-shift-bot", text.eq, text.show, "verdict")
+            check.eq(pool, 99, int.eq, int.show, "the stubbed lever fired exactly once")
+          }
+        | Err(_) -> check.true(False, "decision must not throw")
+      }),
+
+    Case("red preflight escalates and ships nothing", fn () ->
+      match throw.to-result(fn () ->
+        eval-stub(fn () -> decide(preflight.solo(MkFleet(Wedged, Ready, Ready))))) {
+        | Ok((verdict, pool)) -> {
+            check.eq(verdict, "escalated to a human; pool unchanged",
+              text.eq, text.show, "verdict")
+            check.eq(pool, 8, int.eq, int.show, "pool untouched")
+          }
+        | Err(_) -> check.true(False, "escalation must not throw")
+      }),
+
+    -- cancellation as a first-class outcome: fail-fast reports the cancelled
+    -- watchdog as the scope's own result, and the caller reads it as calm
+    Case("the watchdog stands down without paging", fn () ->
+      check.eq(watch.report(), "watchdog stood down; no page sent",
+        text.eq, text.show, "watch report")),
+
+    -- one multi-shot pass really does explore both rollout plans
+    Case("both rollout plans come from a single multi-shot pass", fn () -> {
+      let windows = both-plans(MkFleet(Ready, Ready, Ready))
+      check.eq(list.length(windows), 2, int.eq, int.show, "two plans")
+      match windows {
+        | Cons((label-a, w-a), Cons((label-b, w-b), Nil)) -> {
+            check.eq(label-a, "big-bang", text.eq, text.show, "first branch")
+            check.eq(w-a, 120, int.eq, int.show, "big-bang pays the sum")
+            check.eq(label-b, "rolling", text.eq, text.show, "second branch")
+            check.eq(w-b, 220, int.eq, int.show, "rolling pays worst plus 180")
+          }
+        | _ -> check.true(False, "expected exactly two explored plans")
+      }
+    }),
+
+    -- an exact probabilistic claim computed inside an ordinary case: the
+    -- enumeration projects every weighted world through the probe twin
+    Case("the green forecast is exact and sums to one", fn () -> {
+      let table = risk.green()
+      let green = mass-of(table, "green")
+      let red = mass-of(table, "red")
+      check.true(real.lt?(0.9, green), "calm skies dominate")
+      check.true(real.lt?(red, 0.1), "red nights are rare")
+    }),
+
+    -- the generator IS the fleet model; --exhaustive proves both over all 27
+    Prop("a wedged service never passes preflight", fn () -> {
+      let f = forecast()
+      check.true(
+        bool.not(bool.and(fleet.any-wedged?(f), world.green?(f))),
+        "wedged and green cannot coexist")
+    }),
+
+    Prop("the rolling plan never overruns the 900ms window", fn () -> {
+      let f = forecast()
+      check.true(int.lt?(plan.window(False, f), 900), "rolling fits every world")
+    })
+  ])

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,8 @@ project shape from file names alone.
 - `warp-testing.md`: Warp test model, rows, handlers, cache, properties, and
   world lanes.
 - `relational-warp.md`: relational observation contract, canonical run
-  transcripts, and the shipped deterministic schedule-variation CLI lane.
+  transcripts, and the shipped deterministic schedule- and secret-variation
+  CLI lanes.
 - `errors.md`: diagnostic code catalog.
 
 ## Release 0.1 Evidence

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -75,9 +75,10 @@ jac run PROGRAM.jac
 jac run PROGRAM.jac --allow console --allow net
 jac run PROGRAM.jac --dry-run
 
-# Compare complete results and routed root effects under distinct schedules.
+# Compare complete results and routed root effects under controlled variation.
 jac relate PROGRAM.jac --vary schedule=8 --seed 42
 jac relate PROGRAM.jac --vary schedule=8 --seed 42 --allow console
+jac relate PROGRAM.jac --vary secret=deploy-token --seed 42 --allow secret
 
 # Format and identify code.
 jac fmt PROGRAM.jac
@@ -132,6 +133,11 @@ only during run 1, captured by call ordinal, and replayed from a fresh cursor in
 every later run; calls beyond the captured list receive EOF (`""`). A completed
 transcript difference is Warp diagnostic E1003 and status 1. Constituent
 diagnostic, runtime, and authority failures retain statuses 1, 2, and 3.
+Secret variation runs exactly twice with distinct deterministic latest-version
+payloads for the named Secret while holding the scheduler and Dist seed fixed.
+It compares the raw transcripts, then redacts either derived payload from all
+text, JSON, runtime, and unexpected-error output. This exact-byte scrubber is
+not taint tracking and does not detect transformed or fragmented payloads.
 
 ## Surface Syntax
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -186,7 +186,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 |------|---------|---------|
 | E1001 | expression at top level of a test file | `jacquard test file.jqd` where the file ends with `(app (var main))` |
 | E1002 | eval under --dry-run | a program whose row includes `eval` run with `--dry-run` |
-| E1003 | completed relational runs have different result or routed-root transcripts | `jacquard relate program.jac --vary schedule=8 --seed 42` finds a schedule-dependent result |
+| E1003 | completed relational runs have different result or routed-root transcripts | schedule variation finds a race, or `--vary secret=token` finds payload-dependent Console output and renders both payloads redacted |
 | E1004 | malformed, unsupported, or noncanonical run-transcript-v1 bytes | a transcript with a noncontiguous observation index or truncated payload |
 
 ## Native compilation (E11xx)

--- a/docs/relational-warp.md
+++ b/docs/relational-warp.md
@@ -1,10 +1,10 @@
 # Relational Warp lanes: testable hyperproperties
 
-Status: **RW.0 frozen for v0 (2026-08-12); RW.1-RW.3 schedule tooling
+Status: **RW.0 frozen for v0 (2026-08-12); RW.1-RW.4 schedule and Secret tooling
 shipped.** This document fixes the observation and variation contract for
 implementation tasks RW.1 through RW.7. `run-transcript-v1`, its canonical
-comparator, and `jacquard relate FILE --vary schedule=N --seed S` now ship.
-`SameUnder` and the other variation kinds remain future work.
+comparator, and `jacquard relate FILE --vary schedule=N|secret=NAME --seed S`
+now ship. `SameUnder` and the other variation kinds remain future work.
 
 Read this document with [Warp testing](warp-testing.md),
 [structured concurrency](concurrency.md), and the
@@ -192,6 +192,34 @@ E1003 names one-based run indices and embeds the canonical zero-based RW.2
 first-divergence frame. A constituent failure retains its ordinary status and
 is never reclassified as E1003.
 
+### RW.4 shipped Secret command
+
+The second shipped layer-2 surface is:
+
+    jacquard relate FILE --vary secret=NAME --seed S [--allow EFFECT ...]
+
+It executes exactly two isolated constituents with scheduler and Dist seed
+`S`. The first two full-width SplitMix64 outputs rooted at `S` become printable
+payloads `rw-secret-v0-a-%016Lx` and `rw-secret-v0-b-%016Lx`. Only the canonical
+latest key `JACQUARD_SECRET_V0_<lowercase-name-byte-hex>_LATEST` is overridden;
+unrelated and versioned environment lookups retain their ordinary process
+values. The overlay is local to each fresh evaluator and never mutates the
+process environment.
+
+The command forwards grants unchanged and therefore still requires
+`--allow secret` when the program reaches Secret. It compares the complete raw
+transcripts before applying redaction, so two exposed payloads sent to Console
+remain a real trace divergence. Only presentation replaces every exact derived
+payload occurrence with `<secret redacted>`, searching raw bytes before string
+or JSON escaping. The same final boundary covers warnings, constituent
+diagnostics, runtime errors, and unexpected process reports.
+
+This is an exact-byte guarantee for the two derived payloads, not taint
+tracking. It does not claim detection of fragments, hashes, encodings, or
+other transformations, and it does not observe arguments or return values of
+non-Console operations. Passing evidence remains scoped to the selected
+program, name, and seed.
+
 ## Two layers
 
 ### Layer 1: hermetic Warp cases
@@ -218,7 +246,8 @@ than reusing an ordinary-case entry.
 ### Layer 2: root-driven CLI variation
 
 The CLI can vary inputs and authority available only at the root. Schedule
-variation ships in RW.3; the other two lines remain planned:
+variation ships in RW.3 and Secret variation ships in RW.4; grant variation
+remains planned:
 
     jacquard relate FILE --vary schedule=N --seed S [--allow EFFECT ...]
     jacquard relate FILE --vary secret=NAME --seed S [--allow EFFECT ...]

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,8 +6,8 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `859`
-- Cram transcript files: `54`
+- Alcotest/QCheck cases: `861`
+- Cram transcript files: `56`
 - Doctest examples: `28` across 8 documents
 
 The test count includes six DX.2 filesystem-boundary cases and six DX.5/DX.7
@@ -46,6 +46,9 @@ compiled cases while extending that existing transcript.
 The RW.3 schedule relation adds one compiled deterministic seed-law case and
 two CLI transcripts covering equality, exact divergence, and preserved
 constituent failure classes.
+RW.4 adds two compiled secret-payload/redaction cases and two leak-scanning
+CLI transcripts. Its recovered night-shift flagship extends the existing
+case-study transcript without adding another cram file.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 859 compiled Alcotest/QCheck cases, 54 recursive
+The current successor inventory is exactly 861 compiled Alcotest/QCheck cases, 56 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -759,8 +759,8 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `859`
-- Cram transcript files: `54`
+- Alcotest/QCheck cases: `861`
+- Cram transcript files: `56`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
 `channel-contract` cases plus the `store/9` Channel-private-hash case took the
@@ -802,8 +802,10 @@ inventory. Relational Warp transcript recording adds six compiled cases and one
 internal tooling transcript, producing `853 / 52 / 28`; strict transcript
 parsing and semantic comparison add five compiled cases without adding another
 cram file, producing `858 / 52 / 28`. RW.3 schedule relation adds one compiled
-seed-law case and two CLI transcripts, producing the current `859 / 54 / 28`
-inventory.
+seed-law case and two CLI transcripts, producing `859 / 54 / 28`. RW.4 Secret
+variation adds two compiled payload/redaction cases and two leak-scanning CLI
+transcripts, producing the current `861 / 56 / 28` inventory; its recovered
+night-shift flagship extends the existing case-study transcript.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/src/cli_entry.ml
+++ b/src/cli_entry.ml
@@ -9,11 +9,15 @@ let backtrace_lines exception_value backtrace =
   if String.equal rendered "" then Printexc.to_string exception_value
   else Printexc.to_string exception_value ^ "\n" ^ rendered
 
-(** [run ~program ~err ~render_diagnostic evaluate] evaluates the CLI with Cmdliner's exception
-    capture disabled so a missed structural [Stack_overflow] is classified as E0003. The supplied
-    renderer lets the process boundary honor the selected diagnostic format. Other uncaught
-    exceptions retain the conventional Cmdliner-style report and internal-error exit status 125. *)
-let run ~program ?(err = Format.err_formatter) ?(render_diagnostic = Diag.to_string) evaluate =
+(** [run ~program ~err ~render_diagnostic ~sanitize_output evaluate] evaluates the CLI with
+    Cmdliner's exception capture disabled so a missed structural [Stack_overflow] is classified as
+    E0003. The supplied renderer lets the process boundary honor the selected diagnostic format.
+    [sanitize_output] is the final byte boundary for a command that handles sensitive derived
+    inputs; it is applied to both structured and unexpected reports and defaults to identity. Other
+    uncaught exceptions retain the conventional Cmdliner-style report and internal-error exit status
+    125. *)
+let run ~program ?(err = Format.err_formatter) ?(render_diagnostic = Diag.to_string)
+    ?(sanitize_output = Fun.id) evaluate =
   match evaluate () with
   | status -> status
   | exception Stack_overflow ->
@@ -26,10 +30,10 @@ let run ~program ?(err = Format.err_formatter) ?(render_diagnostic = Diag.to_str
           ~next_step:"Reduce the input nesting and report the missing structural guard."
           ~contrast:None ()
       in
-      Format.fprintf err "%s@." (render_diagnostic diagnostic);
+      Format.fprintf err "%s@." (sanitize_output (render_diagnostic diagnostic));
       diagnostic_error
   | exception exception_value ->
       let backtrace = Printexc.get_raw_backtrace () in
       Format.fprintf err "%s: internal error, uncaught exception:@\n%s@." program
-        (backtrace_lines exception_value backtrace);
+        (sanitize_output (backtrace_lines exception_value backtrace));
       internal_error

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -1236,13 +1236,16 @@ let install_dry (ctx : Eval.ctx) ~(audit : string list ref) : (unit, Diag.t list
     this so it never suggests granting a pure effect. *)
 let grantable_names = [ "clock"; "console"; "dist"; "eval"; "fs"; "infer"; "net"; "secret" ]
 
-(** [grant ?console_read ctx name ~out ~seed] installs the root handler for effect [name]
-    (case-insensitive: "Eval" and "eval" both work); [seed] feeds the dist sampling handler only.
-    [console_read] replaces Console's default stdin reader when supplied, allowing multi-run tools
-    to capture and replay input without changing ordinary run behavior. Returns E0703 for effects
-    that exist but are not grantable (e.g. [abort]) and unknown effect names alike; keep the
+(** [grant ?console_read ?secret_getenv ctx name ~out ~seed] installs the root handler for effect
+    [name] (case-insensitive: "Eval" and "eval" both work); [seed] feeds the dist sampling handler
+    only. [console_read] replaces Console's default stdin reader when supplied, allowing multi-run
+    tools to capture and replay input without changing ordinary run behavior. [secret_getenv]
+    replaces only the Secret environment adapter when supplied; embeddings can therefore provide an
+    isolated lookup overlay without mutating process-global environment state. Returns E0703 for
+    effects that exist but are not grantable (e.g. [abort]) and unknown effect names alike; keep the
     dispatch in sync with {!grantable_names}. *)
-let grant ?console_read (ctx : Eval.ctx) name ~infer_cache ~out ~seed : (unit, Diag.t list) result =
+let grant ?console_read ?secret_getenv (ctx : Eval.ctx) name ~infer_cache ~out ~seed :
+    (unit, Diag.t list) result =
   match String.lowercase_ascii name with
   | "console" -> (
       match console_read with
@@ -1254,7 +1257,7 @@ let grant ?console_read (ctx : Eval.ctx) name ~infer_cache ~out ~seed : (unit, D
   | "clock" -> install_clock ctx
   | "fs" -> install_fs ctx
   | "infer" -> install_infer ?cache_dir:infer_cache ctx
-  | "secret" -> install_secret_environment ctx
+  | "secret" -> install_secret_environment ?getenv:secret_getenv ctx
   | other -> err ~code:"E0703" "effect `%s` is not grantable" other
 
 (** Builtin type signatures for the checker (W3.2): the marker bodies would type as [code], so the

--- a/src/relate.ml
+++ b/src/relate.ml
@@ -2,6 +2,8 @@
 
 module Int_set = Set.Make (Int)
 
+let secret_redaction_marker = "<secret redacted>"
+
 (** [schedule_seeds] keeps the root seed as run one and rejects duplicate SplitMix64 candidates so
     every accepted constituent schedule has a distinct seed. *)
 let schedule_seeds ~root_seed ~count =
@@ -16,3 +18,48 @@ let schedule_seeds ~root_seed ~count =
         else accept (remaining - 1) (Int_set.add candidate seen) (candidate :: reversed)
     in
     accept (count - 1) (Int_set.singleton root_seed) [ root_seed ]
+
+(** [secret_payloads] derives two printable, visibly tool-owned payloads from the existing
+    SplitMix64 stream. The lane labels keep the payloads distinct even if the two generator outputs
+    were ever equal. *)
+let secret_payloads ~root_seed =
+  let generator = Infer_dist.Rng.make root_seed in
+  let first = Infer_dist.Rng.next_int64 generator in
+  let second = Infer_dist.Rng.next_int64 generator in
+  (Printf.sprintf "rw-secret-v0-a-%016Lx" first, Printf.sprintf "rw-secret-v0-b-%016Lx" second)
+
+let starts_with_at source ~offset needle =
+  let source_length = String.length source in
+  let needle_length = String.length needle in
+  if offset + needle_length > source_length then false
+  else
+    let rec equal index =
+      index = needle_length || (source.[offset + index] = needle.[index] && equal (index + 1))
+    in
+    equal 0
+
+(** [redact] scans raw bytes before any diagnostic escaping. Longer payloads win at an overlapping
+    position so replacing a prefix cannot expose the suffix of another forbidden payload. *)
+let redact ~secrets source =
+  let secrets =
+    secrets
+    |> List.filter (fun secret -> not (String.equal secret ""))
+    |> List.sort_uniq String.compare
+    |> List.sort (fun left right -> Int.compare (String.length right) (String.length left))
+  in
+  match secrets with
+  | [] -> source
+  | _ ->
+      let buffer = Buffer.create (String.length source) in
+      let rec scan offset =
+        if offset = String.length source then Buffer.contents buffer
+        else
+          match List.find_opt (starts_with_at source ~offset) secrets with
+          | Some secret ->
+              Buffer.add_string buffer secret_redaction_marker;
+              scan (offset + String.length secret)
+          | None ->
+              Buffer.add_char buffer source.[offset];
+              scan (offset + 1)
+      in
+      scan 0

--- a/src/relate.mli
+++ b/src/relate.mli
@@ -6,3 +6,14 @@ val schedule_seeds : root_seed:int -> count:int -> int list
     SplitMix64 outputs derived from that root. A non-positive [count] returns the empty list. The
     derivation is deterministic on Jacquard's supported 64-bit OCaml runtime and does not mutate
     caller-visible state. *)
+
+val secret_payloads : root_seed:int -> string * string
+(** [secret_payloads ~root_seed] returns two distinct, deterministic printable payloads derived from
+    the first two SplitMix64 outputs rooted at [root_seed]. Both carry the stable
+    [rw-secret-v0-<lane>-] prefix used by relational leak scans. *)
+
+val redact : secrets:string list -> string -> string
+(** [redact ~secrets bytes] replaces every exact occurrence of a nonempty forbidden byte string with
+    [<secret redacted>]. It searches longer strings first at an overlapping position, handles
+    repeated occurrences, and returns [bytes] unchanged when [secrets] has no nonempty member. It
+    does not claim taint tracking, transformed-encoding detection, or secure memory erasure. *)

--- a/src/run_transcript.ml
+++ b/src/run_transcript.ml
@@ -353,18 +353,24 @@ let divergence_kind_name = function
   | Trace_divergence -> "trace-divergence"
   | Length_divergence -> "length-divergence"
 
-let render_side = function
-  | Value_side value -> Printf.sprintf "%S" value
+let render_side ~redact = function
+  | Value_side value -> Printf.sprintf "%S" (redact value)
   | Trace_side event ->
-      Printf.sprintf "operation=%s output=%S" (Hash.to_hex event.operation) event.output
+      Printf.sprintf "operation=%s output=%S" (Hash.to_hex event.operation) (redact event.output)
   | Observation_side observation ->
-      Printf.sprintf "observation value=%S value-bytes=%d trace-events=%d" observation.value
-        (String.length observation.value) (List.length observation.trace)
+      Printf.sprintf "observation value=%S value-bytes=%d trace-events=%d"
+        (redact observation.value) (String.length observation.value) (List.length observation.trace)
   | Missing_side -> "<missing>"
 
-(** [render divergence] uses the same indented [at]/[-]/[+] frame as the repository semantic differ
-    while keeping classification and redaction-capable sides structured. *)
-let render divergence =
+(** [render_redacted ~redact divergence] applies [redact] to raw result and Console bytes before
+    escaping them into the canonical frame. Structural paths, hashes, and byte counts are not
+    rewritten. *)
+let render_redacted ~redact divergence =
   Printf.sprintf "  at %s:\n    - %s\n    + %s"
     (position_path divergence.position)
-    (render_side divergence.left) (render_side divergence.right)
+    (render_side ~redact divergence.left)
+    (render_side ~redact divergence.right)
+
+(** [render divergence] is the identity-redactor specialization retained for every ordinary caller.
+*)
+let render divergence = render_redacted ~redact:Fun.id divergence

--- a/src/run_transcript.mli
+++ b/src/run_transcript.mli
@@ -84,6 +84,12 @@ val render : divergence -> string
     rendering its trace. The function adds no diagnostic header, labels, ANSI escapes, or terminal
     LF. *)
 
+val render_redacted : redact:(string -> string) -> divergence -> string
+(** [render_redacted ~redact divergence] has the same canonical frame as {!render}, but applies the
+    caller's pure byte transformation to raw value and Console-output fields before escaping them.
+    Paths, operation hashes, original byte counts, classifications, and missing-side markers remain
+    unchanged. The callback must not raise; this function performs no persistence or logging. *)
+
 val serialize : transcript -> string
 (** [serialize transcript] emits the canonical byte-oriented [run-transcript-v1] encoding. *)
 

--- a/test/cli/case-studies.t
+++ b/test/cli/case-studies.t
@@ -56,3 +56,14 @@ Stormglass compares naive and resilient checkout policies under the exact same
   PASS stormglass-suite/stormglass/no world drives resilient past its fetch budget (verified exhaustively (27 cases))
   PASS stormglass-suite/stormglass/payment down is never sold as a clear day (verified exhaustively (27 cases))
   5 passed, 0 failed, 0 skipped, 0 refused
+
+Night-shift runs the recovered flagship launcher end to end. This excerpt pins
+the relational lane after the existing granted execution: two distinct
+deploy-token payloads produce one equal observable shift and neither reaches
+the transcript.
+
+  $ JACQUARD=jac sh "$D/night-shift/run.sh" 2>&1 | sed -n '/^== relational:/,/^== Warp:/p'
+  == relational: two deploy tokens, one observable shift ==
+  relate runs=2 seed=42 verdict=equal
+  secret variation stayed redacted
+  == Warp: pinned schedules, stubbed lever, sampled properties ==

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -74,6 +74,8 @@
   run-transcript.t
   relate.t
   relate-divergence.t
+  relate-secret-no-leak.t
+  relate-secret-leak.t
   ../../demos/concurrency/concurrency_evidence.exe
   ../../demos/governed-workspace/live_evidence.exe
   (source_tree ../native-parallel)

--- a/test/cli/relate-secret-leak.t
+++ b/test/cli/relate-secret-leak.t
@@ -1,0 +1,59 @@
+Secret variation must compare raw payloads but redact them only at the final
+presentation boundary. A Console leak therefore diverges even though both
+rendered sides show the same marker. Runtime errors and JSON diagnostics use
+the same scrubber. Every command captures both streams and leak-scans the two
+exact concatenation-built payloads.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ payload_a="rw-secret-v0-a-$(printf bdd732262feb6e95)"
+  $ payload_b="rw-secret-v0-b-$(printf 28efe333b266f103)"
+  $ cat > console-leak.jac <<'EOF'
+  > leak() = {
+  >   let token = secret.read(secret-ref("fixture", None))
+  >   `op:print`(secret.expose(token))
+  > }
+  > leak()
+  > EOF
+  $ jacquard relate console-leak.jac --vary secret=fixture --seed 42 --allow secret --allow console > leak.all 2>&1; status=$?
+  $ cat leak.all
+  error[E1003]: Relational runs diverged
+    Cause: Runs 1 and 2 diverged with trace-divergence:
+             at observation[0].trace[2]:
+               - operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output="<secret redacted>"
+               + operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output="<secret redacted>"
+    Next step: Review the first divergence and make the result and routed effects invariant.
+  $ echo "exit $status"
+  exit 1
+  $ count=$(grep -F -c "$payload_a" leak.all || true); echo "payload-a occurrences=$count"
+  payload-a occurrences=0
+  $ count=$(grep -F -c "$payload_b" leak.all || true); echo "payload-b occurrences=$count"
+  payload-b occurrences=0
+
+  $ jacquard relate console-leak.jac --vary secret=fixture --seed 42 --allow secret --allow console --diagnostic-format=json-v1 > leak-json.all 2>&1; status=$?
+  $ cat leak-json.all
+  {"schema":"jacquard-diagnostic-v1","domain":"warp","code":"E1003","severity":"error","span":null,"summary":"Relational runs diverged","cause":"Runs 1 and 2 diverged with trace-divergence:\n  at observation[0].trace[2]:\n    - operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output=\"<secret redacted>\"\n    + operation=28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e output=\"<secret redacted>\"","next_step":"Review the first divergence and make the result and routed effects invariant."}
+  $ echo "json exit $status"
+  json exit 1
+  $ count=$(grep -F -c "$payload_a" leak-json.all || true); echo "json payload-a occurrences=$count"
+  json payload-a occurrences=0
+  $ count=$(grep -F -c "$payload_b" leak-json.all || true); echo "json payload-b occurrences=$count"
+  json payload-b occurrences=0
+
+  $ cat > runtime-leak.jac <<'EOF'
+  > fail() = {
+  >   let token = secret.read(secret-ref("fixture", None))
+  >   `op:read`(secret.expose(token))
+  > }
+  > fail()
+  > EOF
+  $ jacquard relate runtime-leak.jac --vary secret=fixture --seed 42 --allow secret --allow fs > runtime.all 2>&1; status=$?
+  $ cat runtime.all
+  error: World-effect I/O failed
+    Cause: io error: <secret redacted>: No such file or directory
+    Next step: Correct the path, permissions, or external resource and try again.
+  $ echo "runtime exit $status"
+  runtime exit 2
+  $ count=$(grep -F -c "$payload_a" runtime.all || true); echo "runtime payload-a occurrences=$count"
+  runtime payload-a occurrences=0
+  $ count=$(grep -F -c "$payload_b" runtime.all || true); echo "runtime payload-b occurrences=$count"
+  runtime payload-b occurrences=0

--- a/test/cli/relate-secret-no-leak.t
+++ b/test/cli/relate-secret-no-leak.t
@@ -1,0 +1,24 @@
+Secret variation runs a shape-only reader twice with distinct injected latest
+payloads. The exact payloads are assembled from pieces so neither complete
+secret occurs in this committed transcript. All stdout and stderr are captured
+before both payloads are searched.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ payload_a="rw-secret-v0-a-$(printf bdd732262feb6e95)"
+  $ payload_b="rw-secret-v0-b-$(printf 28efe333b266f103)"
+  $ cat > shape-only.jac <<'EOF'
+  > token-shape() = {
+  >   let token = secret.read(secret-ref("fixture", None))
+  >   text.contains?(secret.expose(token), "rw-secret-v0-")
+  > }
+  > token-shape()
+  > EOF
+  $ jacquard relate shape-only.jac --vary secret=fixture --seed 42 --allow secret > no-leak.all 2>&1; status=$?
+  $ cat no-leak.all
+  relate runs=2 seed=42 verdict=equal
+  $ echo "exit $status"
+  exit 0
+  $ count=$(grep -F -c "$payload_a" no-leak.all || true); echo "payload-a occurrences=$count"
+  payload-a occurrences=0
+  $ count=$(grep -F -c "$payload_b" no-leak.all || true); echo "payload-b occurrences=$count"
+  payload-b occurrences=0

--- a/test/cli/relate.t
+++ b/test/cli/relate.t
@@ -6,9 +6,10 @@ run options.
   $ jacquard relate --help=plain
   NAME
          jacquard-relate - Run a .jac surface or .jqd bootstrap file under
-         distinct deterministic schedules and compare complete result and
-         routed-root transcripts. Console input is captured in run 1 and
-         replayed by ordinal in later runs.
+         deterministic schedule or secret variation and compare complete result
+         and routed-root transcripts. Console input is captured in run 1 and
+         replayed by ordinal in later runs; derived secret payloads are
+         redacted from diagnostics without weakening raw comparison.
   
   SYNOPSIS
          jacquard relate [OPTION]… FILE
@@ -35,9 +36,11 @@ run options.
              bootstrap/jqd.
   
          --vary=KIND (required)
-             Required variation; RW.3 supports only schedule=N with N > 0. Run
-             1 uses the root seed; later runs use successive SplitMix64
-             outputs, skipping already accepted seeds.
+             Required variation. schedule=N with N > 0 uses the root scheduler
+             seed for run 1 and successive distinct SplitMix64 outputs
+             thereafter. secret=NAME runs twice at the root schedule, injects
+             two deterministic payloads for the named latest Secret, and
+             redacts either payload from every diagnostic boundary.
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -111,20 +114,20 @@ of escaping through the CLI's unexpected-internal-error boundary.
   error[E0611]: Relational constituent store could not be prepared
   1
 
-Every malformed, non-positive, or unsupported variation is a Cmdliner usage
-error and names the only supported schedule=N form.
+Every malformed or non-positive variation is a Cmdliner usage error and names
+the two supported forms.
 
   $ jacquard relate stable.jac --vary nope --seed 1
   Usage: jacquard relate [--help] [OPTION]… FILE
-  jacquard: option '--vary': expected schedule=N with N > 0
+  jacquard: option '--vary': expected schedule=N with N > 0 or secret=NAME
   [124]
   $ jacquard relate stable.jac --vary schedule=0 --seed 1
   Usage: jacquard relate [--help] [OPTION]… FILE
-  jacquard: option '--vary': expected schedule=N with N > 0
+  jacquard: option '--vary': expected schedule=N with N > 0 or secret=NAME
   [124]
-  $ jacquard relate stable.jac --vary secret=name --seed 1
+  $ jacquard relate stable.jac --vary secret= --seed 1
   Usage: jacquard relate [--help] [OPTION]… FILE
-  jacquard: option '--vary': expected schedule=N with N > 0
+  jacquard: option '--vary': expected schedule=N with N > 0 or secret=NAME
   [124]
   $ jacquard relate stable.jac --seed 1
   Usage: jacquard relate [--help] [OPTION]… FILE

--- a/test/test_relate.ml
+++ b/test/test_relate.ml
@@ -26,4 +26,86 @@ let test_schedule_seed_law () =
     "negative count is empty" []
     (Relate.schedule_seeds ~root_seed:42 ~count:(-1))
 
-let suite = [ Alcotest.test_case "schedule seed vector and laws" `Quick test_schedule_seed_law ]
+let test_secret_payload_and_redaction_laws () =
+  let expected = ("rw-secret-v0-a-bdd732262feb6e95", "rw-secret-v0-b-28efe333b266f103") in
+  let first_a, first_b = Relate.secret_payloads ~root_seed:42 in
+  let second = Relate.secret_payloads ~root_seed:42 in
+  Alcotest.(check (pair string string)) "exact SplitMix64 payload vector" expected (first_a, first_b);
+  Alcotest.(check (pair string string)) "repeated derivation is identical" (first_a, first_b) second;
+  Alcotest.(check bool) "payloads are distinct" false (String.equal first_a first_b);
+  List.iter
+    (fun payload ->
+      Alcotest.(check bool)
+        "recognizable prefix" true
+        (String.starts_with ~prefix:"rw-secret-v0-" payload))
+    [ first_a; first_b ];
+  Alcotest.(check string)
+    "embedded and repeated payloads are replaced" "before/<secret redacted>/<secret redacted>/after"
+    (Relate.redact ~secrets:[ first_a; first_b ] ("before/" ^ first_a ^ "/" ^ first_b ^ "/after"));
+  Alcotest.(check string)
+    "longest overlapping payload wins" "<secret redacted>/<secret redacted>"
+    (Relate.redact ~secrets:[ "token"; "token-long" ] "token-long/token");
+  Alcotest.(check string)
+    "empty payload is ignored" "unchanged"
+    (Relate.redact ~secrets:[ "" ] "unchanged")
+
+let test_secret_divergence_rendering () =
+  let first, second = Relate.secret_payloads ~root_seed:42 in
+  let redact = Relate.redact ~secrets:[ first; second ] in
+  let value_divergence : Run_transcript.divergence =
+    {
+      position = Value_position 3;
+      kind = Value_divergence;
+      left = Value_side ("prefix-" ^ first ^ "-suffix\n");
+      right = Value_side ("prefix-" ^ second ^ "-suffix\n");
+    }
+  in
+  Alcotest.(check string)
+    "value position and marker remain visible"
+    "  at observation[3].value:\n\
+    \    - \"prefix-<secret redacted>-suffix\\n\"\n\
+    \    + \"prefix-<secret redacted>-suffix\\n\""
+    (Run_transcript.render_redacted ~redact value_divergence);
+  let control : Run_transcript.divergence =
+    {
+      position = Value_position 0;
+      kind = Value_divergence;
+      left = Value_side "left\n";
+      right = Value_side "right\n";
+    }
+  in
+  Alcotest.(check string)
+    "ordinary values retain the canonical renderer" (Run_transcript.render control)
+    (Run_transcript.render_redacted ~redact control);
+  let operation =
+    match
+      Hash.of_canonical_hex "28570e6bcdeb8646a90b31971204be7007f658bee65154b96e587c47a6585d5e"
+    with
+    | Some operation -> operation
+    | None -> Alcotest.fail "frozen Console.print hash is malformed"
+  in
+  let trace_divergence : Run_transcript.divergence =
+    {
+      position = Trace_position { observation_index = 1; trace_index = 2 };
+      kind = Trace_divergence;
+      left = Trace_side { operation; output = first };
+      right = Trace_side { operation; output = second };
+    }
+  in
+  let rendered = Run_transcript.render_redacted ~redact trace_divergence in
+  Alcotest.(check string)
+    "trace path, operation, and redacted output"
+    (Printf.sprintf
+       "  at observation[1].trace[2]:\n\
+       \    - operation=%s output=\"<secret redacted>\"\n\
+       \    + operation=%s output=\"<secret redacted>\""
+       (Hash.to_hex operation) (Hash.to_hex operation))
+    rendered
+
+let suite =
+  [
+    Alcotest.test_case "schedule seed vector and laws" `Quick test_schedule_seed_law;
+    Alcotest.test_case "secret payload and redaction laws" `Quick
+      test_secret_payload_and_redaction_laws;
+    Alcotest.test_case "secret divergence rendering" `Quick test_secret_divergence_rendering;
+  ]

--- a/test/test_secret.ml
+++ b/test/test_secret.ml
@@ -200,6 +200,10 @@ let test_environment_and_vault_boundaries () =
     "environment key is collision-free and versioned" "JACQUARD_SECRET_V0_617069_VERSION_7632"
     (Prelude.secret_environment_key ~name:"api" ~version:(Some "v2"));
   Alcotest.(check string)
+    "latest environment key uses the recovered night-shift name"
+    "JACQUARD_SECRET_V0_6e696768742d73686966742d746f6b656e_LATEST"
+    (Prelude.secret_environment_key ~name:"night-shift-token" ~version:None);
+  Alcotest.(check string)
     "environment result stays opaque" "<secret redacted>"
     (Value.show (eval (read_ref "api" (Some "v2"))));
   Alcotest.(check (list string))


### PR DESCRIPTION
## Summary

- add `jacquard relate FILE --vary secret=NAME --seed S`
- run exactly two isolated constituents with deterministic derived payloads,
  fixed scheduler/Dist seed, unchanged grants, and a per-run latest-Secret
  environment overlay
- compare raw complete transcripts, then scrub either exact payload from text,
  JSON, runtime, warning, store/read, and unexpected-error output
- recover the Night Shift case study and add its real secret-noninterference
  launcher lane

## Safety boundary

The two payloads are the first two full-width SplitMix64 outputs with stable
tool-owned lane prefixes. They never enter argv or process-global environment.
Only the named `_LATEST` key is overridden; unrelated and versioned lookups
retain ordinary process-environment behavior.

Redaction happens after raw transcript comparison, so a program that exposes a
payload through Console still fails with E1003. The guarantee covers exact
derived bytes; it is deliberately not a taint, fragment, transformation, hash,
or non-Console-argument claim.

## Evidence

- clean-cache `dune build @all @doc`: PASS
- clean-cache full `dune runtest --force`: PASS, including native sanitizer
  lanes
- 861/861 compiled Alcotest/QCheck cases; 56 crams; 28 doctests
- focused relate/secret compiled cases and five relation/case-study crams: PASS
- recovered Night Shift launcher: PASS, including both 27-world exhaustive
  properties and the new relation leak scan
- historical release-manifest reconstruction: PASS on the exact head
- independent Claude Code 2.1.226 Fable 5 review at xhigh effort: PASS on
  `5338fb4eea9c88577b473e6aa694683f6344f89a`; no blockers, disputed tests, or
  architecture conflicts

## Scope

No kernel form, surface lowering, canonical serialization, hash/store format,
schedule trace, effect identity, native backend, corpus, or frozen historical
manifest changes.
