### PR TITLE
SX.24: add labeled partial constructor patterns

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -297,6 +297,11 @@ is free; resolution places fields in declaration order and treats omissions as
 `_`. Unknown or repeated selections fail, as do labeled patterns against an
 unlabeled or ambiguously labeled constructor. Nested and `as` patterns are
 valid after `:`. `Ctor(name)` remains an ordinary positional binder pattern.
+Labeled constructor patterns are refutable, just like positional constructor
+patterns, so they are not valid lambda parameters or `let` binders.
+Inside `quote { ... }`, constructor patterns must remain positional; labeled
+patterns there fail with E1237 because quoted code cannot carry their labels
+semantically.
 
 Use a braced block when an arm sequences work:
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -278,6 +278,26 @@ head(xs) =
   }
 ```
 
+For constructors with labeled fields, a match may select only the fields it
+needs:
+
+```jacquard
+type Snapshot =
+  | Snapshot(id: Int, error: Int, vendor: Text)
+
+describe(snapshot) =
+  match snapshot {
+    | Snapshot(vendor: vendor, error: problem) -> (problem, vendor)
+  }
+```
+
+Write every selection as `label: pattern`. There are no label puns, and one
+constructor pattern cannot mix labeled and positional fields. Selection order
+is free; resolution places fields in declaration order and treats omissions as
+`_`. Unknown or repeated selections fail, as do labeled patterns against an
+unlabeled or ambiguously labeled constructor. Nested and `as` patterns are
+valid after `:`. `Ctor(name)` remains an ordinary positional binder pattern.
+
 Use a braced block when an arm sequences work:
 
 ```jacquard
@@ -350,9 +370,9 @@ type Result e a =
   | Ok a
 ```
 
-Labels document constructor fields but do not create record syntax, labeled
-patterns, or generated accessors. Construct values with `Canary(5)` and match
-positionally with `Canary(percent)`.
+Labels do not create record construction or generated accessors. Construct
+values positionally with `Canary(5)`; match either positionally with
+`Canary(percent)` or by selection with `Canary(percent: value)`.
 
 Comma-separated surface groups accept an optional final comma. Compact
 formatting removes it, except for singleton tuples such as `(T,)`; when a
@@ -496,8 +516,9 @@ quote       := "quote" "{" expression "}"
 unquote     := "unquote" "(" expression ")"
 annotation  := "(" expression ":" type ")"
 
-pattern     := "_" | name | literal | Constructor ["(" patterns? ")"]
+pattern     := "_" | name | literal | Constructor ["(" (patterns | labeled-patterns)? ")"]
              | "(" patterns? ")" | pattern "as" name
+labeled-patterns := label ":" pattern ("," label ":" pattern)* [","]
 type        := type-application | tuple-type | function-type | forall-type
 function-type := "(" types? ")" "->{" effects? ["|" row-var] "}" type
 ```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -86,6 +86,10 @@ malformed source, path, or host-message byte in a string field is replaced with 
 | E0302 | name kind mismatch | `(ann (lit 1) (tref add))` — a term used as a type |
 | E0303 | duplicate binding name in a defterm group or surface definition run | two bindings named `f` |
 | E0304 | variable bound more than once in one binder group | `(lam ((pvar x) (pvar x)) ...)` |
+| E0305 | labeled constructor pattern selects an unknown field | `Snapshot(missing: x)` |
+| E0306 | labeled constructor pattern selects one field more than once | `Snapshot(error: x, error: y)` |
+| E0307 | constructor has no usable field-label schema for a labeled pattern | `Pair(left: x)` when `Pair` has only positional fields |
+| E0308 | constructor declaration has ambiguous duplicate labels at labeled-pattern use | `Pair(left: x)` when `left` is declared twice |
 
 ### Resolution warnings (W03xx)
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -234,6 +234,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 | E1234 | generated lowering node lacks a real source span | lowering a hand-built spanless block AST |
 | E1235 | a signature or definition was lowered without its required file context | calling `lower_top` on a signature |
 | E1236 | missing, duplicated, or conflicting surface operation mode; an omitted mode includes migration guidance | `effect E where { op : () -> T }` |
+| E1237 | labeled constructor pattern appears inside quoted surface syntax | `quote { match packet { \| Packet(right: value) -> value } }` |
 
 ### Surface warnings (W12xx)
 

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `868`
+Test count: `869`
 
 Cram count: `58`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `868`
+- Alcotest/QCheck cases: `869`
 - Cram transcript files: `58`
 - Documentation examples: `28` named examples across `8` documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `868`
+- Alcotest/QCheck cases: `869`
 - Cram transcript files: `58`
 - Doctest examples: `28` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 868 compiled Alcotest/QCheck cases, 58 recursive
+The current successor inventory is exactly 869 compiled Alcotest/QCheck cases, 58 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `868`
+- Alcotest/QCheck cases: `869`
 - Cram transcript files: `58`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -812,7 +812,8 @@ producing the then-current `862 / 57 / 28` inventory. RW.6 hermetic relational
 cases add three compiled seam/cache cases and one registered Warp transcript,
 producing the then-current `865 / 58 / 28` inventory. RW.7 adds the three-case
 registered relational regression net without adding a cram file or doctest,
-producing the current `868 / 58 / 28` inventory.
+producing the `868 / 58 / 28` inventory. Task 171 adds the labeled-pattern
+contract case, producing the current `869 / 58 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/release/surface-syntax/DECISION.md
+++ b/docs/release/surface-syntax/DECISION.md
@@ -50,7 +50,7 @@ Allowed decision statuses at this gate are `shipped`, `partial`, and
 |---|---|---|---|
 | D34 | shipped | [scaffold](../../../test/test_surface_scaffold.ml), [patterns](../../../test/test_surface_patterns.ml), and [twins](../../../test/test_surface_twins.ml) pin shared case projection and escapes. | none |
 | D35 | shipped | [handlers and quote](../../../test/test_surface_handlers_quote.ml) and [printing](../../../test/test_surface_print.ml) pin atomic handler bodies and mandatory blocks for non-atomic bodies. | none |
-| D36 | partial | The labeled-field portion shipped in SS.8: [declaration tests](../../../test/test_surface_decls.ml), [trivia tests](../../../test/test_surface_trivia.ml), and [printing tests](../../../test/test_surface_print.ml) pin parsing, metadata, trivia, lowering, and rendering. [CLI evidence](../../../test/cli/surface.t) pins `pair.left` as absent with `E0301`; generated accessor definitions and label validation, including duplicate-label rejection, are deliberate follow-ups. Labeled patterns remain deferred. | [D36 acceptance criteria](FOLLOWUPS.md#d36-generated-constructor-accessors) |
+| D36 | partial | The labeled-field declaration portion shipped in SS.8. SX.24 now ships partial `Ctor(label: pattern, ...)` matching, with [pattern](../../../test/test_surface_patterns.ml), [trivia](../../../test/test_surface_trivia.ml), and [CLI](../../../test/cli/surface.t) evidence for positional lowering, identity, checking, and execution. `pair.left` remains absent with E0301; generated accessors and their broader cross-constructor declaration validation remain deliberate follow-ups. | [D36 accessor acceptance criteria](FOLLOWUPS.md#d36-generated-constructor-accessors) |
 | D37 | shipped | [lexer tests](../../../test/test_surface_lex.ml) and [parser tests](../../../test/test_surface_parse.ml) pin dotted names as atomic and preserve namespace puns. | none |
 | D38 | shipped | SS.22 ships a new callable variadic `text.join` object with an unbounded language/interpreter contract and strict argument evidence in [prelude tests](../../../test/test_prelude.ml), [CLI/native/ASAN boundary evidence](../../../test/cli/ss22.t), and [executable stdlib documentation](../../stdlib.md). Deprecated migration-only `text.join-list` preserves the pre-SS.22 list-plus-separator object hash-for-hash. Native v1 variadic parity is limited to 0-8 arguments; 9 is E1101 under its global ABI ceiling. Successor SX.26 adds marked syntax as a local lowering to this unchanged object. | none |
 | D39 | shipped | SS.22 ships all four `int.*` and `real.*` predicates plus dotted real arithmetic, with NaN and boundary parity in [the native gauntlet](../../../test/native-gauntlet/g35-stdlib-ss22.jqd). The obsolete hyphenated public names are removed without aliases, while the five historical marker IDs and semantic hashes remain stable; the [identity map](../../../test/test_prelude.ml) and [hash-reference CLI/native test](../../../test/cli/ss22.t) prove old references still load, typecheck, interpret, and native-compile. | none |
@@ -122,8 +122,9 @@ SS.21 and SS.22 timestamps and observed-command table below.
 
 ## Caveats
 
-- The parser is delimiter-based and intentionally small. Labeled patterns,
-  records, guards, imports, and custom operators are absent.
+- The parser is delimiter-based and intentionally small. Records, guards,
+  imports, and custom operators are absent; labeled constructor patterns are a
+  local projection onto positional `PCon` rather than a new kernel form.
 - The printer can use an escaped name, hash/group reference, or `jqd { ... }`
   for kernel material without an unambiguous native rendering.
 - Formatting preserves comments, docs, order, and ownership, but not arbitrary

--- a/docs/release/surface-syntax/FOLLOWUPS.md
+++ b/docs/release/surface-syntax/FOLLOWUPS.md
@@ -3,18 +3,22 @@
 This tracked ledger records scope deliberately excluded from SS.21. Successor
 milestone **SS.22, prelude naming and text building**, completed D38 and D39
 without changing the surface grammar. The SS.0-SS.22 implementation arc is
-complete, but D36 accessor generation and label validation remain deliberately
-partial and Tier-F remains parked. None of this ledger establishes stability or
-a freeze for the whole surface syntax.
+complete. SX.24 subsequently shipped labeled partial patterns, but D36 accessor
+generation and its broader declaration validation remain deliberately partial,
+and Tier-F remains parked. None of this ledger establishes stability or a
+freeze for the whole surface syntax.
 
 ## D36 Generated Constructor Accessors
 
 D36 is partial. Labeled constructor field syntax, field metadata and trivia,
-lowering, and canonical printing shipped in SS.8. Surface lowering does not
-emit generated accessor `DefTerm` declarations. Duplicate labels are accepted
-rather than diagnosed, and the draft's cross-constructor label consistency and
+lowering, and canonical printing shipped in SS.8. SX.24 later shipped partial
+labeled patterns and rejects duplicate declaration labels when their ambiguity
+is exercised by such a pattern; it does not turn that use-site check into a
+global declaration rule. Surface lowering still does not emit generated
+accessor `DefTerm` declarations. Duplicate labels remain accepted at
+declaration time, and the draft's cross-constructor label consistency and
 explicit-term collision rules are not enforced. These omissions are the
-reviewed partial boundary, not accidental claims that SS.8 generated accessors.
+reviewed partial boundary, not accidental claims that accessors shipped.
 
 Current non-generation evidence is pinned in `test/cli/surface.t`: declaring
 `type Pair = | Pair(left: Int, right: Int)` and evaluating
@@ -33,7 +37,7 @@ This is evidence of the missing feature, not its implementation contract.
 | validation | reject a label missing from any constructor, duplicated within a constructor, inconsistent in type across constructors, or colliding with an explicit term |
 | diagnostics | each validation failure has a dedicated diagnostic code and exact span tests |
 | preservation | bootstrap identity, full tests, doctests, twins, and demos remain green |
-| excluded | labeled patterns remain outside this acceptance gate |
+| excluded | shipped labeled partial patterns are independent of this accessor gate |
 
 ## D38 Variadic Text Join
 

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -609,6 +609,11 @@ is still the existing positional binder pattern, never a label pun, and
 labels already participate in the constructor's content identity, so changing
 the declaration produces the same identity evolution as any other constructor
 schema change. Bootstrap `.jqd` patterns remain positional and unchanged.
+Like their positional twins, labeled constructor patterns are refutable and
+therefore remain invalid as lambda parameters or `let` binders.
+Because labels are surface-only elaboration data rather than quoted kernel
+data, a labeled constructor pattern inside `quote { ... }` is rejected with
+E1237; write the quoted pattern positionally instead.
 
 A positional match past four fields is the readability failure labeled
 patterns exist to fix (`Snapshot(_, error-rate, p95, _, db-lag, _, vendor, _)`

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -72,8 +72,7 @@ top-item      := signature | definition | type-decl | effect-decl | expr | raw-t
 signature     := term-name ":" cont type
 definition    := term-name ["(" patterns? ")"] "=" cont expr
 type-decl     := "type" type-name type-vars? "=" cont "|"? constructor (seps? "|" cont constructor)*
-constructor   := con-name type-atom*
-| con-name "(" fields? ")"
+constructor   := con-name type-atom* | con-name "(" fields? ")"
 field         := [term-name ":" cont] type
 effect-decl   := mode "effect" effect-name type-vars? "where" "{" seps? uniform-op-signature (seps uniform-op-signature)* seps? "}"
 | "effect" effect-name type-vars? "where" "{" seps? mode-op-signature (seps mode-op-signature)* seps? "}"
@@ -108,8 +107,9 @@ annotation    := "(" expr ":" cont type ")"
 arm-body      := expr | block
 
 pattern       := pattern-atom ["as" binding-name]
-pattern-atom  := "_" | binding-name | literal | con-name ["(" patterns? ")"]
+pattern-atom  := "_" | binding-name | literal | con-name ["(" (patterns | labeled-patterns)? ")"]
 | "(" patterns? ")"
+labeled-patterns := term-name ":" cont pattern ("," term-name ":" cont pattern)* [","]
 type          := type-app | "(" types? ")" row cont type
 | "forall" forall-vars? "." cont type
 type-app      := type-atom type-atom*
@@ -582,12 +582,38 @@ Literal patterns cover `Text` exactly as they cover `Int` and `Real` (`PLit`
 doesn't distinguish); `| "operator" -> 3.0` and `| "ok" -> 200` are ordinary
 literal patterns, nothing special.
 
-Constructor patterns stay positional in v0; a labeled pattern syntax
-(matching D36's labeled fields, below) is deferred. A positional match past
-four fields is exactly the readability failure labeled patterns exist to fix
-(`Snapshot(_, error-rate, p95, _, db-lag, _, vendor, _)` is the canonical bad
-case), so the checker lints it rather than letting it accumulate silently;
-see §7.
+Constructor patterns may be positional or label-selecting. A labeled partial
+pattern uses the declaration's field labels and names only the fields relevant
+to the arm:
+
+```jacquard
+match snapshot {
+  | Snapshot(error: problem, vendor: "acme") -> problem
+  | _ -> 0
+}
+```
+
+Every selected field is written `label: pattern`; there are no label puns and
+labeled and positional fields cannot be mixed in one constructor pattern.
+Labels may be authored in any order. Resolution expands them in declaration
+order, inserting `_` for every omitted labeled or unlabeled field before type,
+redundancy, and exhaustiveness checking. `_`, nested constructors, and `as`
+patterns are all valid to the right of `:`. Canonical resolved printing uses
+declaration order and leaves omissions implicit.
+
+An unknown or repeated selection is an error. A constructor with no labels, or
+with duplicate declaration labels that make lookup ambiguous, cannot be used
+in labeled form; ordinary positional matching remains available. `Ctor(field)`
+is still the existing positional binder pattern, never a label pun, and
+`Ctor()` is the ordinary zero-argument constructor pattern. Constructor field
+labels already participate in the constructor's content identity, so changing
+the declaration produces the same identity evolution as any other constructor
+schema change. Bootstrap `.jqd` patterns remain positional and unchanged.
+
+A positional match past four fields is the readability failure labeled
+patterns exist to fix (`Snapshot(_, error-rate, p95, _, db-lag, _, vendor, _)`
+is the canonical bad case), so the checker lints it and recommends a labeled
+selection; see §7.
 
 When the scrutinee itself is a large multi-line expression, the printer does
 not hoist it into a preceding `let` on the author's behalf; an automatic
@@ -653,8 +679,8 @@ labeled (D36): `field: Type` inside a constructor's parens. SS.8 shipped this
 syntax together with field metadata, trivia, lowering, and canonical printing.
 It did not generate accessor definitions, so `fleet.inv` remains unresolved
 unless declared explicitly. Both field exercises invented this exact
-`Ctor(field: Type, ...)` notation independently. Labeled patterns are deferred
-past v0 (§5, Match).
+`Ctor(field: Type, ...)` notation independently. SX.24 now reuses those labels
+for partial constructor patterns (§5, Match) without generating accessors.
 
 Every operation has an explicit mode. A uniform effect uses the canonical
 `once effect` or `multi effect` shorthand; an effect containing both modes
@@ -797,8 +823,9 @@ abstract over yet). Custom operators, forever contentious, remain excluded
 from 0.1. Offside-rule layout (D27 alternative, revisit only with
 evidence that braces measurably hurt).
 
-Labeled constructor *patterns* (D36 defers them). Labeled declarations ship;
-generated accessors and label validation remain parked D36 follow-ups.
+Generated constructor accessors and their cross-constructor declaration
+validation remain parked D36 follow-ups. Labeled declarations and partial
+label-selecting constructor patterns ship without record syntax.
 Predicate/comparison naming (D39: `?`-suffixed predicates beside bare
 dictionary names, `gte?/lte?/gt?/lt?`, the `real.*` rename); both of these
 are stdlib content, not grammar, and land in docs/stdlib.md rather than
@@ -922,7 +949,7 @@ in commit messages and task dependencies.)
 | D33 | quote body | surface syntax inside `quote { }`, captured pre-resolution |
 | D34 | case convention | PascalCase for types/constructors/effects, kebab-case for terms/operations; pattern-position capitals are constructors |
 | D35 | handle delimiting | atomic body needs no wrapper; a non-atomic body takes an explicit `{ }` block; the clause list is always braced |
-| D36 | labeled fields | partial: `Ctor(field: Type, ...)` parsing, metadata, trivia, lowering, and printing ship; generated accessors and label validation have a separate follow-up gate; labeled patterns remain deferred |
+| D36 | labeled fields | partial: labeled declarations and SX.24 partial patterns ship; pattern use validates unknown, repeated, absent, and ambiguous labels; generated accessors and their broader declaration validation remain a separate follow-up gate |
 | D37 | namespace puns | blessed permanently: dotted names are one atomic token forever; a future field-access form will not use `.` |
 | D38 | text building | variadic `text.join` is the ordinary lowering target and remains directly callable |
 | D39 | comparison naming | `?`-suffixed predicates beside bare dictionary names; prelude gains `gt? gte? lt? lte?`; the `add-real` family migrates to `real.*` |

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -40,6 +40,7 @@ let key_surface_hole = "surface-hole"
 let key_surface_ref_kind = "surface-ref-kind"
 let key_surface_reference = "surface-reference"
 let key_surface_signature = "surface-signature"
+let key_surface_pattern_label = "surface-pattern-label"
 
 (** [surface_container_key kind] is the reserved key for one named delimiter container. *)
 let surface_container_key kind = "surface-container/" ^ kind
@@ -209,6 +210,16 @@ let surface_ref_kind t =
 (** [with_surface_ref_kind kind t] records an explicit surface value-reference kind. Callers use
     ["term"], ["con"], or ["op"]; unknown values are ignored by resolution. *)
 let with_surface_ref_kind kind t = add key_surface_ref_kind (Sym kind) t
+
+(** [surface_pattern_label t] is the explicitly authored field label on one selected child of a
+    labeled constructor pattern. Resolution consumes it when expanding the partial pattern to the
+    existing positional kernel representation; printing retains it as hash-excluded provenance. *)
+let surface_pattern_label t =
+  match find key_surface_pattern_label t with Some (Sym n | Text n) -> Some n | _ -> None
+
+(** [with_surface_pattern_label label t] records an explicit constructor-pattern field selection. It
+    never infers a label from a [PVar] spelling. *)
+let with_surface_pattern_label label t = add key_surface_pattern_label (Sym label) t
 
 (** [is_surface_reference t] is true only for a bare reference authored in `.jac`. Recovery and
     diagnostics use this hash-excluded marker to distinguish source references from bootstrap

--- a/src/resolve.ml
+++ b/src/resolve.ml
@@ -19,7 +19,8 @@
 
     Diagnostics (accumulated; resolution visits the whole tree): E0301 unknown name (with near-miss
     suggestions at edit distance <= 2), E0302 kind mismatch, E0303 duplicate binding name in a
-    [defterm] group, E0304 duplicate variable in one pattern. *)
+    [defterm] group, E0304 duplicate variable in one pattern, and E0305-E0308 labeled-pattern schema
+    failures. *)
 
 (** What a name in scope refers to. [KCon]/[KOp] hashes are the folded constructor/operation hashes
     (decl hash + ordinal, derived in W1.5). *)
@@ -27,19 +28,29 @@ type nkind = KTerm | KCon | KOp | KType | KEffect
 
 type entry = { hash : Hash.t; kind : nkind }
 
-type names = { lookup : string -> entry list; all_names : unit -> string list }
+type names = {
+  lookup : string -> entry list;
+  all_names : unit -> string list;
+  constructor_fields : Hash.t -> string option list option;
+}
 (** The resolver's view of a store. [lookup] returns EVERY binding of a name — the index is (name,
     kind)-keyed (SL.1), so an effect and its operation may share a bare name; kind- directed
-    positions pick their kind, and value positions use term > con > op precedence. *)
+    positions pick their kind, and value positions use term > con > op precedence.
+    [constructor_fields] returns the declaration-order field labels for a resolved constructor; it
+    is the elaboration seam for labeled partial patterns. *)
 
-let empty_names = { lookup = (fun _ -> []); all_names = (fun () -> []) }
+let empty_names =
+  { lookup = (fun _ -> []); all_names = (fun () -> []); constructor_fields = (fun _ -> None) }
 
 (** [of_alist entries] builds a stub index (duplicate names with distinct kinds allowed); the W1.6
-    store exposes the real one. *)
-let of_alist alist =
+    store exposes the real one. [constructor_fields] may provide a constructor's declaration-order
+    field labels for labeled-pattern expansion. It defaults to no schema, so a labeled pattern then
+    fails with a diagnostic instead of guessing from binder names. *)
+let of_alist ?(constructor_fields = fun _ -> None) alist =
   {
     lookup = (fun n -> List.filter_map (fun (m, e) -> if m = n then Some e else None) alist);
     all_names = (fun () -> List.map fst alist);
+    constructor_fields;
   }
 
 let kind_to_string = function
@@ -173,6 +184,105 @@ let pats_vars st ps =
   let seen = Hashtbl.create 8 in
   (seen, List.concat_map (pat_vars_seen st seen) ps)
 
+let labeled_pattern_diagnostic st ~meta ~code ~summary ~cause ~next_step =
+  report st
+    (Diag.error ?span:(Meta.span meta) ~domain:Resolution ~code ~summary ~cause ~next_step
+       ~contrast:None ())
+
+let pattern_field_meta (pattern : Kernel.pat) =
+  let field_meta = Meta.surface_container "pattern-field" pattern.meta in
+  if Meta.is_empty field_meta then pattern.meta else field_meta
+
+let omission_meta pattern_meta =
+  let meta = Meta.with_surface_generated "labeled-pattern-omission" Meta.empty in
+  match Meta.span pattern_meta with Some span -> Meta.with_span span meta | None -> meta
+
+let duplicate_labels labels =
+  let seen = Hashtbl.create 8 in
+  let duplicates = ref [] in
+  List.iter
+    (fun label ->
+      if Hashtbl.mem seen label then duplicates := label :: !duplicates
+      else Hashtbl.add seen label ())
+    labels;
+  List.sort_uniq String.compare !duplicates
+
+let expand_labeled_pattern st ~meta hash patterns =
+  let selections =
+    List.filter_map
+      (fun (pattern : Kernel.pat) ->
+        Option.map (fun label -> (label, pattern)) (Meta.surface_pattern_label pattern.meta))
+      patterns
+  in
+  if List.length selections <> List.length patterns then
+    labeled_pattern_diagnostic st ~meta ~code:"E0307"
+      ~summary:"This labeled constructor pattern has no usable field schema."
+      ~cause:"A labeled pattern field reached resolution without an explicit `label:` marker."
+      ~next_step:"Write every selected field as `label: pattern` and do not mix positional fields.";
+  let selected_labels = List.map fst selections in
+  let selected_duplicates = duplicate_labels selected_labels in
+  List.iter
+    (fun duplicate ->
+      let duplicate_meta =
+        match
+          List.find_opt (fun (label, _) -> String.equal label duplicate) (List.rev selections)
+        with
+        | Some (_, pattern) -> pattern_field_meta pattern
+        | None -> meta
+      in
+      labeled_pattern_diagnostic st ~meta:duplicate_meta ~code:"E0306"
+        ~summary:"A labeled constructor pattern selects one field more than once."
+        ~cause:(Printf.sprintf "Field `%s` is selected more than once in this pattern." duplicate)
+        ~next_step:"Keep one `label: pattern` selection for each constructor field.")
+    selected_duplicates;
+  match st.names.constructor_fields hash with
+  | None ->
+      labeled_pattern_diagnostic st ~meta ~code:"E0307"
+        ~summary:"This labeled constructor pattern has no usable field schema."
+        ~cause:"The resolved constructor does not expose field-label metadata."
+        ~next_step:"Use a stored constructor with labeled fields, or write a positional pattern.";
+      patterns
+  | Some fields ->
+      let declaration_labels = List.filter_map Fun.id fields in
+      let declaration_duplicates = duplicate_labels declaration_labels in
+      if declaration_labels = [] then begin
+        labeled_pattern_diagnostic st ~meta ~code:"E0307"
+          ~summary:"This labeled constructor pattern has no usable field schema."
+          ~cause:"The constructor declares no labeled fields."
+          ~next_step:"Use a positional pattern for this constructor.";
+        patterns
+      end
+      else if declaration_duplicates <> [] then begin
+        labeled_pattern_diagnostic st ~meta ~code:"E0308"
+          ~summary:"This constructor's field labels are ambiguous in a pattern."
+          ~cause:
+            (Printf.sprintf "The constructor declares duplicate field label(s): %s."
+               (String.concat ", " (List.map (Printf.sprintf "`%s`") declaration_duplicates)))
+          ~next_step:
+            "Rename the duplicate declaration fields before selecting constructor fields by label.";
+        patterns
+      end
+      else begin
+        List.iter
+          (fun (label, pattern) ->
+            if not (List.exists (Option.equal String.equal (Some label)) fields) then
+              labeled_pattern_diagnostic st ~meta:(pattern_field_meta pattern) ~code:"E0305"
+                ~summary:"This constructor has no field with the selected label."
+                ~cause:(Printf.sprintf "Field `%s` is not declared by this constructor." label)
+                ~next_step:"Select one of the constructor's declared field labels.")
+          selections;
+        List.map
+          (function
+            | None -> Kernel.{ it = PWild; meta = omission_meta meta }
+            | Some label -> (
+                match
+                  List.find_opt (fun (selected, _) -> String.equal selected label) selections
+                with
+                | Some (_, pattern) -> pattern
+                | None -> Kernel.{ it = PWild; meta = omission_meta meta }))
+          fields
+      end
+
 let rec resolve_pat st ~locals (p : Kernel.pat) : Kernel.pat =
   let it =
     match p.Kernel.it with
@@ -182,7 +292,14 @@ let rec resolve_pat st ~locals (p : Kernel.pat) : Kernel.pat =
           resolve_gref st ~meta:p.Kernel.meta ~locals ~expected_kind:KCon
             ~expected_desc:"a constructor" ~what:"constructor" con
         in
-        Kernel.PCon (con, List.map (resolve_pat st ~locals) ps)
+        let ps = List.map (resolve_pat st ~locals) ps in
+        let ps =
+          match (Meta.surface_form p.Kernel.meta, con) with
+          | Some "labeled-pattern", Kernel.Hashed hash ->
+              expand_labeled_pattern st ~meta:p.meta hash ps
+          | Some "labeled-pattern", Kernel.Named _ | (Some _ | None), _ -> ps
+        in
+        Kernel.PCon (con, ps)
     | Kernel.PTuple ps -> Kernel.PTuple (List.map (resolve_pat st ~locals) ps)
     | Kernel.PAs (x, inner) -> Kernel.PAs (x, resolve_pat st ~locals inner)
   in

--- a/src/store.ml
+++ b/src/store.ml
@@ -431,9 +431,27 @@ let hide_derived t hash =
       write_names t
   | Some (_, (_, Whole)) | None -> ()
 
-(** [names_view t] is the resolver's view of this store (the W1.4 seam). *)
+(** [names_view t] is the resolver's view of this store (the W1.4 seam). Constructor-schema lookup
+    returns declaration-order field labels only for constructor identities present in [t]; missing,
+    malformed, and non-constructor identities return [None]. *)
 let names_view t : Resolve.names =
-  { Resolve.lookup = (fun n -> lookup_all t n); all_names = (fun () -> List.map fst t.names) }
+  let constructor_fields hash =
+    match List.find_opt (fun (known, _) -> Hash.equal known hash) t.index with
+    | Some (_, (decl_hash, Constructor index)) -> (
+        match get t decl_hash with
+        | Ok { Kernel.it = Kernel.DefType { cons; _ }; _ } ->
+            Option.map
+              (fun constructor ->
+                List.map (fun field -> field.Kernel.label) constructor.Kernel.fields)
+              (List.nth_opt cons index)
+        | Ok _ | Error _ -> None)
+    | Some (_, (_, (Whole | Member _ | Operation _))) | None -> None
+  in
+  {
+    Resolve.lookup = (fun n -> lookup_all t n);
+    all_names = (fun () -> List.map fst t.names);
+    constructor_fields;
+  }
 
 (** [bind_name t name hash] binds [name] to a hash already known to the store. Fails on an
     unprintable name (E0605) and on a [defterm] group's whole hash (E0604) — groups are addressed

--- a/src/surface_check.ml
+++ b/src/surface_check.ml
@@ -189,10 +189,13 @@ let warning_wide (pattern : Surface_ast.pat) fields =
     ~domain:Surface ~code:"W1202" ~summary:"Constructor pattern is difficult to review"
     ~cause:
       (Printf.sprintf
-         "This positional constructor pattern has %d fields; labeled constructor patterns are not \
-          available in 0.2."
+         "This positional constructor pattern has %d fields, which makes field positions hard to \
+          track."
          fields)
-    ~next_step:"Keep positional constructor patterns to four fields or fewer." ~contrast:None ()
+    ~next_step:
+      "Select the relevant fields with `Constructor(label: pattern, ...)`, or keep the positional \
+       pattern to four fields or fewer."
+    ~contrast:None ()
 
 let large_match_scrutinee_lines = 4
 
@@ -318,7 +321,8 @@ let rec lint_pat names constructors (pattern : Surface_ast.pat) =
       when Meta.surface_ref_kind pattern.meta <> Some "term"
            && (String_set.mem name constructors || constructor_in_names names name) ->
         [ warning_case pattern name ]
-    | Surface_ast.PCon (_, args) when List.length args > 4 ->
+    | Surface_ast.PCon (_, args)
+      when Meta.surface_form pattern.meta <> Some "labeled-pattern" && List.length args > 4 ->
         [ warning_wide pattern (List.length args) ]
     | _ -> []
   in
@@ -480,7 +484,11 @@ let analysis_names base additions =
         (fun entry -> not (List.mem entry.Resolve.kind local_kinds))
         (base.Resolve.lookup name)
   in
-  { Resolve.lookup; all_names = (fun () -> List.map fst !additions @ base.Resolve.all_names ()) }
+  {
+    Resolve.lookup;
+    all_names = (fun () -> List.map fst !additions @ base.Resolve.all_names ());
+    constructor_fields = base.Resolve.constructor_fields;
+  }
 
 let recovery_member_hashes identity bindings =
   List.mapi

--- a/src/surface_lower.ml
+++ b/src/surface_lower.ml
@@ -49,6 +49,11 @@ let diagnostic_spec = function
       ( Diag.Surface,
         "An effect operation mode is missing or invalid.",
         "Declare the operation explicitly as once or multi." )
+  | "E1237" ->
+      ( Diag.Surface,
+        "A labeled constructor pattern cannot be quoted.",
+        "Use an explicit positional pattern inside `quote`, or move the labeled match outside the \
+         quoted payload." )
   | code -> raise (Diag.Bug_invalid_diagnostic ("unknown surface lowering code " ^ code))
 
 let diagnostic ?span ~code cause =
@@ -90,35 +95,42 @@ let generated_constructor_meta ~form meta =
   let* meta = generated_single_meta ~form meta in
   Ok (meta |> Meta.with_surface_generated form |> Meta.with_surface_ref_kind "con")
 
-(** [lower_pat pat] lowers any complete surface pattern without resolving constructor names. *)
-let rec lower_pat (pat : Surface_ast.pat) : (Kernel.pat, Diag.t list) result =
+let rec lower_pat_at ~quote_depth (pat : Surface_ast.pat) : (Kernel.pat, Diag.t list) result =
   let node it = Kernel.{ it; meta = pat.meta } in
-  match pat.it with
-  | Surface_ast.PWild -> Ok (node Kernel.PWild)
-  | Surface_ast.PBind name -> Ok (node (Kernel.PVar name))
-  | Surface_ast.PLit literal -> Ok (node (Kernel.PLit literal))
-  | Surface_ast.PCon (constructor, args) ->
-      let* args = map_results lower_pat args in
-      Ok (node (Kernel.PCon (kernel_gref constructor, args)))
-  | Surface_ast.PTuple items ->
-      let* items = map_results lower_pat items in
-      Ok (node (Kernel.PTuple items))
-  | Surface_ast.PAs (inner, name) ->
-      let* inner = lower_pat inner in
-      Ok (node (Kernel.PAs (name, inner)))
-  | Surface_ast.PHole _ ->
-      error ~meta:pat.meta ~code:"E1202" "cannot lower a recovered surface pattern hole"
+  if quote_depth > 0 && Meta.surface_form pat.meta = Some "labeled-pattern" then
+    error ~meta:pat.meta ~code:"E1237"
+      "quoted code stores positional kernel patterns and cannot retain a surface field selection"
+  else
+    match pat.it with
+    | Surface_ast.PWild -> Ok (node Kernel.PWild)
+    | Surface_ast.PBind name -> Ok (node (Kernel.PVar name))
+    | Surface_ast.PLit literal -> Ok (node (Kernel.PLit literal))
+    | Surface_ast.PCon (constructor, args) ->
+        let* args = map_results (lower_pat_at ~quote_depth) args in
+        Ok (node (Kernel.PCon (kernel_gref constructor, args)))
+    | Surface_ast.PTuple items ->
+        let* items = map_results (lower_pat_at ~quote_depth) items in
+        Ok (node (Kernel.PTuple items))
+    | Surface_ast.PAs (inner, name) ->
+        let* inner = lower_pat_at ~quote_depth inner in
+        Ok (node (Kernel.PAs (name, inner)))
+    | Surface_ast.PHole _ ->
+        error ~meta:pat.meta ~code:"E1202" "cannot lower a recovered surface pattern hole"
+
+(** [lower_pat pat] lowers any complete surface pattern outside a quoted payload without resolving
+    constructor names. Recovery holes fail with E1202. *)
+let lower_pat pat = lower_pat_at ~quote_depth:0 pat
 
 let ensure_irrefutable ~code ~message (pat : Kernel.pat) =
   if Kernel.is_irrefutable pat then Ok pat else error ~meta:pat.meta ~code message
 
-let lower_irrefutable_pat ~code ~message pat =
-  let* pat = lower_pat pat in
+let lower_irrefutable_pat ?(quote_depth = 0) ~code ~message pat =
+  let* pat = lower_pat_at ~quote_depth pat in
   ensure_irrefutable ~code ~message pat
 
-let lower_lambda_params params =
+let lower_lambda_params ?(quote_depth = 0) params =
   map_results
-    (lower_irrefutable_pat ~code:"E0205"
+    (lower_irrefutable_pat ~quote_depth ~code:"E0205"
        ~message:
          "`lam` parameters must be irrefutable patterns (pwild, pvar, or ptuple/pas of those)")
     params
@@ -227,7 +239,7 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
       let* args = map_results (lower_expr_node ~quote_depth) args in
       Ok Kernel.{ it = App (fn, args); meta = Meta.with_surface_form "call" expr.meta }
   | Surface_ast.Fn (params, body) ->
-      let* params = lower_lambda_params params in
+      let* params = lower_lambda_params ~quote_depth params in
       let* body = lower_expr_node ~quote_depth body in
       Ok Kernel.{ it = Lam (params, body); meta = Meta.with_surface_form "fn" expr.meta }
   | Surface_ast.Tuple items ->
@@ -248,7 +260,7 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
       Ok { lowered with Kernel.meta }
   | Surface_ast.Match (subject, clauses) -> (
       let lower_clause (clause : Surface_ast.clause) =
-        let* cpat = lower_pat clause.cpattern in
+        let* cpat = lower_pat_at ~quote_depth clause.cpattern in
         let* cbody = lower_expr_node ~quote_depth clause.cbody in
         Ok Kernel.{ cpat; cbody; cmeta = clause.cmeta }
       in
@@ -332,14 +344,14 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
       Ok Kernel.{ it = App (fn, left :: args); meta = Meta.with_surface_form "pipe" meta }
   | Surface_ast.Handle (body, ret, ops) ->
       let lower_op (op : Surface_ast.op_clause) =
-        let* params = map_results lower_pat op.oparams in
+        let* params = map_results (lower_pat_at ~quote_depth) op.oparams in
         let* obody = lower_expr_node ~quote_depth op.obody in
         Ok
           Kernel.
             { op = kernel_gref op.operation; params; resume = op.oresume; obody; ometa = op.ometa }
       in
       let* body = lower_expr_node ~quote_depth body in
-      let* rbinder = lower_pat ret.rbinder in
+      let* rbinder = lower_pat_at ~quote_depth ret.rbinder in
       let* rbody = lower_expr_node ~quote_depth ret.rbody in
       let* ops = map_results lower_op ops in
       let ret = Kernel.{ rbinder; rbody; rmeta = ret.rmeta } in
@@ -393,8 +405,8 @@ and lower_block ~quote_depth block_meta = function
           "non-recursive local bindings cannot use function shorthand"
       else
         let* binder =
-          lower_irrefutable_pat ~code:"E0206" ~message:"`let` binders must be irrefutable patterns"
-            binder
+          lower_irrefutable_pat ~quote_depth ~code:"E0206"
+            ~message:"`let` binders must be irrefutable patterns" binder
         in
         let* value = lower_expr_node ~quote_depth value in
         let* meta = generated_meta ~form:"let" item_meta body.meta in
@@ -406,7 +418,7 @@ and lower_block ~quote_depth block_meta = function
 and lower_recursive_let ~quote_depth ~item_meta (binder : Surface_ast.pat) params value body =
   match binder.it with
   | Surface_ast.PBind name ->
-      let* params = lower_lambda_params params in
+      let* params = lower_lambda_params ~quote_depth params in
       let* value = lower_expr_node ~quote_depth value in
       let* lambda_meta = generated_meta ~form:"let-rec-fn" binder.meta value.meta in
       let lambda_meta =
@@ -425,9 +437,10 @@ and lower_recursive_let ~quote_depth ~item_meta (binder : Surface_ast.pat) param
 
 (** [lower_expr expr] locally lowers a surface expression to existing kernel forms without resolving
     store names. Handler operation intent and staged quote payloads are preserved; a top-level
-    unquote fails with E0204. It also returns span-bearing diagnostics for recovery holes,
-    unsupported later-slice forms, malformed recursive bindings, empty blocks, final local lets, or
-    missing spans needed by generated sequence nodes. *)
+    unquote fails with E0204, and a labeled pattern in quoted surface syntax fails with E1237. It
+    also returns span-bearing diagnostics for recovery holes, unsupported later-slice forms,
+    malformed recursive bindings, empty blocks, final local lets, or missing spans needed by
+    generated sequence nodes. *)
 let lower_expr expr = lower_expr_node expr
 
 module String_set = Set.Make (String)

--- a/src/surface_lower.mli
+++ b/src/surface_lower.mli
@@ -20,9 +20,11 @@ val lower_expr : Surface_ast.expr -> (Kernel.expr, Diag.t list) result
     left operand as the first argument of a call. Blocks become local [Let] chains, with bare
     non-final expressions bound to [PWild], while [let rec] shorthand becomes a variable-bound
     [Lam]. Handlers preserve named/hashed operation intent and quote bodies become pre-resolution
-    kernel forms with depth-aware unquote splices. Unquote outside quote is E0204. Lambda parameters
-    and nonrecursive let binders retain E0205/E0206 irrefutability checks. Recovery holes, malformed
-    local bindings, and spanless generated nodes are diagnostics. *)
+    kernel forms with depth-aware unquote splices. Unquote outside quote is E0204, and labeled
+    patterns inside quoted surface syntax are E1237 because their labels have no semantic quoted
+    carrier. Lambda parameters and nonrecursive let binders retain E0205/E0206 irrefutability
+    checks. Recovery holes, malformed local bindings, and spanless generated nodes are diagnostics.
+*)
 
 val free_names : Kernel.expr -> String_set.t
 (** Return unresolved term names read by an expression, excluding pattern/let/lambda binders and

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -373,6 +373,13 @@ let term_name = function
   | Surface_lex.Escaped (Surface_name.Term, name) -> Some name
   | _ -> None
 
+let pattern_label_ahead state =
+  match term_name (current state).Surface_lex.token with
+  | None -> None
+  | Some name ->
+      let next = token_at state (state.index + 1) in
+      if next.Surface_lex.token = Surface_lex.Colon then Some name else None
+
 let equation_definition_ahead_at state start =
   match (token_at state (start + 1)).Surface_lex.token with
   | Surface_lex.LParen ->
@@ -967,6 +974,74 @@ and parse_pattern_list state _opening =
       in
       loop []
 
+and parse_constructor_pattern_list state _opening =
+  skip_list_space state;
+  match (current state).Surface_lex.token with
+  | Surface_lex.RParen ->
+      let closing = advance state in
+      ([], closing, false)
+  | _ ->
+      let mode = ref None in
+      let saw_label = ref false in
+      let parse_item () =
+        let label = pattern_label_ahead state in
+        let labeled = Option.is_some label in
+        (match !mode with
+        | None -> mode := Some labeled
+        | Some expected when expected <> labeled ->
+            report state (current state)
+              "constructor patterns cannot mix positional fields with `label: pattern` fields"
+        | Some _ -> ());
+        match label with
+        | None -> parse_pattern state ~allow_newlines:true
+        | Some label ->
+            saw_label := true;
+            let label_token = advance state in
+            ignore (advance state);
+            skip_continuation state;
+            let pattern = parse_pattern state ~allow_newlines:true in
+            let field_meta = meta_from_token_to_meta label_token pattern.Surface_ast.meta in
+            Surface_ast.
+              {
+                pattern with
+                meta =
+                  pattern.meta
+                  |> Meta.with_surface_pattern_label label
+                  |> Meta.with_surface_container "pattern-field" field_meta;
+              }
+      in
+      let rec loop acc =
+        let pattern = parse_item () in
+        skip_list_space state;
+        match (current state).Surface_lex.token with
+        | Surface_lex.Comma ->
+            ignore (advance state);
+            skip_list_space state;
+            if (current state).Surface_lex.token = Surface_lex.RParen then begin
+              let closing = advance state in
+              (List.rev (pattern :: acc), closing, !saw_label)
+            end
+            else loop (pattern :: acc)
+        | Surface_lex.RParen ->
+            let closing = advance state in
+            (List.rev (pattern :: acc), closing, !saw_label)
+        | Surface_lex.Bar | Surface_lex.RBrace | Surface_lex.Eof ->
+            let closing = current state in
+            report state closing "expected `)` to close the constructor pattern";
+            (List.rev (pattern :: acc), closing, !saw_label)
+        | _ ->
+            let token = current state in
+            report state token
+              (Printf.sprintf "expected `,` or `)`, found %s" (token_description state token));
+            synchronize_paren state;
+            let closing =
+              if (current state).Surface_lex.token = Surface_lex.RParen then advance state
+              else current state
+            in
+            (List.rev (pattern :: acc), closing, !saw_label)
+      in
+      loop []
+
 and parse_pattern state ~allow_newlines =
   with_nesting state (fun () ->
       if allow_newlines then skip_list_space state else skip_comments state;
@@ -1068,8 +1143,9 @@ and parse_constructor_pattern state name_token name_meta constructor =
   match (current state).Surface_lex.token with
   | Surface_lex.LParen ->
       let opening = advance state in
-      let args, closing = parse_pattern_list state opening in
+      let args, closing, labeled = parse_constructor_pattern_list state opening in
       let meta = meta_with_span (Span.merge name_token.Surface_lex.span closing.span) in
+      let meta = if labeled then Meta.with_surface_form "labeled-pattern" meta else meta in
       Surface_ast.{ it = PCon (constructor, args); meta }
   | _ -> Surface_ast.{ it = PCon (constructor, []); meta = name_meta }
 
@@ -2808,7 +2884,7 @@ module Trivia_ownership = struct
       | PCon (_, args) | PTuple args -> List.concat_map (pat (depth + 1)) args
       | PAs (inner, _) -> pat (depth + 1) inner
     in
-    slot Pat node.meta @ children
+    container "pattern-field" node.meta @ slot Pat node.meta @ children
 
   and ty depth (node : Surface_ast.ty) =
     let children =
@@ -2967,7 +3043,9 @@ module Trivia_ownership = struct
   let is_structured_owner slot =
     match slot.role with
     | Container kind ->
-        String.starts_with ~prefix:"row-" kind || String.starts_with ~prefix:"forall-" kind
+        String.equal kind "pattern-field"
+        || String.starts_with ~prefix:"row-" kind
+        || String.starts_with ~prefix:"forall-" kind
     | _ -> false
 
   let doc_suffix_before line items =
@@ -3208,7 +3286,11 @@ module Trivia_ownership = struct
       | PTuple args -> PTuple (List.map (map_pat additions) args)
       | PAs (inner, name) -> PAs (map_pat additions inner, name)
     in
-    Surface_ast.{ it; meta = apply additions Pat pattern.meta }
+    Surface_ast.
+      {
+        it;
+        meta = pattern.meta |> apply additions Pat |> apply_container additions "pattern-field";
+      }
 
   and map_ty additions (annotation : Surface_ast.ty) =
     let it =

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -201,6 +201,9 @@ let pp_gref lookup kind meta fmt = function
   | Kernel.Named name -> pp_named kind fmt name
   | Kernel.Hashed hash -> Format.pp_print_string fmt (name_for_hash lookup meta kind hash)
 
+let labeled_pattern_omission (pattern : Kernel.pat) =
+  Meta.surface_generated pattern.meta = Some "labeled-pattern-omission"
+
 let rec pp_pat context lookup fmt (pat : Kernel.pat) =
   pp_leading context pat.meta fmt;
   (match pat.it with
@@ -211,9 +214,12 @@ let rec pp_pat context lookup fmt (pat : Kernel.pat) =
       Format.fprintf fmt "@[<hv 2>";
       pp_gref lookup Surface_name.Con pat.meta fmt con;
       if args <> [] then begin
-        Format.fprintf fmt "(%a"
-          (pp_comma_list ~inner_metas:[ pat.meta ] context (pp_pat context lookup))
-          args;
+        let labeled = Meta.surface_form pat.meta = Some "labeled-pattern" in
+        let args =
+          if labeled then List.filter (fun arg -> not (labeled_pattern_omission arg)) args else args
+        in
+        let pp_arg = if labeled then pp_labeled_pat context lookup else pp_pat context lookup in
+        Format.fprintf fmt "(%a" (pp_comma_list ~inner_metas:[ pat.meta ] context pp_arg) args;
         Format.fprintf fmt ")"
       end;
       Format.fprintf fmt "@]"
@@ -237,6 +243,16 @@ let rec pp_pat context lookup fmt (pat : Kernel.pat) =
           Format.fprintf fmt "@[<hov>%a as %a@]" (pp_pat context lookup) inner
             (pp_named Surface_name.Term) name));
   pp_trailing context pat.meta fmt
+
+and pp_labeled_pat context lookup fmt (pattern : Kernel.pat) =
+  match Meta.surface_pattern_label pattern.meta with
+  | None -> raise Bug_unsupported_surface_form
+  | Some label ->
+      let field_meta = Meta.surface_container "pattern-field" pattern.meta in
+      pp_leading context field_meta fmt;
+      Format.fprintf fmt "@[<hov 2>%a:@ %a@]" (pp_named Surface_name.Term) label
+        (pp_pat context lookup) pattern;
+      pp_trailing context field_meta fmt
 
 and pp_row context lookup fmt (row : Kernel.row) =
   let opening = owned "row-open" row.wmeta in

--- a/test/cli/surface.t
+++ b/test/cli/surface.t
@@ -44,6 +44,98 @@ gate. The exact current evidence is E0301 and exit 1; the durable acceptance tar
     Next step: Correct the reference to an in-scope name or declaration.
   exit:1
 
+SX.24 labeled constructor patterns select only the fields a branch needs. Selection order is free,
+omitted labeled and unlabeled fields become positional wildcards before checking, and the existing
+pattern machinery therefore proves exhaustiveness and runs the same code in both engines.
+
+  $ cat > labeled-pattern.jac <<'EOF'
+  > type Snapshot = | Snapshot(id: Int, error: Int, Text, vendor: Text, tail: Int)
+  > match Snapshot(1, 2, "opaque", "acme", 5) {
+  >   | Snapshot(vendor: vendor, error: problem) -> problem
+  > }
+  > EOF
+  $ jac check labeled-pattern.jac
+  ok
+  $ jac run labeled-pattern.jac
+  2
+  $ jac build labeled-pattern.jac -o labeled-pattern-native >/dev/null
+  $ ./labeled-pattern-native
+  2
+
+A one-constructor partial pattern is exhaustive because every omitted field is a wildcard. A later
+partial selection of the same constructor is consequently redundant.
+
+  $ cat > labeled-exhaustive.jac <<'EOF'
+  > type Packet = | Packet(left: Int, right: Int)
+  > match Packet(1, 2) { | Packet(left: _) -> 7 }
+  > EOF
+  $ jac check labeled-exhaustive.jac
+  ok
+  $ jac run labeled-exhaustive.jac
+  7
+  $ cat > labeled-redundant.jac <<'EOF'
+  > type Packet = | Packet(left: Int, right: Int)
+  > match Packet(1, 2) {
+  >   | Packet(left: _) -> 1
+  >   | Packet(right: _) -> 2
+  > }
+  > EOF
+  $ jac check labeled-redundant.jac 2>&1 | grep 'warning\[W0801\]'
+  labeled-redundant.jac:4:3-26: warning[W0801]: This match clause is redundant
+
+Resolution expands labels in declaration order. The resulting canonical object is exactly the
+same as an explicit positional pattern with wildcards.
+
+  $ cat > labeled-hash.jac <<'EOF'
+  > type Snapshot = | Snapshot(id: Int, error: Int, Text, vendor: Text, tail: Int)
+  > inspect(value) = match value {
+  >   | Snapshot(vendor: vendor, error: problem) -> (problem, vendor)
+  > }
+  > EOF
+  $ cat > positional-hash.jac <<'EOF'
+  > type Snapshot = | Snapshot(id: Int, error: Int, Text, vendor: Text, tail: Int)
+  > inspect(value) = match value {
+  >   | Snapshot(_, problem, _, vendor, _) -> (problem, vendor)
+  > }
+  > EOF
+  $ jac hash labeled-hash.jac > labeled.hash 2>/dev/null
+  $ jac hash positional-hash.jac > positional.hash 2>/dev/null
+  $ cmp labeled.hash positional.hash && echo identical
+  identical
+
+Unknown selections, duplicate selections, constructors without labels, and ambiguous declaration
+labels fail at the constructor-pattern boundary. Positional and labeled fields cannot be mixed.
+
+  $ cat > labeled-invalid.jac <<'EOF'
+  > type Snapshot = | Snapshot(id: Int, error: Int)
+  > match Snapshot(1, 2) { | Snapshot(missing: x) -> x }
+  > EOF
+  $ jac check labeled-invalid.jac > invalid.out 2>&1; status=$?; grep -o 'error\[E0305\]' invalid.out; echo "exit:$status"
+  error[E0305]
+  exit:1
+  $ sed 's/missing: x/error: x, error: y/' labeled-invalid.jac > labeled-duplicate.jac
+  $ jac check labeled-duplicate.jac > duplicate.out 2>&1; status=$?; grep -o 'error\[E0306\]' duplicate.out; echo "exit:$status"
+  error[E0306]
+  exit:1
+  $ cat > labeled-unlabeled.jac <<'EOF'
+  > type Plain = | Plain Int
+  > match Plain(1) { | Plain(value: x) -> x }
+  > EOF
+  $ jac check labeled-unlabeled.jac > unlabeled.out 2>&1; status=$?; grep -o 'error\[E0307\]' unlabeled.out; echo "exit:$status"
+  error[E0307]
+  exit:1
+  $ cat > labeled-ambiguous.jac <<'EOF'
+  > type Ambiguous = | Ambiguous(value: Int, value: Int)
+  > match Ambiguous(1, 2) { | Ambiguous(value: x) -> x }
+  > EOF
+  $ jac check labeled-ambiguous.jac > ambiguous.out 2>&1; status=$?; grep -o 'error\[E0308\]' ambiguous.out; echo "exit:$status"
+  error[E0308]
+  exit:1
+  $ sed 's/missing: x/x, error: y/' labeled-invalid.jac > labeled-mixed.jac
+  $ jac check labeled-mixed.jac > mixed.out 2>&1; status=$?; grep -o 'error\[E1220\]' mixed.out | head -1; echo "exit:$status"
+  error[E1220]
+  exit:1
+
 The surface formatter preserves trivia, applies B1/B5, and is idempotent.
 
   $ cat > format.jac <<'EOF'

--- a/test/cli/surface.t
+++ b/test/cli/surface.t
@@ -136,6 +136,16 @@ labels fail at the constructor-pattern boundary. Positional and labeled fields c
   error[E1220]
   exit:1
 
+Labels are surface elaboration metadata, so they cannot enter a quoted kernel payload. Positional
+constructor patterns remain available inside quotes.
+
+  $ cat > labeled-quoted.jac <<'EOF'
+  > quote { match packet { | Packet(right: value) -> value } }
+  > EOF
+  $ jac check labeled-quoted.jac > quoted.out 2>&1; status=$?; grep -o 'error\[E1237\]' quoted.out; echo "exit:$status"
+  error[E1237]
+  exit:1
+
 The surface formatter preserves trivia, applies B1/B5, and is idempotent.
 
   $ cat > format.jac <<'EOF'

--- a/test/test_surface_check.ml
+++ b/test/test_surface_check.ml
@@ -528,7 +528,8 @@ let test_wide_pattern_boundary_and_coexistence () =
       Alcotest.(check bool) "wide is warning" true (Diag.severity warning = Diag.Warning);
       Alcotest.(check bool)
         "bounded guidance" true
-        (contains "labeled constructor patterns are not available" (Diag.cause warning)
+        (contains "field positions hard to track" (Diag.cause warning)
+        && contains "Constructor(label: pattern" (Diag.next_step warning)
         && contains "four fields or fewer" (Diag.next_step warning))
   | found -> Alcotest.failf "expected one wide warning, got %d" (List.length found));
   let boundary = analyze "match 1 { | Four(a, b, c, d) -> 0 | _ -> 1 }\n" in
@@ -699,9 +700,10 @@ let test_warning_exact_order_nested_raw_and_redundancy () =
         "Correct the reference to an in-scope name or declaration.";
       expected_golden "warning" "W1202" "warnings.jac:2:24-43"
         "Constructor pattern is difficult to review"
-        "This positional constructor pattern has 5 fields; labeled constructor patterns are not \
-         available in 0.2."
-        "Keep positional constructor patterns to four fields or fewer.";
+        "This positional constructor pattern has 5 fields, which makes field positions hard to \
+         track."
+        "Select the relevant fields with `Constructor(label: pattern, ...)`, or keep the \
+         positional pattern to four fields or fewer.";
       expected_golden "error" "E0802" "warnings.jac:3:6-7" "This value is not callable"
         "the `|>` right-hand side has type int, which is not a function"
         "Make the right-hand side of `|>` callable.";
@@ -709,6 +711,10 @@ let test_warning_exact_order_nested_raw_and_redundancy () =
     rendered;
   let nested = analyze "match 1 { | Outer(Five(a, b, c, d, e)) -> 0 | _ -> 1 }\n" in
   Alcotest.(check int) "nested wide warning" 1 (List.length (diagnostics "W1202" nested));
+  let labeled = analyze "match 1 { | Five(first: a, fifth: e) -> e | _ -> 0 }\n" in
+  Alcotest.(check int)
+    "labeled patterns are not wide positional patterns" 0
+    (List.length (diagnostics "W1202" labeled));
   let raw =
     analyze
       "jqd { (match (lit 1) (clause (pcon x (pvar a) (pvar b) (pvar c) (pvar d) (pvar e)) (lit \

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -57,7 +57,7 @@ let test_one_page_grammar_snapshot () =
   Alcotest.(check bool) "L7 grammar stays within 100 nonblank lines" true (List.length lines <= 100);
   Alcotest.(check string)
     "L7 grammar snapshot (review docs/surface-syntax.md before updating)"
-    "bf77afeeb54671240dee71c3c6ef8ecc600094bf5c6bb24c96769fdd7e8fc46f"
+    "e0793e772b31cf5c2840ab00391f540c4fae7b067904a2687abf0a7273aa6e2d"
     (Hash.to_hex (Hash.of_string grammar))
 
 let format_surface ?width path source =
@@ -1118,14 +1118,14 @@ let validate_release_docs ~decision ~followups ~index =
       [
         "D36";
         "partial";
-        "The labeled-field portion shipped in SS.8: [declaration \
-         tests](../../../test/test_surface_decls.ml), [trivia \
-         tests](../../../test/test_surface_trivia.ml), and [printing \
-         tests](../../../test/test_surface_print.ml) pin parsing, metadata, trivia, lowering, and \
-         rendering. [CLI evidence](../../../test/cli/surface.t) pins `pair.left` as absent with \
-         `E0301`; generated accessor definitions and label validation, including duplicate-label \
-         rejection, are deliberate follow-ups. Labeled patterns remain deferred.";
-        "[D36 acceptance criteria](FOLLOWUPS.md#d36-generated-constructor-accessors)";
+        "The labeled-field declaration portion shipped in SS.8. SX.24 now ships partial \
+         `Ctor(label: pattern, ...)` matching, with \
+         [pattern](../../../test/test_surface_patterns.ml), \
+         [trivia](../../../test/test_surface_trivia.ml), and [CLI](../../../test/cli/surface.t) \
+         evidence for positional lowering, identity, checking, and execution. `pair.left` remains \
+         absent with E0301; generated accessors and their broader cross-constructor declaration \
+         validation remain deliberate follow-ups.";
+        "[D36 accessor acceptance criteria](FOLLOWUPS.md#d36-generated-constructor-accessors)";
       ];
       [
         "D37";
@@ -1284,7 +1284,7 @@ let validate_release_docs ~decision ~followups ~index =
          inconsistent in type across constructors, or colliding with an explicit term" );
       ("diagnostics", "each validation failure has a dedicated diagnostic code and exact span tests");
       ("preservation", "bootstrap identity, full tests, doctests, twins, and demos remain green");
-      ("excluded", "labeled patterns remain outside this acceptance gate");
+      ("excluded", "shipped labeled partial patterns are independent of this accessor gate");
     ];
   acceptance_contract "## D38 Variadic Text Join"
     [
@@ -1506,9 +1506,9 @@ let decision_semantic_mutations =
     ("D34", "shared case projection and escapes", "separate case projection without escapes");
     ("D35", "mandatory blocks for non-atomic bodies", "optional blocks for non-atomic bodies");
     ( "D36",
-      "generated accessor definitions and label validation, including duplicate-label rejection, \
-       are deliberate follow-ups",
-      "generated accessor definitions and label validation are shipped" );
+      "generated accessors and their broader cross-constructor declaration validation remain \
+       deliberate follow-ups",
+      "generated accessors and their broader cross-constructor declaration validation ship" );
     ( "D37",
       "dotted names as atomic and preserve namespace puns",
       "dotted names as segmented and reject namespace puns" );

--- a/test/test_surface_patterns.ml
+++ b/test/test_surface_patterns.ml
@@ -42,10 +42,25 @@ let resolve names expression =
   | Ok expression -> expression
   | Error diagnostics -> fail_diags "resolve" diagnostics
 
-let resolve_codes names source =
+let resolve_diagnostics names source =
   match Resolve.resolve_expr names (lower source) with
   | Ok _ -> Alcotest.failf "expected %S to fail resolution" source
-  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
+  | Error diagnostics -> diagnostics
+
+let check_resolution_diagnostic names ~label ~source ~code ~excerpt =
+  match resolve_diagnostics names source with
+  | [ diagnostic ] ->
+      Alcotest.(check string) (label ^ " code") code (Diag.code_or_uncoded diagnostic);
+      let actual_excerpt =
+        match Diag.span diagnostic with
+        | None -> Alcotest.failf "%s: expected a source span" label
+        | Some span ->
+            String.sub source span.Span.start_pos.offset
+              (span.end_pos.offset - span.start_pos.offset)
+      in
+      Alcotest.(check string) (label ^ " exact span") excerpt actual_excerpt
+  | diagnostics ->
+      Alcotest.failf "%s: expected one diagnostic, got %d" label (List.length diagnostics)
 
 let test_all_pattern_forms_and_literals () =
   check_equivalent "six pattern forms and match"
@@ -181,6 +196,8 @@ let test_labeled_partial_patterns () =
   let snapshot_hash = Hash.of_string "labeled-pattern-snapshot" in
   let evolved_snapshot_hash = Hash.of_string "labeled-pattern-snapshot-evolved" in
   let some_hash = Hash.of_string "labeled-pattern-some" in
+  let outer_hash = Hash.of_string "labeled-pattern-outer" in
+  let inner_hash = Hash.of_string "labeled-pattern-inner" in
   let plain_hash = Hash.of_string "labeled-pattern-plain" in
   let ambiguous_hash = Hash.of_string "labeled-pattern-ambiguous" in
   let constructor_fields hash =
@@ -188,6 +205,8 @@ let test_labeled_partial_patterns () =
       Some [ Some "id"; Some "error"; None; Some "vendor"; Some "tail" ]
     else if Hash.equal hash evolved_snapshot_hash then
       Some [ Some "id"; None; Some "error"; Some "vendor"; Some "tail"; None ]
+    else if Hash.equal hash outer_hash then Some [ Some "inner"; Some "ignored" ]
+    else if Hash.equal hash inner_hash then Some [ Some "x"; Some "y" ]
     else if Hash.equal hash plain_hash then Some [ None ]
     else if Hash.equal hash ambiguous_hash then Some [ Some "value"; Some "value" ]
     else None
@@ -198,6 +217,8 @@ let test_labeled_partial_patterns () =
         ("value", { Resolve.hash = value_hash; kind = Resolve.KTerm });
         ("snapshot", { Resolve.hash = snapshot_hash; kind = Resolve.KCon });
         ("some", { Resolve.hash = some_hash; kind = Resolve.KCon });
+        ("outer", { Resolve.hash = outer_hash; kind = Resolve.KCon });
+        ("inner", { Resolve.hash = inner_hash; kind = Resolve.KCon });
         ("plain", { Resolve.hash = plain_hash; kind = Resolve.KCon });
         ("ambiguous", { Resolve.hash = ambiguous_hash; kind = Resolve.KCon });
       ]
@@ -242,6 +263,18 @@ let test_labeled_partial_patterns () =
     (Form.equal_ignoring_meta
        (Kernel.expr_to_form evolved_positional)
        (Kernel.expr_to_form evolved_labeled));
+  let nested_labeled =
+    resolve names
+      (lower "match value { | Outer(inner: Inner(y: right, x: left)) -> (left, right) }")
+  in
+  let nested_positional =
+    resolve names (lower "match value { | Outer(Inner(left, right), _) -> (left, right) }")
+  in
+  Alcotest.(check bool)
+    "nested labeled patterns expand independently" true
+    (Form.equal_ignoring_meta
+       (Kernel.expr_to_form nested_positional)
+       (Kernel.expr_to_form nested_labeled));
   let lookup _kind hash =
     if Hash.equal hash value_hash then Some "value"
     else if Hash.equal hash snapshot_hash then Some "snapshot"
@@ -283,18 +316,22 @@ let test_labeled_partial_patterns () =
         ] ) ->
       ()
   | _ -> Alcotest.fail "labeled pattern did not expand in declaration order");
+  check_resolution_diagnostic names ~label:"unknown field"
+    ~source:"match value { | Snapshot(missing: x) -> x }" ~code:"E0305" ~excerpt:"missing: x";
+  check_resolution_diagnostic names ~label:"duplicate selection"
+    ~source:"match value { | Snapshot(error: x, error: y) -> x }" ~code:"E0306" ~excerpt:"error: y";
+  check_resolution_diagnostic names ~label:"unlabeled constructor"
+    ~source:"match value { | Plain(value: x) -> x }" ~code:"E0307" ~excerpt:"Plain(value: x)";
+  check_resolution_diagnostic names ~label:"ambiguous declaration labels"
+    ~source:"match value { | Ambiguous(value: x) -> x }" ~code:"E0308"
+    ~excerpt:"Ambiguous(value: x)";
   Alcotest.(check (list string))
-    "unknown field" [ "E0305" ]
-    (resolve_codes names "match value { | Snapshot(missing: x) -> x }");
+    "quoted labeled pattern" [ "E1237" ]
+    (lower_codes "quote { match value { | Snapshot(error: problem) -> problem } }");
   Alcotest.(check (list string))
-    "duplicate selection" [ "E0306" ]
-    (resolve_codes names "match value { | Snapshot(error: x, error: y) -> x }");
-  Alcotest.(check (list string))
-    "unlabeled constructor" [ "E0307" ]
-    (resolve_codes names "match value { | Plain(value: x) -> x }");
-  Alcotest.(check (list string))
-    "ambiguous declaration labels" [ "E0308" ]
-    (resolve_codes names "match value { | Ambiguous(value: x) -> x }");
+    "constructor patterns remain refutable binders" [ "E0205" ]
+    (lower_codes "fn (Snapshot(error: problem)) -> problem");
+  ignore (lower "quote { match value { | Snapshot(_, problem) -> problem } }");
   ignore (resolve names (lower "match value { | Plain(field) -> field }"));
   List.iter
     (fun source -> Alcotest.(check bool) source true (List.mem "E1220" (parse_codes source)))

--- a/test/test_surface_patterns.ml
+++ b/test/test_surface_patterns.ml
@@ -42,6 +42,11 @@ let resolve names expression =
   | Ok expression -> expression
   | Error diagnostics -> fail_diags "resolve" diagnostics
 
+let resolve_codes names source =
+  match Resolve.resolve_expr names (lower source) with
+  | Ok _ -> Alcotest.failf "expected %S to fail resolution" source
+  | Error diagnostics -> List.map (fun diagnostic -> Diag.code_or_uncoded diagnostic) diagnostics
+
 let test_all_pattern_forms_and_literals () =
   check_equivalent "six pattern forms and match"
     {|match subject {
@@ -171,6 +176,134 @@ let test_resolved_hash_parity () =
     "resolved surface/bootstrap hash" true
     (Hash.equal (hash "surface hash" surface) (hash "bootstrap hash" kernel))
 
+let test_labeled_partial_patterns () =
+  let value_hash = Hash.of_string "labeled-pattern-value" in
+  let snapshot_hash = Hash.of_string "labeled-pattern-snapshot" in
+  let evolved_snapshot_hash = Hash.of_string "labeled-pattern-snapshot-evolved" in
+  let some_hash = Hash.of_string "labeled-pattern-some" in
+  let plain_hash = Hash.of_string "labeled-pattern-plain" in
+  let ambiguous_hash = Hash.of_string "labeled-pattern-ambiguous" in
+  let constructor_fields hash =
+    if Hash.equal hash snapshot_hash then
+      Some [ Some "id"; Some "error"; None; Some "vendor"; Some "tail" ]
+    else if Hash.equal hash evolved_snapshot_hash then
+      Some [ Some "id"; None; Some "error"; Some "vendor"; Some "tail"; None ]
+    else if Hash.equal hash plain_hash then Some [ None ]
+    else if Hash.equal hash ambiguous_hash then Some [ Some "value"; Some "value" ]
+    else None
+  in
+  let names =
+    Resolve.of_alist ~constructor_fields
+      [
+        ("value", { Resolve.hash = value_hash; kind = Resolve.KTerm });
+        ("snapshot", { Resolve.hash = snapshot_hash; kind = Resolve.KCon });
+        ("some", { Resolve.hash = some_hash; kind = Resolve.KCon });
+        ("plain", { Resolve.hash = plain_hash; kind = Resolve.KCon });
+        ("ambiguous", { Resolve.hash = ambiguous_hash; kind = Resolve.KCon });
+      ]
+  in
+  let labeled =
+    resolve names
+      (lower "match value { | Snapshot(vendor: Some(name) as vendor, error: problem) -> vendor }")
+  in
+  let positional =
+    resolve names
+      (lower "match value { | Snapshot(_, problem, _, Some(name) as vendor, _) -> vendor }")
+  in
+  Alcotest.(check bool)
+    "labeled expansion equals positional wildcard twin" true
+    (Form.equal_ignoring_meta (Kernel.expr_to_form positional) (Kernel.expr_to_form labeled));
+  let hash label expression =
+    match Canon.hash_expr expression with
+    | Ok hash -> hash
+    | Error diagnostics -> fail_diags label diagnostics
+  in
+  Alcotest.(check bool)
+    "labeled and positional hashes" true
+    (Hash.equal (hash "labeled" labeled) (hash "positional" positional));
+  let evolved_names =
+    Resolve.of_alist ~constructor_fields
+      [
+        ("value", { Resolve.hash = value_hash; kind = Resolve.KTerm });
+        ("snapshot", { Resolve.hash = evolved_snapshot_hash; kind = Resolve.KCon });
+        ("some", { Resolve.hash = some_hash; kind = Resolve.KCon });
+      ]
+  in
+  let evolved_labeled =
+    resolve evolved_names
+      (lower "match value { | Snapshot(vendor: Some(name) as vendor, error: problem) -> vendor }")
+  in
+  let evolved_positional =
+    resolve evolved_names
+      (lower "match value { | Snapshot(_, _, problem, Some(name) as vendor, _, _) -> vendor }")
+  in
+  Alcotest.(check bool)
+    "changed constructor identity selects its changed declaration schema" true
+    (Form.equal_ignoring_meta
+       (Kernel.expr_to_form evolved_positional)
+       (Kernel.expr_to_form evolved_labeled));
+  let lookup _kind hash =
+    if Hash.equal hash value_hash then Some "value"
+    else if Hash.equal hash snapshot_hash then Some "snapshot"
+    else if Hash.equal hash some_hash then Some "some"
+    else None
+  in
+  let printed =
+    match Surface_print.print_top ~lookup (Kernel.Expr labeled) with
+    | Ok text -> text
+    | Error diagnostics -> fail_diags "print labeled pattern" diagnostics
+  in
+  Alcotest.(check string)
+    "canonical declaration order"
+    "match value {\n  | Snapshot(error: problem, vendor: Some(name) as vendor) -> vendor\n}" printed;
+  (match labeled.it with
+  | Kernel.Match
+      ( _,
+        [
+          {
+            cpat =
+              {
+                it =
+                  PCon
+                    ( _,
+                      [
+                        { it = PWild; _ };
+                        { it = PVar "problem"; _ };
+                        { it = PWild; _ };
+                        {
+                          it = PAs ("vendor", { it = PCon (_, [ { it = PVar "name"; _ } ]); _ });
+                          _;
+                        };
+                        { it = PWild; _ };
+                      ] );
+                _;
+              };
+            _;
+          };
+        ] ) ->
+      ()
+  | _ -> Alcotest.fail "labeled pattern did not expand in declaration order");
+  Alcotest.(check (list string))
+    "unknown field" [ "E0305" ]
+    (resolve_codes names "match value { | Snapshot(missing: x) -> x }");
+  Alcotest.(check (list string))
+    "duplicate selection" [ "E0306" ]
+    (resolve_codes names "match value { | Snapshot(error: x, error: y) -> x }");
+  Alcotest.(check (list string))
+    "unlabeled constructor" [ "E0307" ]
+    (resolve_codes names "match value { | Plain(value: x) -> x }");
+  Alcotest.(check (list string))
+    "ambiguous declaration labels" [ "E0308" ]
+    (resolve_codes names "match value { | Ambiguous(value: x) -> x }");
+  ignore (resolve names (lower "match value { | Plain(field) -> field }"));
+  List.iter
+    (fun source -> Alcotest.(check bool) source true (List.mem "E1220" (parse_codes source)))
+    [
+      "match value { | Snapshot(id, error: problem) -> problem }";
+      "match value { | Snapshot(error: problem, id) -> problem }";
+      "match value { | Snapshot(error:) -> 0 }";
+    ]
+
 let later_arm_survives source =
   let recovered = Surface_parse.recover_string ~file:"recover-patterns.jac" source in
   Alcotest.(check bool) (source ^ " reports damage") true (recovered.diagnostics <> []);
@@ -250,11 +383,22 @@ let test_match_recovery () =
       "match x { | Broken 0 | Later -> 9 }";
       "match x { | Broken -> | Later -> 9 }";
       "match x { | Broken(x -> 0 | Later -> 9 }";
+      "match x { | Broken(field:) -> 0 | Later -> 9 }";
       "match x { | Broken -> f(x | Later -> 9 }";
       "match x { | Broken -> (1, x | Later -> 9 }";
       "match x { | Broken as Later -> 0 | Later -> 9 }";
       "match x { | Broken -> 0 | Later -> 9";
     ];
+  let malformed_labeled = "match x { | Broken(field:) -> 0 | Later -> 9 }" in
+  let recovered = Surface_parse.recover_string ~file:"recover-patterns.jac" malformed_labeled in
+  let replayed =
+    match Surface_print.print_recovered recovered with
+    | Ok text -> text
+    | Error diagnostics -> fail_diags "print recovered labeled pattern" diagnostics
+  in
+  Alcotest.(check string)
+    "malformed labeled pattern replays without crossing its recovery boundary" malformed_labeled
+    replayed;
   List.iter
     (fun source -> Alcotest.(check bool) source true (List.mem "E1220" (parse_codes source)))
     [ "match x {}"; "match x | Broken -> 0" ]
@@ -267,6 +411,7 @@ let suite =
     Alcotest.test_case "context restrictions and duplicates" `Quick
       test_contextual_restrictions_and_duplicates;
     Alcotest.test_case "resolved hash parity" `Quick test_resolved_hash_parity;
+    Alcotest.test_case "labeled partial constructor patterns" `Quick test_labeled_partial_patterns;
     Alcotest.test_case "ambiguous nested recovery" `Quick test_ambiguous_nested_recovery;
     Alcotest.test_case "missing match before definition" `Quick test_missing_match_before_definition;
     Alcotest.test_case "match recovery" `Quick test_match_recovery;

--- a/test/test_surface_trivia.ml
+++ b/test/test_surface_trivia.ml
@@ -473,6 +473,15 @@ let test_remaining_delimited_containers () =
       ( "constructor pattern",
         "f = match x { | Some(y\n-- constructor-pattern-inner\n) -> y }\n",
         "-- constructor-pattern-inner" );
+      ( "labeled constructor pattern",
+        "f = match x { | Snapshot(error:\n\
+         -- selected-pattern-leading\n\
+         problem,\n\
+         -- selected-field-leading\n\
+         vendor: vendor\n\
+         -- labeled-pattern-inner\n\
+         ) -> problem }\n",
+        "-- selected-pattern-leading" );
       ("type tuple", "f : (T, U\n-- type-tuple-inner\n)\nf = 1\n", "-- type-tuple-inner");
       ("empty call", "f = call(-- empty-call-inner\n)\n", "-- empty-call-inner");
       ("empty definition", "f(-- empty-definition-inner\n) = 1\n", "-- empty-definition-inner");
@@ -490,7 +499,26 @@ let test_remaining_delimited_containers () =
       let printed = print_recovered source in
       Alcotest.(check int) (label ^ " comment count") 1 (count_occurrences printed comment);
       Alcotest.(check string) (label ^ " idempotent") printed (print_recovered printed))
-    printable
+    printable;
+
+  let labeled =
+    print_recovered
+      "f = match x { | Snapshot(error:\n\
+       -- selected-pattern-leading\n\
+       problem,\n\
+       -- selected-field-leading\n\
+       vendor: vendor\n\
+       -- labeled-pattern-inner\n\
+       ) -> problem }\n"
+  in
+  List.iter
+    (fun comment ->
+      Alcotest.(check int)
+        ("labeled pattern unique " ^ comment)
+        1
+        (count_occurrences labeled comment))
+    [ "-- selected-pattern-leading"; "-- selected-field-leading"; "-- labeled-pattern-inner" ];
+  Alcotest.(check string) "labeled pattern idempotent" labeled (print_recovered labeled)
 
 let test_block_container_provenance () =
   let singleton =


### PR DESCRIPTION
## What

- Adds `Ctor(label: pattern, ...)` partial constructor matching without adding a kernel form.
- Resolves selected labels through the constructor content identity, expands omissions to positional wildcards, and reuses existing checking, exhaustiveness, evaluation, native, and hashing behavior.
- Preserves authored trivia and prints resolved selections in declaration order.
- Adds focused E0305-E0308 schema diagnostics and E1237 for labeled patterns inside quoted code.
- Updates human documentation, release follow-ups, error references, and the agent-facing `docs/SKILL.md`.

## Contract and compatibility

There are no label puns and labeled/positional fields cannot mix. `_`, nested constructors, and `as` patterns are supported after `:`. Unknown or repeated selections, constructors without usable labels, and ambiguous duplicate declaration labels fail at use. Positional `.jac`, bootstrap `.jqd`, the 27-form kernel, and HASH_V0 remain unchanged. Generated accessors and broader D36 declaration validation remain follow-ups.

Quoted kernel data cannot carry surface-only label intent, so labeled patterns inside `quote { ... }` fail with E1237; positional quoted patterns remain supported. This closes the metadata-erasure identity hazard found during independent review.

## Evidence

- Fable 5 review of `5c02826` found the quoted-pattern identity blocker.
- Fix `28df929` received a Fable 5 follow-up verdict of **PASS with no findings**.
- `dune fmt` plus clean diff
- `dune build @all`
- `dune build @doc`
- `dune runtest`: **869 tests**, 28 doctest examples across 8 documents, all crams and native/sanitizer evidence; 435.334s
- Focused surface-pattern/check/trivia suites and `test/cli/surface.t`

This semantic/compatibility/diagnostic/formatter evidence closes SX.24 without inventing a new UX.0 protocol run.
