### PR TITLE
docs: align guides with Jacquard 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ Things you can do here that most languages cannot offer:
   explicitly granted with `--allow`, including effects performed by dynamic
   code. This is language-level enforcement in a research runtime, not a
   substitute for an operating-system sandbox.
-- Run one program against many worlds. The same code can run against the real
-  network, a scripted fake, a recording of last week's traffic, or a
-  probability model of how servers usually behave. A handler is the piece
+- Run one program against many worlds. The same code can run against the
+  shipped deterministic network stub, a scripted response list, a recorded
+  trace, or a probability model of how servers usually behave. A real network
+  adapter does not ship yet; a host integration can implement the same effect
+  boundary without changing the Jacquard program. A handler is the piece
   that answers a program's requests to the outside world; you swap the
   handler, and the code never changes. This can replace much conventional
   mocking at effect boundaries and makes "what would my agent do if the API
@@ -407,13 +409,13 @@ corpus and selected demos are evidence fixtures, not an authoring requirement.
 
 `jacquard build` accepts a public `.jac` program directly (or a retained kernel
 `.jqd` carrier) and compiles it and its reachable declarations to a
-standalone binary whose output is byte-identical to `jacquard run` —
-stdout, stderr, and exit codes, pinned by a differential harness in CI
-(`scripts/native-diff.sh`). The full effect language compiles, including
-capturing and multi-shot handlers, and code values compile since task
-73 — quotes, splices, and the structural code ops. `eval` alone stays
-on the interpreter tier (E1102 policy: dynamically loaded code runs
-where the authority model lives).
+standalone binary. Within the documented native subset, its output is
+byte-identical to `jacquard run` — stdout, stderr, and exit codes, pinned by a
+differential harness in CI (`scripts/native-diff.sh`). The effect-and-handler
+kernel compiles, including capturing and multi-shot handlers, and code values
+compile since task 73 — quotes, splices, and the structural code ops. Dynamic
+`Eval`, interpreted Task scheduling, and typed Channels stay on the interpreter
+tier.
 
 ```bash
 export JACQUARD_PRELUDE=$PWD/prelude
@@ -438,9 +440,11 @@ Requirements and knobs:
 - A C toolchain: clang (any recent) or gcc. Tail calls are O(1) stack on
   every toolchain: musttail on clang and gcc 15+, a trampoline below
   them (the emitted C is identical either way).
-- The binary parses `--allow EFFECT` (console, clock, fs, dist, infer so
-  far), `--seed N` for the sampling grant, and refuses `--infer-cache`
-  and `--dry-run` (interpreter tooling) with pointed errors.
+- The binary parses `--allow EFFECT` for its implemented root grants
+  (`console`, `clock`, `fs`, `dist`, and `infer`), plus `--seed N` for the
+  sampling grant. It rejects unsupported grants such as `net`, `eval`, and
+  `secret`, and refuses `--infer-cache` and `--dry-run` (interpreter tooling)
+  with pointed errors.
 - `JACQUARD_STACK_MB` sizes the program stack (default 1024): deep
   non-tail recursion is real C recursion in this backend.
 - Compiled units cache under `.jacquard-native/`, keyed by content, so
@@ -592,13 +596,13 @@ Deeper design references:
 - `docs/whitepaper.tex`: historical initial design thesis, motivation, risks,
   and related work; its roadmap and implementation-status sections are
   outdated.
-- `docs/ast.md`: kernel AST and metadata/hash contract.
-- `spec/jacquard-kernel-ast-m0.md`: kernel source-of-truth spec.
+- `docs/ast.md`: implemented kernel AST contract and retained design reasoning.
+- `spec/jacquard-kernel-ast-m0.md`: implemented kernel source-of-truth spec.
 - `spec/serialization.md`: canonical byte format.
 - `docs/stdlib.md`: prelude and ringed standard library.
 - `docs/warp-testing.md`: Warp testing model.
 - `docs/errors.md`: diagnostic catalog.
-- `docs/development-plan.md`: original implementation plan.
+- `docs/development-plan.md`: completed historical implementation plan.
 
 ## Development Workflow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,9 @@ project shape from file names alone.
 
 - `../README.md`: fresh-clone setup, common commands, demos, CI, and repo map.
 - `../AGENTS.md`: operating rules for future agents.
-- `SKILL.md`: the whole language in one file for coding agents — kernel forms,
-  rows and capabilities, Dist, code-as-data, Warp, CLI, style, and gotchas.
-  (Also discoverable as a project skill via `docs/SKILL.md`.)
+- `SKILL.md`: standalone language and tool guide for coding agents — kernel
+  forms, rows and capabilities, Dist, code-as-data, Warp, CLI, style, and
+  gotchas. (Also discoverable as a project skill via `docs/SKILL.md`.)
 - `tutorial.md`: runnable examples from literals through hashing and tooling.
 - `../demos/README.md`: demo catalog and what each demo proves.
 - `surface-syntax.md`: public `.jac` authoring syntax and its projection onto
@@ -26,10 +26,12 @@ project shape from file names alone.
 
 - `whitepaper.tex`: historical initial design thesis, motivation, risks, and
   related work; its roadmap and implementation-status sections are outdated.
-- `ast.md`: kernel AST draft and metadata/hash contract.
-- `../spec/jacquard-kernel-ast-m0.md`: kernel AST source-of-truth spec.
+- `ast.md`: implemented kernel AST contract with retained design reasoning.
+- `../spec/jacquard-kernel-ast-m0.md`: implemented kernel AST source-of-truth
+  specification.
 - `../spec/serialization.md`: canonical byte serialization and hashing.
-- `development-plan.md`: original task plan and milestone discipline.
+- `development-plan.md`: completed historical task plan and milestone
+  discipline; not the current backlog.
 - `concurrency.md`: phase-zero pure parallel hints, the staged
   structured-concurrency design, and SC.17 transitive cancellation semantics.
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -106,6 +106,16 @@ jac replay TRACE.jqd PROGRAM.jqd --to 12
 jac replay TRACE.jqd PROGRAM.jqd --fork '4=(response 503 "down")'
 jac tiers PROGRAM.jac
 
+# Audit-chain and governed Workspace review tools.
+jac audit genesis
+jac audit append AUDIT_LOG.audit AUDIT_ENTRY.jqd --previous HASH
+jac governance check WORKSPACE.jac --output-format json-v1
+jac governance verify-log AUDIT_LOG.audit --head HASH
+jac governance verify-run RUN_BUNDLE.jqd
+jac governance reconcile RECONCILIATION_BUNDLE.jqd
+jac governance explain PROPOSAL_ID --bundle RECONCILIATION_BUNDLE.jqd
+jac why-effect Net --source WORKSPACE.jac --output-format json-v1
+
 # Native AOT accepts public surface input directly.
 jac build PROGRAM.jac -o program
 jac export PROGRAM.jac -o PROGRAM.jqd  # explicit evidence/debug carrier only
@@ -147,6 +157,10 @@ Grant variation runs exactly twice with no extra `--allow`: one live
 It compares only ordered rendered result values, not routed events, Console
 output, audits, calls, costs, latency, or external consequences. Forwarded,
 mixed read/write, unsupported, and unknown effects are usage errors.
+The `audit` commands append canonical hash-chained entries and publish their
+heads. The `governance` and `why-effect` commands verify frozen Workspace v0
+artifacts or conservatively analyze declaration-only source; they do not
+execute that source or turn review evidence into host authorization.
 
 ## Surface Syntax
 
@@ -169,9 +183,9 @@ Names follow these rules:
 - Reals are floating point. Text is UTF-8 and indexed by codepoint, not
   grapheme cluster.
 
-Reserved words are `type`, `effect`, `fn`, `let`, `rec`, `match`, `handle`,
-`return`, `resume`, `quote`, `unquote`, `if`, `then`, `else`, `as`, `where`,
-`forall`, and `jqd`.
+Reserved words are `type`, `effect`, `once`, `multi`, `fn`, `let`, `rec`,
+`match`, `handle`, `return`, `resume`, `quote`, `unquote`, `if`, `then`,
+`else`, `as`, `where`, `forall`, and `jqd`.
 
 ### Values, Calls, And Definitions
 
@@ -461,7 +475,11 @@ top-item    := signature | definition | type-decl | effect-decl | expression
 signature   := name ":" type
 definition  := name ["(" patterns? ")"] "=" expression
 type-decl   := "type" Type type-vars? "=" ("|" constructor)+
-effect-decl := "effect" Effect type-vars? "where" "{" op-signature* "}"
+effect-decl := mode "effect" Effect type-vars? "where" "{" uniform-op-signature+ "}"
+| "effect" Effect type-vars? "where" "{" mode-op-signature+ "}"
+uniform-op-signature := name ":" "(" types? ")" "->" type
+mode-op-signature := mode name ":" "(" types? ")" "->" type
+mode        := "once" | "multi"
 
 expression  := call ("|>" call)*
 call        := primary ("(" expressions? ")")*
@@ -490,9 +508,13 @@ continuation rather than item separation.
 
 ## Capabilities And Root Authority
 
-World effects are `Console`, `Clock`, `Fs`, `Net`, `Eval`, and `Infer`.
-`Dist` is pure inference rather than world authority. Root handlers exist only
-when explicitly granted:
+The complete `--allow` vocabulary is `clock`, `console`, `dist`, `eval`, `fs`,
+`infer`, `net`, and `secret`. `Console`, `Clock`, `Fs`, and `Net` describe the
+ordinary external world; `Eval` is dynamic-code authority, `Infer` delegates to
+an unverified model boundary, `Secret` uses the environment adapter, and `Dist`
+installs seeded sampling. `Dist` is computationally pure rather than outside-
+world authority, but selecting its root sampling handler is still an explicit
+grant. These root handlers exist only when granted:
 
 ```sh
 jac check agent.jac --print-sigs
@@ -511,6 +533,8 @@ Rules to rely on:
   audits writes and network actions, and performs no audited world mutation.
 - `--allow fs` currently grants the whole filesystem. Authority is effect-level,
   not path- or domain-level object capability.
+- The interpreter's `--allow net` handler is a deterministic stub. Scripted and
+  recording handlers ship, but a real socket/HTTP adapter does not.
 - Evaluated code runs with root grants, not under an interposed attenuation
   handler. Audit its inferred requirements and grants accordingly.
 - Top-level rows are closed. When an API expects an open-row thunk, eta-expand
@@ -519,6 +543,11 @@ Rules to rely on:
 Never infer authority from a hand-written manifest or comment; use the checked
 row. Never add a grant merely to silence a refusal without reviewing why the
 row contains that effect.
+
+`Approval`, `Audit`, `Judge`, `Workspace`, and `Channel` have implemented
+language or embedding boundaries but are not ordinary `--allow` root names.
+In particular, a governance verdict is evidence consumed by trusted host code;
+it does not install ambient authority.
 
 ## Discrete Probability With Dist
 
@@ -699,8 +728,9 @@ diagnostics, not permissive fallbacks.
 kernel input. It uses the same parse/lower/resolution path as check and hash,
 emits C for the reachable program, links the Jacquard runtime, and asks clang
 or gcc to compile with optimization and LTO. It does not generate a persistent
-bootstrap twin. Native and interpreted behavior are expected to be
-byte-identical for stdout, stderr, and exit status.
+bootstrap twin. For programs within the documented native subset, native and
+interpreted behavior are expected to be byte-identical for stdout, stderr, and
+exit status.
 
 ```sh
 # Installed releases discover the runtime automatically. In a checkout only:
@@ -721,10 +751,12 @@ Materialize stdin or other non-seekable input before export.
 
 The backend supports deep handlers with both reusable `multi` continuations and
 affine `once` resumptions, including the E0906 repeated-resume backstop. It also
-supports Dist, quotes, splices, and structural Code operations. Dynamic `eval`
-is interpreter-only and reports
-E1102 when compiled. `--dry-run` and `--infer-cache` are interpreter tooling
-and compiled binaries refuse them. A C toolchain is required. Deep non-tail
+supports Dist, quotes, splices, and structural Code operations. Its implemented
+root grants are `console`, `clock`, `fs`, `dist`, and `infer`. Dynamic `eval`,
+interpreter root Task scheduling, and typed Channels do not compile as native
+execution features; `eval` reports E1102, while unsupported native grants are
+refused with E1103. `--dry-run` and `--infer-cache` are interpreter tooling and
+compiled binaries refuse them. A C toolchain is required. Deep non-tail
 recursion uses the configured program stack; set `JACQUARD_STACK_MB` if needed.
 Compiled units cache under `.jacquard-native/` by content hash.
 
@@ -776,7 +808,15 @@ Do not invent new kernel forms for surface sugar.
 - No null, records, modules/imports, guards, or-patterns, custom operators,
   implicit traits/typeclasses, or generated field accessors. Explicit
   dictionaries are ordinary values.
-- No concurrency or enforced effect membranes in the shipped language.
+- The interpreter ships deterministic structured Tasks, cooperative
+  cancellation, bounded schedule exploration/replay, and scoped typed
+  Channels. It does not ship preemption, host threads, asynchronous host I/O,
+  native Task scheduling, native Channels, select/timeouts, actors, or
+  supervision.
+- The frozen Workspace v0 governed membrane ships as an evidence-backed
+  research reference. It is not a general isolation mechanism, production
+  authorization system, or operating-system sandbox; trusted host code still
+  owns identity, persistence, live drivers, and final execution.
 - Probability is finite/discrete: no continuous distributions or gradients.
 - Quote/eval is untyped staging; there is no typed staging or macro expander.
 - No Jacquard package manager, dependency solver, registry trust model, or

--- a/docs/ast.md
+++ b/docs/ast.md
@@ -1,7 +1,11 @@
-# Jacquard Kernel AST — M0, Draft 0.1
+# Jacquard Kernel AST — Implemented M0/0.2 Contract
 
-Status: proposal for review. Everything here is arguable; the count accounting and open
-questions at the end mark where I expect the argument.
+Status: implemented. The 27-form grammar and canonicalization rules are the
+kernel contract shipped in Jacquard 0.2. This document preserves the original
+design reasoning while marking settled decisions and genuine future questions.
+The exact carrier grammar is normative in
+`../spec/jacquard-kernel-ast-m0.md`; serialization bytes are normative in
+`../spec/serialization.md`.
 
 ---
 
@@ -16,9 +20,11 @@ separated:
 (head, meta, args)
 ```
 
-This is Elixir's `{form, meta, args}` generalized. It is what `quote` produces, what macros
-will eventually see, what gets serialized, and what gets content-addressed. There is exactly
-one shape. A model that learns it has learned the entire physical syntax of the language.
+This is Elixir's `{form, meta, args}` generalized. It is what `quote` produces,
+what quote/unquote and gated-eval tooling sees, what gets serialized, and what
+gets content-addressed. A future macro expander could consume the same shape,
+but no macro expander ships today. There is exactly one shape. A model that
+learns it has learned the entire physical syntax of the language.
 
 **Layer 2: the grammar.** An ASDL-style refinement over triples that says which heads exist
 and what their argument shapes must be. A triple that satisfies the grammar is a *kernel form*;
@@ -117,7 +123,7 @@ products (clause shapes, rows, specs) are structures, not forms, exactly as Pyth
 treats `arguments` and `keyword`.
 
 ```asdl
--- Jacquard kernel, M0 draft 0.1
+-- Jacquard kernel, implemented M0 contract
 -- Every constructor below is realized as a triple (head, meta, args)
 -- with head = the constructor name, lowercased.
 
@@ -160,7 +166,7 @@ module Jacquard
   opclause = (hash op, pat* params, name resume, expr body)
   binding  = (name id, type? annotation, expr value)
   conspec  = (name id, field* fields)
-  field    = (name? label, type ty)                        -- labels generate accessor fns
+  field    = (name? label, type ty)                        -- schema labels hash; no generated accessors today
   opmode   = Multi | Once
   opspec   = (name id, opmode mode, type* params, type result)
   row      = (hash* effects, name? var)                    -- effect set + optional row variable
@@ -208,11 +214,12 @@ with a receipt from the survey:
 
 Decisions within what remains:
 
-- **`Lam`/`App` are n-ary, not curried.** Judgment call, could flip. Uncurried gives a
-  clearer cost model, crisp arity errors, and one obvious place for the effect row on each
-  arrow. Unison is curried and makes it work; Koka is uncurried. Currying remains available
-  the ordinary way (a lambda returning a lambda). Zero-ary `Lam`/`App` doubles as
-  thunk/force, which a strict language needs (§7).
+- **`Lam`/`App` are n-ary, not curried.** Decision D5 is settled and shipped.
+  Uncurried calls give a clearer cost model, crisp arity errors, and one obvious
+  place for the effect row on each arrow. Unison is curried and makes it work;
+  Koka is uncurried. Currying remains available the ordinary way (a lambda
+  returning a lambda). Zero-ary `Lam`/`App` doubles as thunk/force, which a
+  strict language needs (§7).
 - **`Lam` params are patterns** (commitment: patterns everywhere), restricted to irrefutable
   ones; the checker enforces irrefutability, semantics is `Match`.
 - **`Let` carries a `rec` flag** rather than spending a second form. `rec` restricts the
@@ -267,9 +274,10 @@ is mandatory. Humans and models should rarely write rows; they should always be 
 *read* them, fully elaborated, in displayed signatures. Inference for writing, elaboration
 for reading.
 
-Records beyond labeled constructor fields (true row-typed records) are deferred; `field`
-labels on `DefType` constructors generate accessor functions at zero kernel cost, which
-covers the common case.
+Records beyond labeled constructor fields (true row-typed records) are deferred.
+The shipped `.jac` surface preserves labels as constructor schema: labels print
+and contribute to canonical identity, but do not generate accessor functions or
+labeled patterns. Those remain separately gated surface follow-ups.
 
 ### 5.4 Declarations
 
@@ -296,11 +304,10 @@ on hashes, and an edit invalidates exactly its dependents.
 ## 6. Content addressing: the canonicalization pipeline
 
 ```
-surface text
-  └─ parse ─────────▶ triple form (names, trivia, spans in meta)
-       └─ expand ───▶ triple form (macro-free; hygiene resolved via scope sets)
-            └─ resolve ─▶ kernel form (Var for locals, Ref(hash) for globals)
-                 └─ canonicalize ─▶ hash input
+.jac text ──▶ parse surface tree ──▶ lower
+.jqd text ──▶ read triple form ───▶ validate
+both carriers ──▶ pre-resolution kernel form ──▶ resolve
+resolved kernel form (Var for locals, Ref(hash) for globals) ──▶ canonicalize ──▶ hash input
 ```
 
 Canonicalization rules:
@@ -312,8 +319,8 @@ Canonicalization rules:
    each member's individual hash is the group hash plus its index. (Unison's cycle
    treatment.)
 4. Constructor and operation references canonicalize to (declaration hash, ordinal).
-5. Serialize the canonical tree deterministically; hash with a fixed function
-   (BLAKE3 is the working assumption; a named constant in the spec, not a commitment).
+5. Serialize the canonical tree deterministically; hash with `HASH_V0`, which
+   is SHA-256 via `digestif` (decision D1).
 
 Consequences worth saying out loud: renames are free and history-preserving; formatting
 and comments never dirty a build; a semantic differ falls out of comparing trees rather
@@ -358,18 +365,20 @@ if c then a else b
 **The entire probabilistic layer, declared with no new forms:**
 
 ```
-type Distribution a = ...          -- library data: Bernoulli, Categorical, Normal, ...
+type Distribution a = ...          -- finite library data: Bernoulli, Categorical, UniformInt
 
 multi effect Dist where
-  sample  : Distribution a -> a
-  observe : Distribution a -> a -> ()
+  sample  : (Distribution a) -> a
+  observe : (Distribution a, a) -> ()
 ```
 
 which is one `DefType` and one `DefEffect`. A model is any expression whose row includes
-`Dist`. An inference algorithm is a `Handle`: the enumeration handler resumes per support
-element and weights; an SMC or gradient handler is a different `Handle` around the same
-untouched model. Your fields intuition lands here too: composing two models multiplies
-their weight functions, and the handler is where superposition becomes a posterior.
+`Dist`. An inference algorithm is a `Handle`: exact enumeration resumes per
+support element and weights, while likelihood weighting samples with a fixed
+seed. Both ship for finite discrete distributions. Continuous distributions,
+gradients, and SMC do not ship in 0.2. Your fields intuition lands here too:
+composing two models multiplies their weight functions, and the handler is
+where superposition becomes a posterior.
 
 **Homoiconicity check.** `sample (bernoulli 0.5)` as its quoted triple:
 
@@ -387,19 +396,18 @@ risk: there is very little language to learn.
 ## 9. What M0 deliberately excludes
 
 Records with row types; guards and or-patterns; implicit ad-hoc-polymorphism
-resolution (traits/classes); macros beyond quote/unquote/eval; typed staging;
+resolution (traits/classes); a macro expander beyond quote/unquote/gated eval; typed staging;
 numeric tower; ownership (GC assumed); any performance story. Explicit
 dictionaries are ordinary `DefType`/`DefTerm` values and need no kernel form.
 Exclusion here means "not in the kernel grammar yet," not "never."
 
-## 10. Open questions and honest flags
+## 10. Settled decisions, open questions, and honest flags
 
-1. **The count is 27, not 25.** Cheapest cuts if the number matters: drop `PAs`
-   (ergonomics only) and `TTuple` (encode as `TApp` of built-in tuple constructors).
-   I'd keep both and let the target flex; forms should earn their place, and these do.
-2. **Uncurried could flip.** If early macro or pipeline ergonomics favor currying, the
-   change is contained: `Lam`/`App`/`TArrow` arities and the row placement convention.
-   Decide before M2 (the checker), cheap before then.
+1. **The count is settled at 27.** The original target was roughly 25; `PAs`
+   and `TTuple` earned their places and now belong to the permanent kernel.
+2. **Uncurried is settled.** D5 selected n-ary, uncurried calls before the
+   checker shipped. Changing `Lam`/`App`/`TArrow` arities now would be a kernel
+   and compatibility change, not an open pre-M2 choice.
 3. **Explicit dictionaries settle the 0.1 ad-hoc-polymorphism boundary.** Generic
    functions visibly receive ordinary `Eq`, `Ord`, `Show`, or `Num` values.
    Implicit search, operators, and defaulting remain deferred; any future sugar

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -1,4 +1,10 @@
-# Jacquard Development Plan — M0 through M4
+# Jacquard Development Plan — M0 through M4 (Completed, Historical)
+
+> **Status:** This original implementation plan is complete and retained as a
+> design and sequencing record. Its unchecked boxes describe the acceptance
+> criteria as originally written; they are not the current task backlog. For
+> the shipped boundary, use `release/0.2/`; use Task Master only when the owner
+> explicitly activates it for current work.
 
 Version 0.1, July 2026. Companion to `jacquard-kernel-ast-m0.md` (the spec) and the whitepaper.
 Audience: a junior engineer implementing, plus the owner making the flagged decisions.
@@ -7,9 +13,10 @@ Sizes: S is a day or less, M is 2 to 4 days, L is 1 to 2 weeks. Estimates assume
 engineer, OCaml-competent but new to language implementation. Honest total: roughly
 60 to 80 working days, about four months solo, before the M4 demos.
 
-How to run this plan: work strictly in phase order, tasks within a phase in numbered
-order unless marked parallel-safe. Every milestone boundary is a review gate with a
-runnable demo. Nothing merges without its definition-of-done checklist passing in CI.
+The original execution rule was to work strictly in phase order, with tasks
+inside a phase completed in numbered order unless marked parallel-safe. Every
+milestone boundary was a review gate with a runnable demo, and nothing merged
+without its definition-of-done checklist passing in CI.
 
 ---
 

--- a/docs/effect-linearity.md
+++ b/docs/effect-linearity.md
@@ -1,4 +1,9 @@
-# Effect Linearity Modes — Design, Draft 0.1
+# Effect Linearity Modes — Design and Implemented Contract
+
+Status: the operation-mode encoding, explicit surface modes, affine `Resume`
+checks, runtime backstop, and reviewed prelude assignments described here ship
+in Jacquard 0.2. Historical task/phasing language is retained as the design
+record; sections explicitly labeled deferred remain future work.
 
 Companion to the kernel spec, the effects runtime (tasks 70/71), and the
 concurrency design. Origin: external review flagged that multi-shot
@@ -58,14 +63,15 @@ The exact bootstrap carriers are `(op fetch ((tref request)) (tref response))`
 for `Multi` and `(op fetch once ((tref request)) (tref response))` for `Once`.
 Explicit `multi` is rejected so absence remains the unique legacy encoding.
 In `HASH_V0`, `Multi` contributes no byte; `Once` appends byte `0x01` after the
-serialized result type. Until the surface-syntax phase lands, tools render a
-`Once` operation in bootstrap notation rather than erase its mode.
+serialized result type. Bootstrap tools render a `Once` operation explicitly
+rather than erase its mode. The shipped surface printer emits explicit
+`once`/`multi` syntax under D41-D42.
 
 Mode is part of the **interface hash**. Tightening an operation from `multi`
 to `once` changes what dependents' handlers are allowed to do, so it is a
-breaking interface change by construction, and `jac pkg diff` reports it in
-authority terms: "op `fetch`: multi -> once (handlers may no longer resume
-repeatedly)."
+breaking interface change by construction. A future package-aware authority
+differ could report it as: "op `fetch`: multi -> once (handlers may no longer
+resume repeatedly)." Jacquard 0.2 does not ship `jac pkg`.
 
 ## 4. Surface syntax
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -202,7 +202,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 | code | meaning | example |
 |------|---------|---------|
 | E1200 | retired surface-parser scaffold diagnostic; reserved and no longer emitted | an older build rejecting every nonempty `.jac` file |
-| E1201 | canonical surface printer is not implemented at this scaffold boundary | calling the SS.1 printer placeholder |
+| E1201 | retired surface-printer scaffold diagnostic; reserved and no longer emitted | an older scaffold calling the pre-SS.1 printer placeholder |
 | E1202 | recovered surface tree still contains holes | checking malformed `.jac` after parser recovery |
 | E1203 | kernel subtree has no self-contained surface fragment | rendering an ambiguous raw `group` in a semantic diff |
 | E1210 | unexpected surface character | `@` outside a string |

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1,4 +1,9 @@
-# The Jacquard Standard Library — Design, Draft 0.1
+# The Jacquard Standard Library — Design and Implemented Reference
+
+Status: this began as the standard-library design and now records the shipped
+Jacquard 0.2 prelude. Signature catalogs and explicitly labeled pseudocode are
+not complete source files. Section 12 records implementation narrowings where
+the original design and current behavior differ.
 
 Companion to the kernel spec, the whitepaper, and the dev plan. This document
 supersedes the prelude sketch in dev plan task W2.6; a reconciliation table sits at
@@ -513,7 +518,7 @@ they read it:
 | `Console` | low | `console.scripted` or explicit root grant | terminal observation or interaction |
 | `Clock` | low | `clock.fixed` or explicit root grant | wall-clock observation or waiting |
 | `Fs` | medium | `fs.in-memory`, `fs.read-only`, or explicit root grant | filesystem access; the root grant is not path-scoped |
-| `Net` | high | `net.scripted`, `net.record`, or explicit root grant | network access |
+| `Net` | high | `net.scripted`, `net.record`, or explicit root grant (deterministic stub in 0.2) | network-shaped requests; live socket/HTTP access requires a host adapter that does not ship |
 | `Eval` | high | explicit root grant only | execution of constructed code at root authority |
 | `Infer` | medium | `infer.scripted` or explicit root grant | unverified model output |
 | `Approval` | special | four hash-revalidating Approval handlers | exact consent semantics, not ordinary risk ordering |
@@ -1101,13 +1106,19 @@ OCaml driver (`jacquard infer enumerate`) reports E0901 for the same model.
 **`Map k v` displays as `map.t k v`.** Elaborated signatures print the store name of the
 wrapper type; the doc's display-syntax `Map k v` is the same type.
 
-**`--allow fs` is the whole filesystem.** The grant is the only boundary in this draft —
+**`--allow fs` is the whole filesystem.** The grant is the only boundary in 0.2 —
 no path confinement. Attenuate with in-language handlers (`fs.read-only`); path-scoped
 grants are future work.
 
+**`--allow net` is a deterministic stub, not live networking.** It returns a
+canned success response naming the requested URL. `net.scripted`, `net.record`,
+and replay handlers provide test worlds, but Jacquard 0.2 does not ship a
+socket or HTTP client adapter. An embedding can supply that boundary later.
+
 **`eval` bypasses interposed handlers.** Eval'd code runs at root authority with a fresh
 continuation, so wrapping handlers (including `fs.read-only`) do not attenuate `eval-code`
-payloads; only root grants apply. Owner decision pending (M1 note).
+payloads; only root grants apply. This is the documented 0.2 behavior; changing
+it requires a separate authority decision and evidence boundary.
 
 **Smaller narrowings.** `text.trim` strips ASCII whitespace only. `uniform-int`
 enumeration support caps at 10000 outcomes (pmf and sampling work on any range).

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -1,14 +1,14 @@
 # Jacquard Surface Syntax — Design and Implemented Charter
 
-Companion to the kernel spec, stdlib design, testing framework, package manager
-CLI, and the native compilation plan. This document decides whether Jacquard
-gets a human-facing syntax, what it optimizes for, and what it looks like,
-form by form, with the desugaring of each.
+Companion to the kernel spec, stdlib design, testing framework, and native
+compilation plan. This document records why Jacquard has a human-facing syntax,
+what it optimizes for, and what it looks like, form by form, with the
+desugaring of each.
 
-Short version: yes, after task 74, printer-first, delimiter-based, and one
-infix operator total. Executable display examples migrate to this grammar and
-become doctests when it lands; deliberately schematic snippets stay labeled
-as pseudocode rather than being claimed as compilable source.
+Short version: the printer-first, delimiter-based surface with one infix
+operator ships. Executable display examples have migrated to this grammar;
+fences labeled as doctests run in CI, while deliberately schematic snippets
+stay labeled as pseudocode rather than being claimed as compilable source.
 
 Draft 0.2 folds in the first field feedback: two independent implementations
 translated an existing kernel-level program plus the full demo corpus, and
@@ -269,9 +269,10 @@ critical path; syntax work before 74 stabilizes would compete for the same
 attention.
 
 One compounding payoff worth naming: the display notation used throughout the
-stdlib, testing, and package manager docs is the starting point for the real
-grammar. Phase S3 migrates every executable example to its canonical spelling
-and makes it a doctest; non-executable type sketches are marked explicitly.
+stdlib, testing, and future package-management designs was the starting point
+for the real grammar. Phase S3 migrated executable examples to canonical
+spelling and made selected examples doctests; non-executable type sketches are
+marked explicitly.
 
 ## 2. The inversion that drives the design
 

--- a/docs/warp-testing.md
+++ b/docs/warp-testing.md
@@ -1,10 +1,16 @@
-# Warp — The Jacquard Testing Framework, Design Draft 0.1
+# Warp — The Jacquard Testing Framework, Design and Implemented Reference
 
-Companion to the stdlib design; assumes its rings, conventions, and notation. "Warp"
-is the working title only (the warp is the fixed set of threads the jacquard weaves
-through, which is what a test suite is to a program). The library names themselves
-live under `test.*` and `check.*`, because the stdlib's first principle says
-predictable names beat clever ones, and that principle applies to its own tooling.
+Status: Warp ships in Jacquard 0.2 with typed discovery, hermetic/world lanes,
+seeded and exhaustive properties, schedule exploration, cache, coverage, and
+relational cases. Historical phasing in section 11 remains as the design
+record, and statements explicitly marked as future work remain non-claims.
+
+Companion to the stdlib design; assumes its rings, conventions, and notation.
+"Warp" is the shipped framework name (the warp is the fixed set of threads the
+jacquard weaves through, which is what a test suite is to a program). The
+library names themselves live under `test.*` and `check.*`, because the
+stdlib's first principle says predictable names beat clever ones, and that
+principle applies to its own tooling.
 
 The framework has three unfair advantages, all inherited rather than built. Rows
 prove hermeticity, so the checker sorts unit tests from integration tests and makes

--- a/spec/jacquard-kernel-ast-m0.md
+++ b/spec/jacquard-kernel-ast-m0.md
@@ -1,7 +1,9 @@
-# Jacquard Kernel AST — M0, Draft 0.1
+# Jacquard Kernel AST — Implemented M0/0.2 Specification
 
-Status: proposal for review. Everything here is arguable; the count accounting and open
-questions at the end mark where I expect the argument.
+Status: implemented. This is the source-of-truth grammar for Jacquard's
+27-form kernel and permanent `.jqd` carrier as shipped in 0.2. Historical
+design reasoning is retained, but settled decisions are labeled as such.
+Canonical byte details are normative in `serialization.md`.
 
 ---
 
@@ -16,9 +18,11 @@ separated:
 (head, meta, args)
 ```
 
-This is Elixir's `{form, meta, args}` generalized. It is what `quote` produces, what macros
-will eventually see, what gets serialized, and what gets content-addressed. There is exactly
-one shape. A model that learns it has learned the entire physical syntax of the language.
+This is Elixir's `{form, meta, args}` generalized. It is what `quote` produces,
+what quote/unquote and gated-eval tooling sees, what gets serialized, and what
+gets content-addressed. A future macro expander could consume the same shape,
+but no macro expander ships today. There is exactly one shape. A model that
+learns it has learned the entire physical syntax of the language.
 
 **Layer 2: the grammar.** An ASDL-style refinement over triples that says which heads exist
 and what their argument shapes must be. A triple that satisfies the grammar is a *kernel form*;
@@ -87,7 +91,7 @@ products (clause shapes, rows, specs) are structures, not forms, exactly as Pyth
 treats `arguments` and `keyword`.
 
 ```asdl
--- Jacquard kernel, M0 draft 0.1
+-- Jacquard kernel, implemented M0 contract
 -- Every constructor below is realized as a triple (head, meta, args)
 -- with head = the constructor name, lowercased.
 
@@ -130,7 +134,7 @@ module Jacquard
   opclause = (hash op, pat* params, name resume, expr body)
   binding  = (name id, type? annotation, expr value)
   conspec  = (name id, field* fields)
-  field    = (name? label, type ty)                        -- labels generate accessor fns
+  field    = (name? label, type ty)                        -- schema labels hash; no generated accessors today
   opmode   = Multi | Once
   opspec   = (name id, opmode mode, type* params, type result)
   row      = (hash* effects, name? var)                    -- effect set + optional row variable
@@ -214,11 +218,12 @@ with a receipt from the survey:
 
 Decisions within what remains:
 
-- **`Lam`/`App` are n-ary, not curried.** Judgment call, could flip. Uncurried gives a
-  clearer cost model, crisp arity errors, and one obvious place for the effect row on each
-  arrow. Unison is curried and makes it work; Koka is uncurried. Currying remains available
-  the ordinary way (a lambda returning a lambda). Zero-ary `Lam`/`App` doubles as
-  thunk/force, which a strict language needs (§7).
+- **`Lam`/`App` are n-ary, not curried.** Decision D5 is settled and shipped.
+  Uncurried calls give a clearer cost model, crisp arity errors, and one obvious
+  place for the effect row on each arrow. Unison is curried and makes it work;
+  Koka is uncurried. Currying remains available the ordinary way (a lambda
+  returning a lambda). Zero-ary `Lam`/`App` doubles as thunk/force, which a
+  strict language needs (§7).
 - **`Lam` params are patterns** (commitment: patterns everywhere), restricted to irrefutable
   ones; the checker enforces irrefutability, semantics is `Match`.
 - **`Let` carries a `rec` flag** rather than spending a second form. `rec` restricts the
@@ -265,9 +270,10 @@ is mandatory. Humans and models should rarely write rows; they should always be 
 *read* them, fully elaborated, in displayed signatures. Inference for writing, elaboration
 for reading.
 
-Records beyond labeled constructor fields (true row-typed records) are deferred; `field`
-labels on `DefType` constructors generate accessor functions at zero kernel cost, which
-covers the common case.
+Records beyond labeled constructor fields (true row-typed records) are deferred.
+The shipped `.jac` surface preserves labels as constructor schema: labels print
+and contribute to canonical identity, but do not generate accessor functions or
+labeled patterns. Those remain separately gated surface follow-ups.
 
 ### 5.4 Declarations
 
@@ -294,11 +300,10 @@ on hashes, and an edit invalidates exactly its dependents.
 ## 6. Content addressing: the canonicalization pipeline
 
 ```
-surface text
-  └─ parse ─────────▶ triple form (names, trivia, spans in meta)
-       └─ expand ───▶ triple form (macro-free; hygiene resolved via scope sets)
-            └─ resolve ─▶ kernel form (Var for locals, Ref(hash) for globals)
-                 └─ canonicalize ─▶ hash input
+.jac text ──▶ parse surface tree ──▶ lower
+.jqd text ──▶ read triple form ───▶ validate
+both carriers ──▶ pre-resolution kernel form ──▶ resolve
+resolved kernel form (Var for locals, Ref(hash) for globals) ──▶ canonicalize ──▶ hash input
 ```
 
 Canonicalization rules:
@@ -355,18 +360,20 @@ if c then a else b
 **The entire probabilistic layer, declared with no new forms:**
 
 ```
-type Distribution a = ...          -- library data: Bernoulli, Categorical, Normal, ...
+type Distribution a = ...          -- finite library data: Bernoulli, Categorical, UniformInt
 
-effect Dist where
-  sample  : Distribution a -> a
-  observe : Distribution a -> a -> ()
+multi effect Dist where
+  sample  : (Distribution a) -> a
+  observe : (Distribution a, a) -> ()
 ```
 
 which is one `DefType` and one `DefEffect`. A model is any expression whose row includes
-`Dist`. An inference algorithm is a `Handle`: the enumeration handler resumes per support
-element and weights; an SMC or gradient handler is a different `Handle` around the same
-untouched model. Your fields intuition lands here too: composing two models multiplies
-their weight functions, and the handler is where superposition becomes a posterior.
+`Dist`. An inference algorithm is a `Handle`: exact enumeration resumes per
+support element and weights, while likelihood weighting samples with a fixed
+seed. Both ship for finite discrete distributions. Continuous distributions,
+gradients, and SMC do not ship in 0.2. Your fields intuition lands here too:
+composing two models multiplies their weight functions, and the handler is
+where superposition becomes a posterior.
 
 **Homoiconicity check.** `sample (bernoulli 0.5)` as its quoted triple:
 
@@ -383,21 +390,23 @@ risk: there is very little language to learn.
 
 ## 9. What M0 deliberately excludes
 
-Records with row types; guards and or-patterns; ad-hoc polymorphism (traits/classes);
-macros beyond quote/unquote/eval; typed staging; numeric tower; ownership (GC assumed);
+Records with row types; guards and or-patterns; implicit ad-hoc-polymorphism
+resolution (traits/classes); a macro expander beyond quote/unquote/gated eval;
+typed staging; numeric tower; ownership (GC assumed);
 any performance story. Exclusion here means "not in the kernel grammar yet," not "never."
 
-## 10. Open questions and honest flags
+## 10. Settled decisions, open questions, and honest flags
 
-1. **The count is 27, not 25.** Cheapest cuts if the number matters: drop `PAs`
-   (ergonomics only) and `TTuple` (encode as `TApp` of built-in tuple constructors).
-   I'd keep both and let the target flex; forms should earn their place, and these do.
-2. **Uncurried could flip.** If early macro or pipeline ergonomics favor currying, the
-   change is contained: `Lam`/`App`/`TArrow` arities and the row placement convention.
-   Decide before M2 (the checker), cheap before then.
-3. **Ad-hoc polymorphism is the largest deferred design.** OCaml's biggest regret in the
-   survey (`+.` forever). Options when it lands: Rust-style traits, modular implicits,
-   or something abilities-flavored. It will touch `TForall` and `DefTerm` annotations.
+1. **The count is settled at 27.** The original target was roughly 25; `PAs`
+   and `TTuple` earned their places and now belong to the permanent kernel.
+2. **Uncurried is settled.** D5 selected n-ary, uncurried calls before the
+   checker shipped. Changing `Lam`/`App`/`TArrow` arities now would be a kernel
+   and compatibility change, not an open pre-M2 choice.
+3. **Explicit dictionaries settle the 0.1 ad-hoc-polymorphism boundary.**
+   Generic functions visibly receive ordinary `Eq`, `Ord`, `Show`, or `Num`
+   values. Implicit search, operators, and defaulting remain deferred; any
+   future sugar must elaborate to the ratified values without changing
+   existing code.
 4. **Typed staging.** `Code` is untyped in M0 and `eval` is dynamically checked at the
    boundary. Fine for a kernel; not fine forever if macros become central.
 5. **Capability granularity.** Effects-as-capabilities controls authority per handled


### PR DESCRIPTION
## Summary

- align README and the standalone agent guide with the shipped Net stub, native subset, structured concurrency, Workspace governance boundary, and complete root-grant vocabulary
- correct effect-mode grammar, kernel hashing, constructor-label identity, finite Dist examples, and settled D5/27-form decisions
- mark completed design plans and implemented reference documents clearly while preserving their historical reasoning
- retire the stale E1201 printer description and add shipped audit/governance command examples

## Verification

- dune build @all
- dune build @doc
- documentation doctests: 28 examples across 8 documents
- Alcotest/QCheck: 868 passing tests
- dune fmt
- relative Markdown link check across all edited files
- git diff --check

Full dune runtest reached only three environment-specific native sanitizer cram diffs because LeakSanitizer cannot run under ptrace; no semantic or documentation failures occurred.

No implementation code, release evidence, release manifests, or historical evidence bytes changed.