### PR TITLE
SX.23: add identity-bound named call arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ The bet behind all of this: when most code is written by machines, the humans
 reviewing it need the language itself to answer "what can this touch, and how
 sure are we" without reading every line.
 
+Jacquard also lets public call sites say what each argument means:
+
+```text
+resize(image, scale: ratio) = (image, ratio)
+
+resize(photo, scale: 2)
+```
+
+An unlabeled positional prefix may come first; labeled arguments may follow in
+any order and still run left to right as written. Labels are explicit API, not
+guesses from local binder names: top-level functions and effect operations
+declare them, while constructors reuse their declared field labels. Calls are
+still exact-arity and uncurried—there are no defaults, label puns, or named
+calls through local and higher-order values. The lower-level `.jqd` carrier
+remains positional.
+
 ## The Review Case In Miniature
 
 Suppose a model hands you this one-line change in Python:
@@ -154,7 +170,9 @@ For readers who speak programming languages:
   effect operations, and each inference algorithm is a handler.
 - Content-addressed definitions. Identity is a hash of canonical resolved
   structure with non-identity metadata erased, so formatting, comments, and
-  ordinary local or term renames change nothing downstream.
+  ordinary local or term renames change nothing downstream. Explicit external
+  call labels are a separately stored, hash-bound API contract; changing those
+  labels for the same callable identity is rejected.
 - Tooling that leans on the above: formatter, structure-aware differ, Warp
   tests with a content-addressed cache, record/replay, and a reproducible
   release evidence pack.
@@ -181,8 +199,8 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 868
-Alcotest/QCheck cases, 58 cram transcripts, 28 documentation examples, native
+semantic boundary remains historical; the current successor is pinned by 877
+Alcotest/QCheck cases, 59 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
 runtime/output license exception and packages the native runtime. The current
@@ -537,6 +555,8 @@ Key release docs:
 - `docs/release/0.2/LIMITS.md`: explicit non-goals and trusted boundaries
 - `docs/release/0.2/DECISION.md`: RC1 and same-commit final decision
 - `docs/release/0.2/RELEASE-NOTES.md`: public contents and install command
+- `docs/release/named-call-arguments/DECISION.md` and `EVIDENCE.md`: post-0.2
+  direct named-call contract, hash-bound ABI, proving tests, and non-claims
 - `docs/release/structured-concurrency/EVIDENCE.md`: successor C0-C2 publication
   claims plus the shipped interpreted C3 Channel runtime, exact counts, demo,
   and proving tests

--- a/corpus/golden/diags.golden
+++ b/corpus/golden/diags.golden
@@ -88,6 +88,12 @@ redundant-clause | redundant-clause.jqd:1:57-85: warning[W0801]: This match clau
 eta-positive | eta-positive.jac:2:21-30: error[E0807]: A computation was used where a thunk is required
   Cause: this position expects a thunk, but `condition` is a bare reference; wrap it in `fn () -> ...`
   Next step: Wrap the reference in `fn () -> ...` so the computation is delayed.
+named-bool-warning | named-bool-warning.jac:2:13-17: warning[W1206]: Positional boolean argument is difficult to review
+  Cause: Argument 1 is the Bool constructor `True`; the behavior it selects is not visible from its position.
+  Next step: Use the callable's explicit named argument, or replace a behavioral Bool with a sum type such as `type Mode = | Live | DryRun`.
+named-repeated-type-warning | named-repeated-type-warning.jac:3:1-15: warning[W1207]: Same-typed positional arguments are difficult to distinguish
+  Cause: Parameters 1 through 2 all have type int, so a reordered call can still typecheck.
+  Next step: Use the callable's explicit labels for the ambiguous suffix, or use a purpose-specific sum type such as `type Mode = | Live | DryRun`.
 strict-recovery | error[E1202]: Recovered syntax cannot cross this semantic boundary.
   Cause: Recovery holes are not valid input to the strict type checker.
   Next step: Fix the reported syntax damage before checking, hashing, storing, or running it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,9 +104,14 @@ Read these together when reviewing the historical 0.1 candidate boundary:
 ## Post-0.1 Surface Syntax Evidence
 
 - `release/surface-syntax/DECISION.md`: SS.21 advertise/not-advertise decision,
-  L1-L7 status, D34-D40 conformance, caveats, and reproduction commands.
+  L1-L7 status, D34-D42/D75-D76 conformance, caveats, and reproduction
+  commands.
 - `release/surface-syntax/FOLLOWUPS.md`: durable D36/D38/D39 and Tier-F
   follow-up scope outside the surface release gate.
+- `release/named-call-arguments/DECISION.md`: SX.23 direct named-call contract,
+  hash-bound companion ABI, compatibility boundary, and explicit non-claims.
+- `release/named-call-arguments/EVIDENCE.md`: parser/resolver/store/hash/native
+  evidence and the current test inventory for named calls.
 - `release/surface-syntax/MANIFEST.sha256`: historical surface-syntax evidence
   integrity set, validated by the surface manifest checker. Successor milestones
   publish separate reconstructible overlays rather than extending this set.

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -197,13 +197,52 @@ limit = 100
 
 add-tax(amount, rate) = real.mul(amount, real.add(1.0, rate))
 
+resize(image, scale: ratio) = (image, ratio)
+
 increment = fn (n) -> add(n, 1)
 
 answer : () ->{} Int
 answer() = increment(41)
 
 answer()
+
+resize(photo, scale: 2)
 ```
+
+An eligible callable may declare an unlabeled positional prefix followed by an
+explicitly labeled suffix. At a call, positional arguments must likewise come
+first; labeled arguments may then appear in any order. Calls remain uncurried
+and exact-arity: every slot is supplied exactly once, with no defaults, label
+puns, partial application, or positional argument after a label. Arguments
+always evaluate once, left to right in source order; resolution inserts local
+`let` bindings when declaration-order application would otherwise reorder
+them.
+
+Named calls are deliberately direct and fail closed. A top-level equation
+parameter declares a label with `label: binder`, an effect operation declares
+one with `label: Type`, and a constructor reuses its field label. The label is
+external API and need not equal its binder. Locals, anonymous functions,
+higher-order callees, patterned parameters, and unlabeled declarations accept
+only positional calls; attempting a named call reports E0309. Unknown,
+duplicate/overlapping, missing, malformed-declaration, and ambiguous-schema
+cases report E0310-E0314.
+
+Term and operation labels are persisted as a versioned `call-abi-v1`
+companion keyed by the exact callable hash. Renaming the callable or its local
+binder leaves that companion intact. Publishing different labels for the same
+hash is E0612, so never infer labels from binder names or replace a stored ABI.
+Constructor labels already belong to the constructor schema and content
+identity. Named syntax lowers to ordinary positional `App`/`Let`, so a valid
+named call hashes and runs like its explicit positional twin.
+
+For review, when a direct term or operation publishes a usable companion label for the hotspot,
+the checker warns on two still-valid positional shapes: W1206 for a direct
+`True`/`False` argument, and W1207 for a definite adjacent run of same-typed
+parameters. Prefer the callable's explicit labels.
+If a boolean controls behavior rather than reporting a predicate, prefer a
+purpose-specific sum such as `type Mode = | Live | DryRun`. These are advisory
+warnings, not type errors, and the checker emits neither warning for a named
+call.
 
 Top-level `name = value` and `name(args) = body` create definitions. A
 signature immediately before the matching definition is optional. Bare
@@ -376,7 +415,8 @@ type Result e a =
 ```
 
 Labels do not create record construction or generated accessors. Construct
-values positionally with `Canary(5)`; match either positionally with
+values either positionally with `Canary(5)` or by label with
+`Canary(percent: 5)`; match either positionally with
 `Canary(percent)` or by selection with `Canary(percent: value)`.
 
 Comma-separated surface groups accept an optional final comma. Compact
@@ -397,6 +437,10 @@ multi effect Choice where {
 
 once effect Abort a where {
   abort : () -> a
+}
+
+once effect Sending where {
+  send : (path: Text, body: Text) -> Text
 }
 ```
 
@@ -485,6 +529,10 @@ Useful structural operations include:
 
 `unquote` outside `quote` is invalid. A splice must produce `Code`. Nested
 quote levels are significant. `(expression : Type)` is a type annotation.
+Named calls are rejected with E1238 anywhere inside a surface quote, including
+inside a live `unquote`, because labels have no durable quoted carrier. Use a
+positional call in quoted code. Labeled constructor patterns are independently
+rejected there with E1237.
 
 `jqd { (bootstrap form) }` is the surface escape for a kernel form that cannot
 be represented without preserving an internal grouping. It is not general
@@ -498,16 +546,16 @@ This practical grammar covers ordinary public source:
 file        := top-item*
 top-item    := signature | definition | type-decl | effect-decl | expression
 signature   := name ":" type
-definition  := name ["(" patterns? ")"] "=" expression
+definition  := name ["(" ([label ":"] pattern ("," [label ":"] pattern)*)? ")"] "=" expression
 type-decl   := "type" Type type-vars? "=" ("|" constructor)+
 effect-decl := mode "effect" Effect type-vars? "where" "{" uniform-op-signature+ "}"
 | "effect" Effect type-vars? "where" "{" mode-op-signature+ "}"
-uniform-op-signature := name ":" "(" types? ")" "->" type
-mode-op-signature := mode name ":" "(" types? ")" "->" type
+uniform-op-signature := name ":" "(" ([label ":"] type ("," [label ":"] type)*)? ")" "->" type
+mode-op-signature := mode name ":" "(" ([label ":"] type ("," [label ":"] type)*)? ")" "->" type
 mode        := "once" | "multi"
 
 expression  := call ("|>" call)*
-call        := primary ("(" expressions? ")")*
+call        := primary ("(" ([label ":"] expression ("," [label ":"] expression)*)? ")")*
 primary     := literal | marked-text | name | tuple | list | block | fn | match | if
              | handle | quote | unquote | annotation
 marked-text := '$"' ("{{" | "{" expression "}" | character-or-escape)* '"'
@@ -737,6 +785,9 @@ units. Consequently:
 - Reordering members of a recursive SCC is stable.
 - Renaming a top-level display name changes the name index, not its object.
 - Provenance can change without changing the approved content hash.
+- Explicit term/operation call labels are a versioned, hash-bound companion
+  ABI. Binder and callable renames preserve it; a conflicting relabel is
+  E0612 rather than an identity-silent API change.
 
 Use `jac fmt --write` for canonical layout. Use stores and `jac diff` when you
 need rename classification, changed canonical subtrees, or affected
@@ -771,6 +822,10 @@ reparse to the same semantic top/member hashes; quoted constructor and
 operation intent remains encoded with `surface-ref-v0`. Publication is atomic
 and refuses an existing destination. The canonical bootstrap output erases
 comments, formatting, spans, documentation, and provenance metadata by design.
+It also contains only positional kernel applications and carries no
+`call-abi-v1` companion, so an exported `.jqd` declaration cannot by itself
+teach another surface source file its labels. The store companion is the
+cross-file named-call boundary.
 Export validates parsing, resolution, and canonical identity, but does not
 typecheck; use `jac check`, `jac run`, or `jac build` for that guarantee.
 Materialize stdin or other non-seekable input before export.
@@ -807,7 +862,8 @@ source remain under Apache-2.0. See `RUNTIME-EXCEPTION.md`, `LICENSE`, and
 `.jqd` is the permanent kernel/debug carrier used by the prelude, replay,
 explicit export, and implementation fixtures. It is an s-expression encoding
 of 27 fixed kernel forms. Native build also accepts `.jqd`, but ordinary users
-should write and build `.jac` directly.
+should write and build `.jac` directly. Bootstrap calls are always positional;
+there is no named-argument grammar in `.jqd`.
 
 The expression heads are `lit`, `var`, `ref`, `lam`, `app`, `let`, `match`,
 `tuple`, `handle`, `quote`, `unquote`, and `ann`; pattern heads are `pwild`,

--- a/docs/ast.md
+++ b/docs/ast.md
@@ -79,6 +79,7 @@ Reserved keys (all optional):
 | `span` | file, line/col range | diagnostics, Elm-grade errors |
 | `scopes` | scope-set for identifiers | hygiene, per Racket's sets-of-scopes (Flatt, POPL 2016) |
 | `name` | source name for a hash-resolved ref | human/model legibility of resolved trees |
+| `surface-call-label` | transient source label on a call argument or declared parameter | lets the surface resolver elaborate named syntax before canonical metadata erasure |
 | `trivia` | comments, exact whitespace | full-fidelity round-tripping (Roslyn lesson) without hash instability (Go's CommentMap lesson, learned in the negative) |
 | `origin` | provenance record: human id, model id, tool | agent-era requirement: who wrote this node, signable, and it rides outside identity |
 | `doc` | attached documentation | docs travel with code |
@@ -220,6 +221,11 @@ Decisions within what remains:
   Koka is uncurried. Currying remains available the ordinary way (a lambda
   returning a lambda). Zero-ary `Lam`/`App` doubles as thunk/force, which a
   strict language needs (§7).
+  Surface named calls add no kernel argument shape: direct labels resolve to
+  declaration-order positional `App`; an authored reordering becomes
+  left-to-right `Let` bindings followed by that `App`. Named calls are
+  therefore hash-identical to the corresponding positional or explicit-let
+  kernel program.
 - **`Lam` params are patterns** (commitment: patterns everywhere), restricted to irrefutable
   ones; the checker enforces irrefutability, semantics is `Match`.
 - **`Let` carries a `rec` flag** rather than spending a second form. `rec` restricts the
@@ -276,8 +282,9 @@ for reading.
 
 Records beyond labeled constructor fields (true row-typed records) are deferred.
 The shipped `.jac` surface preserves labels as constructor schema: labels print
-and contribute to canonical identity, but do not generate accessor functions or
-labeled patterns. Those remain separately gated surface follow-ups.
+and contribute to canonical identity, support direct named construction and
+partial labeled patterns, but do not generate accessor functions. True records
+and generated accessors remain separately gated follow-ups.
 
 ### 5.4 Declarations
 
@@ -296,8 +303,18 @@ Three forms, and the third is where two commitments become one mechanism:
   granted authorities. No ambient handlers, no ambient authority. Attenuation is handler
   interposition (wrap the child in a filtering handler). §10 flags the granularity caveat.
 
+Top-level term and operation call labels are intentionally not added to these
+kernel declarations. Surface publication derives an explicit label vector and
+stores it as a versioned `call-abi-v1` companion keyed by the exact derived
+term or operation hash. It is never inferred from local binder names. A rename
+or alpha-renaming therefore preserves the external ABI, while a conflicting
+relabel of the same identity is rejected. Constructor call labels instead come
+from `conspec` fields and already participate in identity.
+
 There is no module form. A codebase is a content-addressed map from hashes to declarations;
-names, namespaces, and renames are metadata operations that never touch identity. This is
+names, namespaces, and renames are index operations that never touch identity. Explicit
+external call labels are the narrow exception to treating every index attachment as mere
+display metadata: the hash-bound companion is API state and conflicts fail closed. This is
 the Unison move, and it is what makes agent loops cacheable: re-typecheck and re-test keyed
 on hashes, and an edit invalidates exactly its dependents.
 
@@ -325,7 +342,8 @@ Canonicalization rules:
 Consequences worth saying out loud: renames are free and history-preserving; formatting
 and comments never dirty a build; a semantic differ falls out of comparing trees rather
 than text; and provenance/signatures ride in `meta` at any granularity without forking
-identities.
+identities. Kernel hash/diff equality does not compare `call-abi-v1` companions; consumers
+that review a published surface API must inspect the store index as well as the object.
 
 ## 7. Semantic commitments the grammar assumes
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -90,6 +90,12 @@ malformed source, path, or host-message byte in a string field is replaced with 
 | E0306 | labeled constructor pattern selects one field more than once | `Snapshot(error: x, error: y)` |
 | E0307 | constructor has no usable field-label schema for a labeled pattern | `Pair(left: x)` when `Pair` has only positional fields |
 | E0308 | constructor declaration has ambiguous duplicate labels at labeled-pattern use | `Pair(left: x)` when `left` is declared twice |
+| E0309 | callee has no usable explicit named-call ABI | `local(value: 1)` for a local function, or `plain(value: 1)` for an unlabeled top-level term |
+| E0310 | named call selects an unknown label | `resize(image: img, size: 2)` when the declared label is `scale` |
+| E0311 | named call repeats or overlaps one argument slot | `choose(left: 1, left: 2)` or `resize(img, image: other)` |
+| E0312 | named call does not fill the exact arity | `choose(left: 1)` when both `left` and `right` are required |
+| E0313 | declaration has an invalid explicit named-call ABI | `bad(label: (x, y)) = x` or repeated parameter labels |
+| E0314 | constructor named-call schema is ambiguous or malformed | using labels on a constructor with duplicate labels or an unlabeled field after a labeled field |
 
 ### Resolution warnings (W03xx)
 
@@ -122,6 +128,7 @@ malformed source, path, or host-message byte in a string field is replaced with 
 | E0609 | invalid, mismatched, or unreadable diff operands | diffing a file against a store |
 | E0610 | diff source contains a top-level expression | diffing a runnable script instead of declarations |
 | E0611 | relational constituent store cannot be created or initialized | running `jacquard relate` with an unusable temporary directory |
+| E0612 | a callable hash is already bound to a different `call-abi-v1` companion | publishing new external labels for an unchanged term or operation identity |
 
 ## Prelude and grants (E07xx)
 
@@ -235,6 +242,7 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 | E1235 | a signature or definition was lowered without its required file context | calling `lower_top` on a signature |
 | E1236 | missing, duplicated, or conflicting surface operation mode; an omitted mode includes migration guidance | `effect E where { op : () -> T }` |
 | E1237 | labeled constructor pattern appears inside quoted surface syntax | `quote { match packet { \| Packet(right: value) -> value } }` |
+| E1238 | named call appears anywhere inside quoted surface syntax, including a live unquote | `quote { unquote(choose(left: 1)) }` |
 
 ### Surface warnings (W12xx)
 
@@ -245,6 +253,8 @@ also emits E0817; consuming the captured resumption twice emits E0816.
 | W1203 | match scrutinee spans more than four source lines | manually bind the expression with `let`, then match on its name |
 | W1204 | shortest legal type/effect declaration header exceeds the canonical formatter width | shorten the declaration name or type-variable list |
 | W1205 | shortest legal `forall` prefix exceeds the canonical formatter width | split the declaration or reduce its quantified variables |
+| W1206 | positional term/operation call passes a direct `Bool` constructor literal in a slot with an explicit companion label | use that label, or a purpose-specific sum such as `Mode = \| Live \| DryRun` |
+| W1207 | positional term/operation call fills a definite adjacent run of same-typed parameters with an applicable companion label | call the ambiguous suffix by label so swaps remain visible in review |
 
 ## Explicit bootstrap export (E13xx)
 

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,9 +3,9 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `869`
+Test count: `877`
 
-Cram count: `58`
+Cram count: `59`
 
 Documentation example count: `28` across `8` documents
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,8 +32,8 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `869`
-- Cram transcript files: `58`
+- Alcotest/QCheck cases: `877`
+- Cram transcript files: `59`
 - Documentation examples: `28` named examples across `8` documents
 
 The development suite also includes corpus goldens, release-manifest checks,
@@ -49,6 +49,9 @@ slow handling of the canonical depth-100,000 inputs.
 - `../0.1/` retains the historical core candidate boundary;
 - `../surface-syntax/` and `../dx-jac-export/` cover public `.jac`, formatting,
   direct native build, export, and parser hardening;
+- `../named-call-arguments/` covers the post-release direct named-call
+  projection and its additive identity-bound store companion; it does not
+  retroactively put named syntax in the frozen 0.2 binary artifacts;
 - `../explicit-dictionaries/` covers explicit `Eq`, `Ord`, `Show`, and `Num`
   values;
 - `../effect-linearity/` and `../effect-taxonomy/` cover affine `once`

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,8 +6,8 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `869`
-- Cram transcript files: `58`
+- Alcotest/QCheck cases: `877`
+- Cram transcript files: `59`
 - Doctest examples: `28` across 8 documents
 
 The test count includes six DX.2 filesystem-boundary cases and six DX.5/DX.7
@@ -59,6 +59,10 @@ canonical divergence, and cache invalidation.
 RW.7 adds three compiled cases for exact concurrency-demo transcript invariance
 and direct/fail-fast transitive-cancellation sentinel safety. It extends the
 existing concurrency transcript and adds no cram or doctest entry.
+Task 171 adds one labeled-pattern contract case. SX.23 then adds six compiled
+named-call cases, two D76 decision-mutation cases, and one CLI transcript,
+producing the current `877 / 59 / 28` successor inventory without changing the
+historical DX.2 publication.
 
 ## Proved behavior
 

--- a/docs/release/named-call-arguments/DECISION.md
+++ b/docs/release/named-call-arguments/DECISION.md
@@ -1,0 +1,96 @@
+# SX.23 Named Call Arguments Decision
+
+- Decision date: 2026-08-19
+- Reconstruction base: `0509eddd56d88ec492f67ae45c66a332a606bbcb`
+- Release posture: post-0.2 successor research prototype
+
+## Decision
+
+Ship explicit named arguments for direct surface callables at the D76 boundary.
+Keep the kernel, `HASH_V0`, evaluator, native ABI, and bootstrap `.jqd` grammar
+unchanged. Treat term and operation labels as a versioned, identity-bound
+surface API rather than inferring them from alpha-renamable binder names.
+
+The supported declaration and call shapes are:
+
+```jacquard
+resize(image, scale: ratio) = (image, ratio)
+
+type Packet = | Packet(Int, body: Text)
+
+once effect Sending where {
+  send : (path: Text, body: Text) -> Text
+}
+
+resize(photo, scale: 2)
+Packet(200, body: "ok")
+```
+
+An unlabeled positional prefix may precede a labeled suffix. Labeled call
+arguments may be authored in any order, but every slot is supplied exactly
+once. There are no defaults, label puns, partial calls, or positional arguments
+after the first label. A declaration label must select a simple variable
+parameter; the label and binder are distinct.
+
+Eligible callees are direct top-level terms, constructors, and effect
+operations. Constructors reuse their field schema. Terms and operations expose
+an explicit `call-abi-v1` slot vector keyed by their exact derived hash.
+Same-SCC term calls use the same contract. Local functions, anonymous or
+higher-order callees, patterned parameters, variadics, unlabeled callables, and
+opaque identities without a companion fail closed with E0309.
+
+## Semantics And Identity
+
+Resolution elaborates named syntax to the existing positional kernel. A call
+already in declaration order becomes an ordinary `App`. A reordered call
+becomes left-to-right `Let` bindings in authored order followed by a
+declaration-order `App`. Each argument therefore evaluates once in source order
+in both the interpreter and native backend.
+
+The declaration-order named spelling hashes exactly like its positional twin;
+the reordered spelling hashes like the equivalent explicit-let positional
+program. Call labels themselves are erased with surface metadata before kernel
+hashing. The external API is nevertheless durable: `names.jqd` stores the
+additive, versioned `call-abi-v1` companion. Reopen and public-name or
+local-binder renames preserve it. A different vector for the same callable
+hash is rejected transactionally with E0612.
+
+Constructor field labels remain part of the constructor schema and content
+identity. This decision does not add record types or generated accessors.
+
+## Compatibility Boundary
+
+- Existing positional `.jac` and all `.jqd` programs keep their current
+  meaning and hashes.
+- Existing stores without companions remain readable. Their unlabeled terms
+  and operations remain positional-only.
+- `jac export` emits only positional `.jqd`. It preserves the elaborated
+  program's hashes and behavior, but does not carry a companion that would let
+  a later `.jac` file rediscover labels.
+- Kernel semantic diff does not compare store companions; API review that
+  includes external labels must inspect the name index.
+- Named calls anywhere inside a surface quote, including a live `unquote`, are
+  E1238 because quoted code has no durable label carrier. Positional quoted
+  calls and raw `.jqd` quotes are unchanged.
+
+## Diagnostics And Review Guidance
+
+E0309-E0314 distinguish unsupported/unlabeled callees, unknown labels,
+duplicate or overlapping slots, incomplete arity, invalid declarations, and
+ambiguous constructor schemas. E0612 protects persistent API identity. E1238
+protects quote round-tripping. Parser ordering errors remain E1220.
+
+When a direct term/operation API exposes an applicable companion label, W1206 advises on a direct
+positional `Bool` constructor literal and W1207 advises on a definite adjacent
+run of same-typed positional parameters. Named calls do not emit either
+warning, and a purpose-specific sum is the recommended
+alternative when a boolean selects behavior. These warnings remain non-fatal.
+
+## Claim Boundary
+
+The implementation and evidence establish parsing, formatting, lowering,
+resolution, store persistence, diagnostics, checking, hashing, interpreter and
+native behavior, and compatibility for the bounded forms above. They do not
+establish that named arguments improve readability for humans. The existing
+preregistered readability protocol has no SX.23 cohort; its regression gate is
+run only to prove that this change did not disturb the protocol machinery.

--- a/docs/release/named-call-arguments/EVIDENCE.md
+++ b/docs/release/named-call-arguments/EVIDENCE.md
@@ -1,0 +1,65 @@
+# SX.23 Named Call Arguments Evidence
+
+Status: successor evidence over Task 171's merged labeled-pattern base
+`0509eddd56d88ec492f67ae45c66a332a606bbcb`.
+
+## Current Inventory
+
+- Alcotest/QCheck cases: `877`
+- Cram transcript files: `59`
+- Doctest examples: `28` across 8 documents
+
+SX.23 adds six compiled semantic cases in
+[`test_surface_named_calls.ml`](../../../test/test_surface_named_calls.ml) and
+two D76 decision-mutation cases in
+[`test_surface_laws.ml`](../../../test/test_surface_laws.ml), plus one CLI transcript in
+[`named-args.t`](../../../test/cli/named-args.t). No doctest cohort is added.
+
+## Evidence Matrix
+
+| boundary | evidence |
+|---|---|
+| parse, recovery, trivia, width, and formatter idempotence | `parse print quote recovery` compiled case; `jac fmt` CLI transcript |
+| direct terms and same-SCC calls | `direct hashes and source order` compiled case |
+| constructors and operations, including positional prefixes | `constructors and operations` compiled case; `supported.jac` CLI fixture |
+| exact source-order evaluation and native parity | effectful reordered CLI program prints `RL(1, 2)` identically under `jac run` and a clang-built binary |
+| positional kernel and hash parity | declaration-order and explicit-let hash twins in the compiled suite; `.jac`/exported `.jqd` hash comparison in the CLI transcript |
+| fail-closed diagnostics and spans | `fail-closed diagnostics` compiled case; E0309-E0314 and E1238 CLI fixtures |
+| persistent identity-bound ABI | `store identity reopen conflict` proves installation, reopen, public rename, binder rename, E0612 conflict, and transactional preservation |
+| checker review guidance and editor recovery | `checker warnings and recovery names` proves W1206/W1207 positive and negative shapes plus same-file recovery ABI visibility |
+| bootstrap boundary | `jac export` produces runnable positional `.jqd`; named syntax in quotes is E1238 |
+
+## Required Gates
+
+Run from the repository root with the repository-local opam environment and a
+repository-local `TMPDIR`:
+
+```sh
+eval "$(opam env)"
+mkdir -p "$PWD/.scratch/tmp"
+export TMPDIR="$PWD/.scratch/tmp"
+opam exec -- dune build @all
+opam exec -- dune runtest
+opam exec -- dune fmt
+git diff --exit-code
+opam exec -- dune build @doc
+```
+
+The focused CLI transcript is:
+
+```sh
+opam exec -- dune runtest test/cli/named-args.t --force
+```
+
+The ordinary `@all` gate also runs the existing readability-protocol and
+schedule checks. Their passing status is regression evidence only. No SX.23
+participant data, readability score, blinded rescore, or study conclusion is
+claimed or invented.
+
+## Limits
+
+This is bounded executable evidence, not a proof over every surface tree, a
+human readability result, or a new runtime semantics. Named local/HOF calls,
+defaults, puns, partial application, record types/accessors, a named `.jqd`
+carrier, exported companion ABI, and companion-aware kernel diff are outside
+the shipped boundary.

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 869 compiled Alcotest/QCheck cases, 58 recursive
+The current successor inventory is exactly 877 compiled Alcotest/QCheck cases, 59 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,8 +760,8 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `869`
-- Cram transcript files: `58`
+- Alcotest/QCheck cases: `877`
+- Cram transcript files: `59`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
 `channel-contract` cases plus the `store/9` Channel-private-hash case took the
@@ -813,7 +813,9 @@ cases add three compiled seam/cache cases and one registered Warp transcript,
 producing the then-current `865 / 58 / 28` inventory. RW.7 adds the three-case
 registered relational regression net without adding a cram file or doctest,
 producing the `868 / 58 / 28` inventory. Task 171 adds the labeled-pattern
-contract case, producing the current `869 / 58 / 28` inventory.
+contract case, producing `869 / 58 / 28`. SX.23 then adds six named-call cases,
+two D76 decision-mutation cases, and one transcript, producing the current
+`877 / 59 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/docs/release/surface-syntax/DECISION.md
+++ b/docs/release/surface-syntax/DECISION.md
@@ -15,6 +15,10 @@ not prove every possible kernel tree or freeze future surface revisions.
 
 The SS.0-SS.22 implementation arc is complete at these evidence boundaries.
 The EL.4 successor overlay additionally ships D41-D42 operation-mode syntax.
+The SX.23 successor overlay additionally ships D76 direct named calls; its
+separate [decision](../named-call-arguments/DECISION.md) and
+[evidence](../named-call-arguments/EVIDENCE.md) are authoritative for that
+post-manifest boundary.
 That completion does not promote partial D36, resource-scoped rows, or the
 separately integrated affine-checker/stdlib work into this surface claim and
 does not establish a freeze for the entire surface syntax.
@@ -22,7 +26,9 @@ does not establish a freeze for the entire surface syntax.
 Bootstrap `.jqd` remains permanently supported as the kernel/debug format of
 record, quote-literal notation, and a test and tooling carrier. It is not
 deprecated. The surface gate does not change the 27-form kernel, `HASH_V0`,
-store format, evaluator, native semantics, or authority model. EL.1's
+historical store format, evaluator, native semantics, or authority model.
+SX.23 leaves stored kernel objects unchanged but additively extends the mutable
+name index with a versioned hash-bound call ABI companion. EL.1's
 hash-stable operation-mode extension is the kernel input to this overlay:
 legacy `Multi` remains absent and byte-identical, while explicit `Once` is
 interface-visible.
@@ -57,6 +63,7 @@ Allowed decision statuses at this gate are `shipped`, `partial`, and
 | D40 | shipped | [declaration tests](../../../test/test_surface_decls.ml) pin lowering order. [CLI evidence](../../../test/cli/surface.t) executes multiple bare expressions interleaved with declarations in document order and pins stdout `40\n41\n42\n` with exit 0. | none |
 | D41 | shipped | [declaration tests](../../../test/test_surface_decls.ml), [printing tests](../../../test/test_surface_print.ml), and [trivia tests](../../../test/test_surface_trivia.ml) pin per-operation `once`/`multi`, uniform effect-level shorthand, canonical emission, recovery, and formatter idempotence. | none |
 | D42 | shipped | [declaration diagnostics](../../../test/test_surface_decls.ml) reject omission, duplication, conflicts, and partially annotated mixed effects with E1236; the [operation-mode twin](../../../corpus/valid/operation-modes.jac) pins resolved `.jac`/`.jqd` hash parity while bootstrap absence remains legacy `Multi`. | none |
+| D76 | shipped | [named-call cases](../../../test/test_surface_named_calls.ml) and the [CLI transcript](../../../test/cli/named-args.t) pin explicit labels for direct top-level terms, constructors, and operations; positional-prefix/labeled-suffix exact arity; source-order evaluation; positional kernel/hash parity; store reopen/rename/conflict behavior; quote refusal; diagnostics; formatting; native parity; and advisory review warnings. | [named-call decision](../named-call-arguments/DECISION.md) |
 
 ### D39 Stable Identity
 
@@ -135,13 +142,21 @@ SS.21 and SS.22 timestamps and observed-command table below.
 - CLI auto-detection selects surface syntax only for `.jac`. Store add, replay,
   current Warp files, the prelude, and internal fixtures retain bootstrap
   routes.
+- Named calls remain limited to direct callables with an explicit ABI. There
+  are no defaults, puns, named local/HOF calls, or named syntax in quotes or
+  `.jqd`. `jac export` preserves the elaborated positional program and hashes,
+  but does not export the store companion needed by later named resolution.
+- SX.23's tests and protocol regression make no measured human-readability
+  claim; no named-argument cohort was added to the preregistered study.
 
 ## Deferred Scope
 
 D38 and D39 completed as SS.22 standard-library work without grammar changes.
 D36 generated accessors and label validation remain partial after SS.8 and the
 completed SS.0-SS.22 arc. D41-D42 operation modes now occupy their reviewed
-grammar headroom; resource-scoped row display remains unscheduled with no
+grammar headroom. SX.23 later spends the reviewed D76 call/parameter-label
+syntax without implementing D36 accessors or default/higher-order named calls;
+resource-scoped row display remains unscheduled with no
 syntax, semantics, or compatibility promise.
 Their separate acceptance gates are the
 [D36 accessor criteria](FOLLOWUPS.md#d36-generated-constructor-accessors),
@@ -216,4 +231,5 @@ Successor milestone **EL.4, explicit surface operation modes**, is complete at
 the D41-D42 evidence boundary. This updates the grammar and evidence; it does
 not freeze the surface or claim production stability. D36 accessor generation
 and label validation plus resource-scoped-row headroom retain their own later
-acceptance gates.
+acceptance gates. SX.23 is separately complete at the D76 named-call evidence
+boundary linked above.

--- a/docs/release/surface-syntax/FOLLOWUPS.md
+++ b/docs/release/surface-syntax/FOLLOWUPS.md
@@ -5,8 +5,10 @@ milestone **SS.22, prelude naming and text building**, completed D38 and D39
 without changing the surface grammar. The SS.0-SS.22 implementation arc is
 complete. SX.24 subsequently shipped labeled partial patterns, but D36 accessor
 generation and its broader declaration validation remain deliberately partial,
-and Tier-F remains parked. None of this ledger establishes stability or a
-freeze for the whole surface syntax.
+and Tier-F remains parked. SX.23 separately shipped direct named calls with
+explicit term/operation labels and constructor field-label reuse; it did not
+ship accessors, defaults, label puns, or named local/higher-order calls. None of
+this ledger establishes stability or a freeze for the whole surface syntax.
 
 ## D36 Generated Constructor Accessors
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -286,6 +286,15 @@ bool.or-else  : (Bool, () ->{| e} Bool) ->{| e} Bool
 A future surface `&&` desugars to `match`, costing nothing. Until then the library
 refuses to pretend strict application short-circuits.
 
+`Bool` is still the right result for predicates and ordinary boolean data. For
+an argument that selects behavior, prefer a purpose-specific sum such as
+`type Mode = | Live | DryRun`; its constructors make the call and later match
+auditable. When a direct term or operation publishes a usable companion label
+for the relevant slot, the checker reports advisory W1206 for a direct positional `True`/`False`
+argument and W1207 for a definite adjacent run of same-typed positional
+parameters. Explicit named arguments suppress those warnings. Neither warning changes typing or claims that a
+human readability study has measured an improvement.
+
 ## 4. Ring 1: control effects and their handlers
 
 Four effects cover pure control. Each is shown with its declaration and the handlers

--- a/docs/surface-syntax.md
+++ b/docs/surface-syntax.md
@@ -6,7 +6,8 @@ what it optimizes for, and what it looks like, form by form, with the
 desugaring of each.
 
 Short version: the printer-first, delimiter-based surface with one infix
-operator ships. Executable display examples have migrated to this grammar;
+operator, labeled constructor patterns, explicit operation modes, marked text,
+and direct named calls ship. Executable display examples have migrated to this grammar;
 fences labeled as doctests run in CI, while deliberately schematic snippets
 stay labeled as pseudocode rather than being claimed as compilable source.
 
@@ -25,8 +26,8 @@ roughly 1,900 lines written by two different models.
 Draft 0.2 supplied the reviewed design for the completed SS.0-SS.22
 implementation arc. This document now records both that design and the exact
 shipped boundary; it is not a claim that the whole surface grammar is stable or
-frozen. Decisions D27-D42 in section 10 remain the design record, with D36
-formally partial as described below. Any later revision must record and review
+frozen. Decisions D27-D42, D75, and D76 in section 10 remain the surface design
+record, with D36 formally partial as described below. Any later revision must record and review
 its decision change rather than quietly choosing different syntax.
 
 This work is post-0.1 and follows the completed native differential harness
@@ -40,6 +41,9 @@ and D39 completed in SS.22 as standard-library work without expanding the
 grammar. D36 generated accessors and D36 label validation remain separate
 follow-ups. The later explicit-dictionary decision ratifies ordinary `Eq`,
 `Ord`, `Show`, and `Num` values without adding syntax or changing lowering.
+SX.23 adds D76 direct named calls as another projection: labels elaborate to
+the existing positional `App`/`Let` forms, while a versioned hash-bound store
+companion preserves the external term and operation ABI across name changes.
 
 There is one explicit compatibility reservation in the generic pre-resolution form layer:
 `(surface-ref-v0 con name)` and `(surface-ref-v0 op name)`. Surface lowering uses these forms to
@@ -70,19 +74,19 @@ and the L7 grammar-growth tripwire.
 file          := seps? [top-item (seps top-item)*] seps?
 top-item      := signature | definition | type-decl | effect-decl | expr | raw-top
 signature     := term-name ":" cont type
-definition    := term-name ["(" patterns? ")"] "=" cont expr
+definition    := term-name ["(" ([term-name ":" cont] pattern ("," [term-name ":" cont] pattern)*)? ")"] "=" cont expr
 type-decl     := "type" type-name type-vars? "=" cont "|"? constructor (seps? "|" cont constructor)*
 constructor   := con-name type-atom* | con-name "(" fields? ")"
 field         := [term-name ":" cont] type
 effect-decl   := mode "effect" effect-name type-vars? "where" "{" seps? uniform-op-signature (seps uniform-op-signature)* seps? "}"
 | "effect" effect-name type-vars? "where" "{" seps? mode-op-signature (seps mode-op-signature)* seps? "}"
-uniform-op-signature := op-name ":" cont "(" types? ")" "->" cont type
-mode-op-signature := mode op-name ":" cont "(" types? ")" "->" cont type
+uniform-op-signature := op-name ":" cont "(" ([term-name ":" cont] type ("," [term-name ":" cont] type)*)? ")" "->" cont type
+mode-op-signature := mode op-name ":" cont "(" ([term-name ":" cont] type ("," [term-name ":" cont] type)*)? ")" "->" cont type
 mode          := "once" | "multi"
 raw-top       := "jqd" raw-bootstrap-form
 
 expr          := call (cont "|>" cont call)*
-call          := primary ("(" exprs? ")")*
+call          := primary ("(" ([term-name ":" cont] expr ("," [term-name ":" cont] expr)*)? ")")*
 primary       := literal | marked-text | value-name | internal-ref | paren | tuple | list | block | fn
 | match | if | handle | quote | unquote | annotation
 paren         := "(" expr ")"
@@ -222,6 +226,10 @@ Effect parameters may be unused by an operation:
 ```jacquard
 multi effect Choice a where {
   choose : () -> Bool
+}
+
+once effect Sending where {
+  send : (path: Text, body: Text) -> Text
 }
 ```
 
@@ -541,6 +549,60 @@ blank lines may appear between them, and nothing else may. Field-exercise
 code routinely put a blank line there, so the grammar has to allow it
 explicitly rather than reject it by accident.
 
+### Calls and named arguments
+
+Calls are exact-arity and uncurried. Ordinary positional calls remain valid.
+For a public API where a swap would be hard to review, a top-level equation
+may declare an explicit external label before its local binder:
+
+```jacquard
+resize(image, scale: ratio) = (image, ratio)
+
+resize(photo, scale: 2)
+```
+
+The unlabeled parameters and arguments form one positional prefix. Every
+labeled parameter or argument follows that prefix, but labeled arguments may
+otherwise be written in any order. There are no defaults, label puns, partial
+calls, or positional arguments after the first label. Each slot must be filled
+exactly once. A declaration label and its binder are deliberately different
+things: `scale` is the API name above; `ratio` is an alpha-renamable local.
+
+Three direct callable forms expose labels. Top-level equation parameters use
+`label: binder`; operation parameter types use `label: Type`; constructors
+reuse their declared field labels. Same-SCC top-level calls are included.
+Local lambdas, values returned by higher-order code, patterned parameters,
+variadics, opaque hash references without a companion, and otherwise
+unlabeled callees remain positional-only. Resolution reports E0309 rather than
+guessing a label from a binder name. E0310-E0314 cover unknown labels,
+duplicate or overlapping slots, incomplete arity, invalid declarations, and
+ambiguous constructor schemas.
+
+Named arguments evaluate exactly once from left to right as authored. When
+their order differs from the declaration, resolution lowers them to generated
+left-to-right `Let` bindings followed by the existing declaration-order
+positional `App`. A declaration-order named call therefore has the same
+kernel form and hash as its positional twin; a reordered call has the same
+hash as the equivalent explicit-let positional program. Interpreter and native
+execution consume only those existing forms.
+
+Term and operation labels live in an additive, versioned `call-abi-v1`
+companion in `names.jqd`, keyed by the exact derived callable hash. The
+companion survives store reopen, public rename, and local-binder rename. A
+different label vector for that same hash is rejected with E0612 instead of
+silently changing the API. Constructor labels already participate in their
+schema identity. Explicit `jac export` output remains positional `.jqd` and
+does not carry this companion; it preserves the elaborated program's identity
+but is not a standalone source of labels for later `.jac` resolution.
+
+When a direct term or operation publishes a usable companion label for the hotspot, W1206
+advises against a direct positional `True`/`False` argument and W1207 marks a
+definite adjacent run of same-typed positional parameters where a swap could
+still typecheck. Named calls suppress both review warnings. For a behavioral
+boolean, a purpose-specific sum such as `type Mode = | Live | DryRun` is often
+clearer than either spelling. These warnings are advisory and make no measured
+human-readability claim.
+
 ### Blocks, let, sequencing
 
 ```
@@ -686,6 +748,10 @@ It did not generate accessor definitions, so `fleet.inv` remains unresolved
 unless declared explicitly. Both field exercises invented this exact
 `Ctor(field: Type, ...)` notation independently. SX.24 now reuses those labels
 for partial constructor patterns (§5, Match) without generating accessors.
+SX.23 separately reuses constructor labels for direct named construction and
+allows operations to declare external call labels as `label: Type`. Operation
+labels do not alter the operation's kernel type or identity; their exact vector
+is persisted by the hash-bound `call-abi-v1` companion described under Calls.
 
 Every operation has an explicit mode. A uniform effect uses the canonical
 `once effect` or `multi effect` shorthand; an effect containing both modes
@@ -780,6 +846,11 @@ markers, but `surface-ref-v0` is a reserved head: malformed arity, argument sort
 validation errors even when nested as quote data. The normative grammar and diagnostics are in
 `spec/jacquard-kernel-ast-m0.md` §4.1; byte-level compatibility is in `spec/serialization.md`.
 
+Named calls are E1238 anywhere inside a surface quote, including inside a live
+`unquote`: the quoted carrier has positional `App` but no durable representation
+for call labels. Write the quoted call positionally. Labeled constructor
+patterns have the parallel E1237 boundary.
+
 Delimiter recovery is construct-aware for `quote`, `match`, `if`, `handle`, and expression blocks.
 The primary diagnostic points at the token or EOF where closing became impossible and its hint
 points back to the construct's opening span. The recovery tree receives a synthetic, metadata-marked
@@ -830,7 +901,10 @@ evidence that braces measurably hurt).
 
 Generated constructor accessors and their cross-constructor declaration
 validation remain parked D36 follow-ups. Labeled declarations and partial
-label-selecting constructor patterns ship without record syntax.
+label-selecting constructor patterns ship without record syntax. Named calls
+ship only for the direct, explicit ABI boundary above; default arguments,
+label puns, named higher-order/local calls, and inference from binder names are
+excluded.
 Predicate/comparison naming (D39: `?`-suffixed predicates beside bare
 dictionary names, `gte?/lte?/gt?/lt?`, the `real.*` rename); both of these
 are stdlib content, not grammar, and land in docs/stdlib.md rather than
@@ -876,7 +950,7 @@ syntax follows each file extension and uses surface rendering when either source
 operands, malformed source, and top-level source expressions are diagnostics with exit status 1.
 Store/store comparison keeps its full-store, bootstrap-rendered default.
 
-Two diagnostics belong to this slice specifically. First, a bare reference
+The original surface slice added two diagnostics specifically. First, a bare reference
 passed where a thunk type is expected (`fn () -> naive-checkout()` is the
 correct form; a bare `naive-checkout` where a `() ->{| e} T` is wanted is not,
 since top-level definitions close their rows) should say so in surface
@@ -889,15 +963,23 @@ program meaning without raising an error: the pattern silently becomes an
 always-matching binder, so it warrants its own warning rather than reporting
 an unbound variable, or nothing at all.
 
+The named-call successor adds the E0309-E0314 resolution matrix, E0612 for a
+conflicting persistent ABI, and E1238 for quoted named syntax. Its W1206 and
+W1207 review warnings target direct positional booleans and definite
+same-typed parameter runs only when that term/operation API exposes an
+applicable companion label; they are advisory, do not fire for a named call, and are not evidence
+that named syntax is more readable to humans.
+
 ## 8. Migration
 
 Bootstrap s-expressions remain fully supported forever; they are the debug
 format, the quote-literal format, and the format of record for the kernel
 spec. The corpus gains a `.jac` twin for every `.jqd` program, and the
 differential harness compares hashes across the pair (L3). Stdlib and
-testing-doc examples migrate into doctest files. Nothing about the store,
-hashing, or the native backend changes at all, which is the projection
-thesis verified by construction.
+testing-doc examples migrate into doctest files. SX.23 adds only a versioned
+companion to the mutable store name index; kernel objects, `HASH_V0`, and the
+native backend remain unchanged, which is the projection thesis verified by
+construction.
 
 The corpus twins and doctests this phase produces should include, verbatim,
 the patterns the field exercise flagged as already working: a signature
@@ -962,3 +1044,4 @@ in commit messages and task dependencies.)
 | D41 | operation-mode granularity | per-operation `once`/`multi`, with `once effect`/`multi effect` shorthand only for uniform effects |
 | D42 | operation-mode defaults | no surface default; every operation is explicit, while bootstrap legacy `multi` remains encoded by absence |
 | D75 | text interpolation | `$"text {expr}"` lowers locally to one resolved variadic `text.join`; expressions are explicitly `Text`, `{` is escaped as `{{`, and nested marked interpolation is rejected in 0.1 |
+| D76 | named calls | explicit labels on direct top-level terms and operations, constructor field-label reuse, positional-prefix/labeled-suffix exact arity, source-order evaluation, and a versioned hash-bound companion ABI; locals/HOFs/defaults/puns and quoted named syntax are excluded |

--- a/src/check.ml
+++ b/src/check.ml
@@ -56,6 +56,8 @@ type ctx = {
   mutable sites : match_site list;
       (** match sites recorded for the exhaustiveness pass (W3.5), which runs after inference so
           scrutinee types are fully solved *)
+  mutable review_warnings : Diag.t list;
+      (** surface-only positional-call warnings collected during inference, newest first *)
   mutable origins : (Hash.t * string) list;
       (** effect hash -> a callee that introduced it (the manifest diagnostic's call-chain endpoint,
           W3.6) *)
@@ -204,6 +206,147 @@ let show_scheme ctx s =
 
 let surface_form_is meta forms =
   match Meta.surface_form meta with Some form -> List.mem form forms | None -> false
+
+let is_bool_ty ctx t =
+  match (Types.repr t, Store.lookup_kind ctx.store "bool" Resolve.KType) with
+  | TCon (identity, []), Some { Resolve.hash; _ } -> Hash.equal identity hash
+  | _ -> false
+
+let rec same_review_type left right =
+  match (Types.repr left, Types.repr right) with
+  | TVar left, TVar right -> left == right
+  | TSkolem (left, _), TSkolem (right, _) -> left = right
+  | TCon (left_hash, left_args), TCon (right_hash, right_args) ->
+      Hash.equal left_hash right_hash
+      && List.length left_args = List.length right_args
+      && List.for_all2 same_review_type left_args right_args
+  | TTuple left, TTuple right ->
+      List.length left = List.length right && List.for_all2 same_review_type left right
+  | TArrow (left_params, left_row, left_result), TArrow (right_params, right_row, right_result) ->
+      List.length left_params = List.length right_params
+      && List.for_all2 same_review_type left_params right_params
+      && same_review_row left_row right_row
+      && same_review_type left_result right_result
+  | TResume (left_input, left_row, left_answer), TResume (right_input, right_row, right_answer) ->
+      same_review_type left_input right_input
+      && same_review_row left_row right_row
+      && same_review_type left_answer right_answer
+  | ( TVariadicArrow (left_param, left_row, left_result),
+      TVariadicArrow (right_param, right_row, right_result) ) ->
+      same_review_type left_param right_param
+      && same_review_row left_row right_row
+      && same_review_type left_result right_result
+  | TExactThunk left, TExactThunk right -> same_review_type left right
+  | _ -> false
+
+and same_review_row left right =
+  let left = Types.repr_row left and right = Types.repr_row right in
+  List.length left.effects = List.length right.effects
+  && List.for_all2 Hash.equal left.effects right.effects
+  &&
+  match (left.tail, right.tail) with
+  | RClosed, RClosed -> true
+  | RSkolem (left, _), RSkolem (right, _) -> left = right
+  | RVar left, RVar right -> left == right
+  | _ -> false
+
+let first_labeled_repeated_parameter_run slots parameters =
+  let includes_labeled_slot start length =
+    List.mapi (fun index slot -> (index, slot)) slots
+    |> List.exists (fun (index, slot) ->
+        index >= start && index < start + length && Option.is_some slot)
+  in
+  let rec extend length previous = function
+    | next :: rest when same_review_type previous next -> extend (length + 1) next rest
+    | rest -> (length, rest)
+  in
+  let rec find start = function
+    | first :: second :: rest when same_review_type first second ->
+        let length, remaining = extend 2 second rest in
+        if includes_labeled_slot start length then Some (start, length, first)
+        else find (start + length) remaining
+    | _ :: rest -> find (start + 1) rest
+    | [] -> None
+  in
+  find 0 parameters
+
+let call_argument_meta (argument : Kernel.expr) =
+  let field_meta = Meta.surface_container "call-argument" argument.meta in
+  if Meta.is_empty field_meta then argument.meta else field_meta
+
+let usable_review_call_abi ctx (fn : Kernel.expr) =
+  let names = Store.names_view ctx.store in
+  let candidate =
+    match fn.it with
+    | Kernel.Ref (hash, (Kernel.Term | Kernel.Op)) -> names.Resolve.callable_abi hash
+    | _ -> None
+  in
+  let usable slots =
+    let rec labeled_suffix saw_label = function
+      | [] -> true
+      | Some _ :: rest -> labeled_suffix true rest
+      | None :: _ when saw_label -> false
+      | None :: rest -> labeled_suffix false rest
+    in
+    let labels = List.filter_map Fun.id slots in
+    labels <> [] && labeled_suffix false slots
+    && List.length labels = List.length (List.sort_uniq String.compare labels)
+  in
+  Option.bind candidate (fun slots -> if usable slots then Some slots else None)
+
+let positional_call_review_warning ctx ~fn ~meta ~params ~args ~arg_tys =
+  if
+    (not (surface_form_is meta [ "call"; "pipe" ]))
+    || List.exists
+         (fun (argument : Kernel.expr) -> Option.is_some (Meta.surface_call_label argument.meta))
+         args
+  then None
+  else
+    match usable_review_call_abi ctx fn with
+    | None -> None
+    | Some slots -> (
+        let behavioral_bool =
+          List.find_mapi
+            (fun index (((argument : Kernel.expr), actual), slot) ->
+              match (argument.it, slot) with
+              | Kernel.Ref (constructor, Kernel.Con), Some _ when is_bool_ty ctx actual ->
+                  Some (index, argument, constructor)
+              | _ -> None)
+            (List.combine (List.combine args arg_tys) slots)
+        in
+        match behavioral_bool with
+        | Some (index, argument, constructor) ->
+            let literal = Surface_name.render Surface_name.Con (name_of ctx constructor) in
+            Some
+              (Diag.warning
+                 ?span:(Meta.span (call_argument_meta argument))
+                 ~domain:Surface ~code:"W1206"
+                 ~summary:"Positional boolean argument is difficult to review"
+                 ~cause:
+                   (Printf.sprintf
+                      "Argument %d is the Bool constructor `%s`; the behavior it selects is not \
+                       visible from its position."
+                      (index + 1) literal)
+                 ~next_step:
+                   "Use the callable's explicit named argument, or replace a behavioral Bool with \
+                    a sum type such as `type Mode = | Live | DryRun`."
+                 ~contrast:None ())
+        | None -> (
+            match first_labeled_repeated_parameter_run slots params with
+            | Some (start, length, parameter) ->
+                Some
+                  (Diag.warning ?span:(Meta.span meta) ~domain:Surface ~code:"W1207"
+                     ~summary:"Same-typed positional arguments are difficult to distinguish"
+                     ~cause:
+                       (Printf.sprintf
+                          "Parameters %d through %d all have type %s, so a reordered call can \
+                           still typecheck."
+                          (start + 1) (start + length) (show_ty ctx parameter))
+                     ~next_step:
+                       "Use the callable's explicit labels for the ambiguous suffix, or use a \
+                        purpose-specific sum type such as `type Mode = | Live | DryRun`."
+                     ~contrast:None ())
+            | None -> None))
 
 let eta_expansion_candidate ctx expected actual =
   let rec constraint_body ty =
@@ -1017,6 +1160,12 @@ and infer ?(immediate_transformer = false) ctx env ~(ambient : row ref) ~(requir
                       ~code:"E0801" "%s: expected %s, got %s (%s)" what (show_ty ctx expected)
                       (show_ty ctx actual) detail))
             (List.combine args (List.combine params arg_tys));
+          let review_warning =
+            positional_call_review_warning ctx ~fn ~meta ~params ~args ~arg_tys
+          in
+          Option.iter
+            (fun warning -> ctx.review_warnings <- warning :: ctx.review_warnings)
+            review_warning;
           (* record who introduced each effect, for the manifest diagnostic (W3.6) *)
           (let callee =
              match fn.Kernel.it with
@@ -1778,6 +1927,7 @@ let make_ctx (store : Store.t) : (ctx, Diag.t list) result =
           level = 0;
           checking = [];
           sites = [];
+          review_warnings = [];
           origins = [];
           tier_apps = [];
           tier_ops = [];
@@ -1806,6 +1956,7 @@ let recovery_hashes identity bindings =
 let check_top_with ?recovery_identity ~recovery ctx (top : Kernel.top) :
     (top_sig, Diag.t list) result =
   ctx.sites <- [];
+  ctx.review_warnings <- [];
   match
     let partial =
       match top with
@@ -1863,11 +2014,19 @@ let check_top_with ?recovery_identity ~recovery ctx (top : Kernel.top) :
           | _ -> { names = []; row = None; warnings = [] })
     in
     (* exhaustiveness runs after inference so scrutinee types are solved (W3.5) *)
-    let warnings =
+    let match_warnings =
       if recovery && Recovery_marker.top top then (
         ctx.sites <- [];
         [])
       else check_matches ctx
+    in
+    let warning_offset diagnostic =
+      match Diag.span diagnostic with Some span -> span.Span.start_pos.offset | None -> max_int
+    in
+    let warnings =
+      List.rev ctx.review_warnings @ match_warnings
+      |> List.stable_sort (fun left right ->
+          Int.compare (warning_offset left) (warning_offset right))
     in
     { partial with warnings }
   with
@@ -1921,6 +2080,7 @@ module Recovery = struct
       level = 0;
       checking = [];
       sites = [];
+      review_warnings = [];
       origins = [];
       tier_apps = [];
       tier_ops = [];
@@ -2039,5 +2199,7 @@ let checker_codes : (string * string) list =
     ("E0818", "polymorphic reuse of a non-value local binding (value restriction)");
     ("E0819", "opaque Secret used by generic inspection or serialization");
     ("W0801", "redundant match clause");
+    ("W1206", "labeled API called with a positional Bool constructor literal");
+    ("W1207", "labeled API called across a definite repeated-type positional parameter run");
     ("E1202", "recovery marker rejected by the strict checker");
   ]

--- a/src/check.mli
+++ b/src/check.mli
@@ -50,7 +50,9 @@ type top_sig = {
   row : Types.row option;
   warnings : Diag.t list;
 }
-(** Signatures, optional expression effect row, and non-fatal diagnostics from one checked top. *)
+(** Signatures, optional expression effect row, and non-fatal diagnostics from one checked top.
+    W0801 covers redundant clauses; surface-authored positional term/operation calls with an
+    applicable explicit companion label may additionally produce review warnings W1206-W1207. *)
 
 val check_top : ctx -> Kernel.top -> (top_sig, Diag.t list) result
 (** [check_top ctx top] strictly checks resolved kernel input. Recovery markers fail with E1202;

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -41,6 +41,7 @@ let key_surface_ref_kind = "surface-ref-kind"
 let key_surface_reference = "surface-reference"
 let key_surface_signature = "surface-signature"
 let key_surface_pattern_label = "surface-pattern-label"
+let key_surface_call_label = "surface-call-label"
 
 (** [surface_container_key kind] is the reserved key for one named delimiter container. *)
 let surface_container_key kind = "surface-container/" ^ kind
@@ -220,6 +221,15 @@ let surface_pattern_label t =
 (** [with_surface_pattern_label label t] records an explicit constructor-pattern field selection. It
     never infers a label from a [PVar] spelling. *)
 let with_surface_pattern_label label t = add key_surface_pattern_label (Sym label) t
+
+(** [surface_call_label t] is an explicitly authored external argument label on a callable
+    parameter, operation parameter, or call argument. It is surface ABI/elaboration data and is
+    never inferred from a binder spelling. *)
+let surface_call_label t =
+  match find key_surface_call_label t with Some (Sym n | Text n) -> Some n | _ -> None
+
+(** [with_surface_call_label label t] records one explicit callable ABI or call-site label. *)
+let with_surface_call_label label t = add key_surface_call_label (Sym label) t
 
 (** [is_surface_reference t] is true only for a bare reference authored in `.jac`. Recovery and
     diagnostics use this hash-excluded marker to distinguish source references from bootstrap

--- a/src/resolve.ml
+++ b/src/resolve.ml
@@ -20,7 +20,8 @@
     Diagnostics (accumulated; resolution visits the whole tree): E0301 unknown name (with near-miss
     suggestions at edit distance <= 2), E0302 kind mismatch, E0303 duplicate binding name in a
     [defterm] group, E0304 duplicate variable in one pattern, and E0305-E0308 labeled-pattern schema
-    failures. *)
+    failures. E0309-E0314 cover missing, invalid, incomplete, or ambiguous explicit named-call ABIs
+    and call sites. *)
 
 (** What a name in scope refers to. [KCon]/[KOp] hashes are the folded constructor/operation hashes
     (decl hash + ordinal, derived in W1.5). *)
@@ -28,29 +29,42 @@ type nkind = KTerm | KCon | KOp | KType | KEffect
 
 type entry = { hash : Hash.t; kind : nkind }
 
+type call_abi = string option list
+(** Declaration-order callable slots. [None] is positional-only; [Some label] is one explicit
+    external label. A usable ABI has one unlabeled prefix and one uniquely labeled suffix. *)
+
 type names = {
   lookup : string -> entry list;
   all_names : unit -> string list;
   constructor_fields : Hash.t -> string option list option;
+  callable_abi : Hash.t -> call_abi option;
 }
 (** The resolver's view of a store. [lookup] returns EVERY binding of a name — the index is (name,
     kind)-keyed (SL.1), so an effect and its operation may share a bare name; kind- directed
     positions pick their kind, and value positions use term > con > op precedence.
     [constructor_fields] returns the declaration-order field labels for a resolved constructor; it
-    is the elaboration seam for labeled partial patterns. *)
+    is the elaboration seam for labeled partial patterns and constructor calls. [callable_abi]
+    returns an explicit, hash-bound v1 parameter-label vector for a term or operation and never
+    derives labels from binder names. *)
 
 let empty_names =
-  { lookup = (fun _ -> []); all_names = (fun () -> []); constructor_fields = (fun _ -> None) }
+  {
+    lookup = (fun _ -> []);
+    all_names = (fun () -> []);
+    constructor_fields = (fun _ -> None);
+    callable_abi = (fun _ -> None);
+  }
 
 (** [of_alist entries] builds a stub index (duplicate names with distinct kinds allowed); the W1.6
     store exposes the real one. [constructor_fields] may provide a constructor's declaration-order
     field labels for labeled-pattern expansion. It defaults to no schema, so a labeled pattern then
     fails with a diagnostic instead of guessing from binder names. *)
-let of_alist ?(constructor_fields = fun _ -> None) alist =
+let of_alist ?(constructor_fields = fun _ -> None) ?(callable_abi = fun _ -> None) alist =
   {
     lookup = (fun n -> List.filter_map (fun (m, e) -> if m = n then Some e else None) alist);
     all_names = (fun () -> List.map fst alist);
     constructor_fields;
+    callable_abi;
   }
 
 let kind_to_string = function
@@ -207,6 +221,336 @@ let duplicate_labels labels =
     labels;
   List.sort_uniq String.compare !duplicates
 
+type group_entry = { group_name : string; group_index : int; group_abi : call_abi option }
+
+let named_call_diagnostic st ~meta ~code ~summary ~cause ~next_step =
+  report st
+    (Diag.error ?span:(Meta.span meta) ~domain:Resolution ~code ~summary ~cause ~next_step
+       ~contrast:None ())
+
+let call_argument_meta (argument : Kernel.expr) =
+  let field_meta = Meta.surface_container "call-argument" argument.meta in
+  if Meta.is_empty field_meta then argument.meta else field_meta
+
+let call_parameter_meta parameter =
+  let field_meta = Meta.surface_container "call-parameter" parameter.Kernel.meta in
+  if Meta.is_empty field_meta then parameter.Kernel.meta else field_meta
+
+(** [declared_call_abi st ~what ~simple parameters] validates and returns an explicitly authored
+    callable ABI. It reports E0313 and returns [None] for patterned parameters, duplicate labels, or
+    an unlabeled slot after the labeled suffix. Entirely unlabeled declarations also return [None]
+    without a diagnostic. *)
+let declared_call_abi st ~what ~simple parameters =
+  let slots =
+    List.map (fun parameter -> Meta.surface_call_label parameter.Kernel.meta) parameters
+  in
+  if List.for_all Option.is_none slots then None
+  else
+    let first_patterned = List.find_opt (fun parameter -> not (simple parameter)) parameters in
+    let rec unlabeled_after_named saw_named = function
+      | [] -> None
+      | parameter :: rest -> (
+          match Meta.surface_call_label parameter.Kernel.meta with
+          | Some _ -> unlabeled_after_named true rest
+          | None when saw_named -> Some parameter
+          | None -> unlabeled_after_named false rest)
+    in
+    let duplicates = duplicate_labels (List.filter_map Fun.id slots) in
+    match (first_patterned, unlabeled_after_named false parameters, duplicates) with
+    | Some parameter, _, _ ->
+        named_call_diagnostic st ~meta:(call_parameter_meta parameter) ~code:"E0313"
+          ~summary:"This declaration cannot expose a named-call ABI."
+          ~cause:(Printf.sprintf "%s has a destructuring or wildcard parameter." what)
+          ~next_step:
+            "Use simple variable parameters throughout the callable, then label only its suffix.";
+        None
+    | None, Some parameter, _ ->
+        named_call_diagnostic st ~meta:(call_parameter_meta parameter) ~code:"E0313"
+          ~summary:"This declaration cannot expose a named-call ABI."
+          ~cause:(Printf.sprintf "%s has an unlabeled parameter after a labeled parameter." what)
+          ~next_step:"Keep every unlabeled parameter in one prefix before the labeled suffix.";
+        None
+    | None, None, duplicate :: _ ->
+        let parameter =
+          Option.value ~default:(List.hd parameters)
+            (List.find_opt
+               (fun parameter ->
+                 Option.equal String.equal
+                   (Meta.surface_call_label parameter.Kernel.meta)
+                   (Some duplicate))
+               (List.rev parameters))
+        in
+        named_call_diagnostic st ~meta:(call_parameter_meta parameter) ~code:"E0313"
+          ~summary:"This declaration cannot expose a named-call ABI."
+          ~cause:(Printf.sprintf "%s repeats external label `%s`." what duplicate)
+          ~next_step:"Give each labeled parameter one unique external label.";
+        None
+    | None, None, [] -> Some slots
+
+(** [binding_call_abi st binding] exposes labels only for a direct top-level lambda. *)
+let binding_call_abi st (binding : Kernel.binding) =
+  match binding.value.it with
+  | Kernel.Lam (parameters, _) ->
+      declared_call_abi st
+        ~what:(Printf.sprintf "Term `%s`" binding.bname)
+        ~simple:(fun parameter ->
+          match parameter.Kernel.it with Kernel.PVar _ -> true | _ -> false)
+        parameters
+  | _ -> None
+
+(** [operation_call_abi st operation] validates the operation's explicit parameter labels. *)
+let operation_call_abi st (operation : Kernel.opspec) =
+  declared_call_abi st
+    ~what:(Printf.sprintf "Operation `%s`" operation.op_name)
+    ~simple:(fun _ -> true)
+    operation.op_params
+
+(** [named_call_schema st group fn] returns a schema only for a direct resolved constructor, term,
+    operation, or same-SCC group member. Locals, higher-order values, and computed callees fail
+    closed by returning [None]. *)
+let named_call_schema st group fn =
+  match fn.Kernel.it with
+  | Kernel.Ref (hash, Kernel.Con) -> st.names.constructor_fields hash
+  | Kernel.Ref (hash, (Kernel.Term | Kernel.Op)) -> st.names.callable_abi hash
+  | Kernel.GroupRef index ->
+      Option.bind
+        (List.find_opt (fun entry -> entry.group_index = index) group)
+        (fun entry -> entry.group_abi)
+  | Kernel.Lit _ | Kernel.Var _ | Kernel.Lam _ | Kernel.App _ | Kernel.Let _ | Kernel.Match _
+  | Kernel.Tuple _ | Kernel.Handle _ | Kernel.Quote _ | Kernel.Unquote _ | Kernel.Ann _ ->
+      None
+
+(** [fresh_named_argument_names ~locals ~group count] creates printable, collision-free local
+    temporaries for source-order evaluation. *)
+let fresh_named_argument_names ~locals ~group count =
+  let occupied = Hashtbl.create (List.length locals + List.length group + count) in
+  List.iter (fun name -> Hashtbl.replace occupied name ()) locals;
+  List.iter (fun entry -> Hashtbl.replace occupied entry.group_name ()) group;
+  let rec choose ordinal suffix =
+    let name =
+      if suffix = 0 then Printf.sprintf "named-call-arg-%d" ordinal
+      else Printf.sprintf "named-call-arg-%d-%d" ordinal suffix
+    in
+    if Hashtbl.mem occupied name then choose ordinal (suffix + 1)
+    else begin
+      Hashtbl.add occupied name ();
+      name
+    end
+  in
+  List.init count (fun ordinal -> choose ordinal 0)
+
+let generated_meta marker source =
+  source |> Meta.without_trivia |> Meta.with_surface_generated marker
+
+(** [lower_reordered_named_call] evaluates every argument once in source order, then applies the
+    callee positionally in declaration order. It is called only for a nonempty exact-arity call. *)
+let lower_reordered_named_call ~locals ~group (source : Kernel.expr) fn source_arguments
+    ordered_sources =
+  let names = fresh_named_argument_names ~locals ~group (List.length source_arguments) in
+  let variables =
+    Array.of_list
+      (List.map2
+         (fun name argument ->
+           Kernel.
+             {
+               it = Var name;
+               meta = generated_meta "named-call-argument-reference" argument.Kernel.meta;
+             })
+         names source_arguments)
+  in
+  let final_arguments = List.map (Array.get variables) ordered_sources in
+  let final =
+    Kernel.
+      {
+        it = App (fn, final_arguments);
+        meta = generated_meta "named-call-positional-app" source.meta;
+      }
+  in
+  List.fold_right2
+    (fun name value body ->
+      let binder =
+        Kernel.{ it = PVar name; meta = generated_meta "named-call-argument-binder" value.meta }
+      in
+      let meta =
+        if String.equal name (List.hd names) then
+          Meta.with_surface_generated "named-call-reordered" source.meta
+        else generated_meta "named-call-argument-let" value.meta
+      in
+      Kernel.{ it = Let { isrec = false; binder; value; body }; meta })
+    names source_arguments final
+
+(** [elaborate_named_call st ~group ~locals source fn arguments] validates explicit labels and
+    returns the existing positional [App] representation. Invalid or unsupported sites report one of
+    E0309-E0314 and retain a structurally valid application for accumulated resolution. *)
+let elaborate_named_call st ~group ~locals (source : Kernel.expr) fn arguments =
+  let labels = List.map (fun argument -> Meta.surface_call_label argument.Kernel.meta) arguments in
+  if List.for_all Option.is_none labels then Kernel.{ source with it = App (fn, arguments) }
+  else
+    match named_call_schema st group fn with
+    | None ->
+        named_call_diagnostic st ~meta:source.meta ~code:"E0309"
+          ~summary:"This callee has no usable named-call ABI."
+          ~cause:
+            "Named arguments require a direct constructor, operation, or top-level term with \
+             explicit labels."
+          ~next_step:
+            "Call this value positionally, or declare an explicit labeled ABI on an eligible \
+             direct callable.";
+        Kernel.{ source with it = App (fn, arguments) }
+    | Some schema -> (
+        let rec positional_prefix count = function
+          | None :: rest -> positional_prefix (count + 1) rest
+          | Some _ :: _ | [] -> count
+        in
+        let prefix = positional_prefix 0 labels in
+        let malformed_order =
+          List.mapi (fun index label -> (index, label)) labels
+          |> List.find_opt (fun (index, label) -> index >= prefix && Option.is_none label)
+        in
+        let duplicate_call_labels = duplicate_labels (List.filter_map Fun.id labels) in
+        let schema_labels = List.filter_map Fun.id schema in
+        let duplicate_schema_labels = duplicate_labels schema_labels in
+        let rec schema_has_unlabeled_after_named saw_named = function
+          | [] -> false
+          | Some _ :: rest -> schema_has_unlabeled_after_named true rest
+          | None :: _ when saw_named -> true
+          | None :: rest -> schema_has_unlabeled_after_named false rest
+        in
+        let malformed_schema_order = schema_has_unlabeled_after_named false schema in
+        let unknown =
+          List.find_opt
+            (fun argument ->
+              match Meta.surface_call_label argument.Kernel.meta with
+              | Some label -> not (List.exists (String.equal label) schema_labels)
+              | None -> false)
+            arguments
+        in
+        let slot_for_label label =
+          let rec find index = function
+            | [] -> None
+            | Some candidate :: _ when String.equal label candidate -> Some index
+            | _ :: rest -> find (index + 1) rest
+          in
+          find 0 schema
+        in
+        let overlap =
+          List.find_opt
+            (fun argument ->
+              match Option.bind (Meta.surface_call_label argument.Kernel.meta) slot_for_label with
+              | Some slot -> slot < prefix
+              | None -> false)
+            arguments
+        in
+        let report_argument code summary cause next_step argument =
+          named_call_diagnostic st ~meta:(call_argument_meta argument) ~code ~summary ~cause
+            ~next_step
+        in
+        if schema_labels = [] then begin
+          named_call_diagnostic st ~meta:source.meta ~code:"E0309"
+            ~summary:"This callee has no usable named-call ABI."
+            ~cause:"The callable exposes no explicit external argument labels."
+            ~next_step:
+              "Call it positionally, or add an explicit labeled suffix to an eligible declaration.";
+          Kernel.{ source with it = App (fn, arguments) }
+        end
+        else if duplicate_schema_labels <> [] then begin
+          named_call_diagnostic st ~meta:source.meta ~code:"E0314"
+            ~summary:"This callee's named-call ABI is ambiguous."
+            ~cause:
+              (Printf.sprintf "Its ABI repeats label(s) %s."
+                 (String.concat ", " (List.map (Printf.sprintf "`%s`") duplicate_schema_labels)))
+            ~next_step:"Repair the callable declaration or its stored ABI before using labels.";
+          Kernel.{ source with it = App (fn, arguments) }
+        end
+        else if malformed_schema_order then begin
+          named_call_diagnostic st ~meta:source.meta ~code:"E0314"
+            ~summary:"This callee's named-call ABI is ambiguous."
+            ~cause:"Its ABI has an unlabeled slot after a labeled slot."
+            ~next_step:
+              "Move every unlabeled constructor field into one prefix before the labeled suffix.";
+          Kernel.{ source with it = App (fn, arguments) }
+        end
+        else if prefix > List.length schema || List.length arguments <> List.length schema then begin
+          named_call_diagnostic st ~meta:source.meta ~code:"E0312"
+            ~summary:"This named call does not fill the callable's exact arity."
+            ~cause:
+              (Printf.sprintf "The call supplies %d argument(s), but the ABI requires %d."
+                 (List.length arguments) (List.length schema))
+            ~next_step:"Supply every required slot exactly once; named calls have no defaults.";
+          Kernel.{ source with it = App (fn, arguments) }
+        end
+        else
+          match (malformed_order, duplicate_call_labels, unknown, overlap) with
+          | Some (index, _), _, _, _ ->
+              let argument = List.nth arguments index in
+              report_argument "E0312" "A positional argument follows a named argument."
+                "Named-call arguments must be a positional prefix followed by labeled arguments."
+                "Move this positional argument before every `label: expression` argument." argument;
+              Kernel.{ source with it = App (fn, arguments) }
+          | None, duplicate :: _, _, _ ->
+              let argument =
+                Option.value ~default:(List.hd arguments)
+                  (List.find_opt
+                     (fun argument ->
+                       Option.equal String.equal
+                         (Meta.surface_call_label argument.Kernel.meta)
+                         (Some duplicate))
+                     (List.rev arguments))
+              in
+              report_argument "E0311" "This call supplies one named slot more than once."
+                (Printf.sprintf "Label `%s` appears more than once in this call." duplicate)
+                "Keep exactly one argument for each external label." argument;
+              Kernel.{ source with it = App (fn, arguments) }
+          | None, [], Some argument, _ ->
+              let label = Option.get (Meta.surface_call_label argument.Kernel.meta) in
+              report_argument "E0310" "This callable has no slot with the selected label."
+                (Printf.sprintf "Label `%s` is not present in the callable's explicit ABI." label)
+                "Use one of the callable's declared external labels." argument;
+              Kernel.{ source with it = App (fn, arguments) }
+          | None, [], None, Some argument ->
+              let label = Option.get (Meta.surface_call_label argument.Kernel.meta) in
+              report_argument "E0311" "This call fills one slot both positionally and by label."
+                (Printf.sprintf "Label `%s` selects a slot already filled by the positional prefix."
+                   label)
+                "Remove the duplicate argument or shorten the positional prefix." argument;
+              Kernel.{ source with it = App (fn, arguments) }
+          | None, [], None, None -> (
+              let ordered = Array.make (List.length schema) None in
+              List.iteri
+                (fun source_index argument ->
+                  if source_index < prefix then ordered.(source_index) <- Some source_index
+                  else
+                    match
+                      Option.bind (Meta.surface_call_label argument.Kernel.meta) slot_for_label
+                    with
+                    | Some slot -> ordered.(slot) <- Some source_index
+                    | None -> ())
+                arguments;
+              let missing =
+                Array.to_list ordered
+                |> List.mapi (fun index source -> (index, source))
+                |> List.find_opt (fun (_, source) -> Option.is_none source)
+              in
+              match missing with
+              | Some (index, _) ->
+                  let description =
+                    match List.nth schema index with
+                    | Some label -> Printf.sprintf "labeled slot `%s`" label
+                    | None -> Printf.sprintf "unlabeled slot %d" (index + 1)
+                  in
+                  named_call_diagnostic st ~meta:source.meta ~code:"E0312"
+                    ~summary:"This named call leaves one required slot unfilled."
+                    ~cause:(Printf.sprintf "The call does not provide %s." description)
+                    ~next_step:
+                      "Extend the positional prefix or supply every remaining declared label.";
+                  Kernel.{ source with it = App (fn, arguments) }
+              | None ->
+                  let ordered_sources = List.map Option.get (Array.to_list ordered) in
+                  if ordered_sources = List.init (List.length arguments) Fun.id then
+                    Kernel.{ source with it = App (fn, arguments) }
+                  else lower_reordered_named_call ~locals ~group source fn arguments ordered_sources
+              ))
+
 let expand_labeled_pattern st ~meta hash patterns =
   let selections =
     List.filter_map
@@ -351,7 +695,7 @@ and resolve_row st ~locals ~effectself (r : Kernel.row) : Kernel.row =
         r.Kernel.effects;
   }
 
-(* [group] maps defterm member names to their source-order index. *)
+(* [group] maps defterm member names to their source-order index and any explicit call ABI. *)
 let rec resolve_expr_in st ~group ~locals (e : Kernel.expr) : Kernel.expr =
   let mk it = { e with Kernel.it } in
   match e.Kernel.it with
@@ -366,8 +710,12 @@ let rec resolve_expr_in st ~group ~locals (e : Kernel.expr) : Kernel.expr =
       in
       if lexical && List.mem x locals then e
       else
-        match if lexical then List.assoc_opt x group else None with
-        | Some i -> { Kernel.it = Kernel.GroupRef i; meta = Meta.with_name x e.Kernel.meta }
+        match
+          if lexical then List.find_opt (fun entry -> String.equal entry.group_name x) group
+          else None
+        with
+        | Some entry ->
+            { Kernel.it = Kernel.GroupRef entry.group_index; meta = Meta.with_name x e.Kernel.meta }
         | None -> (
             let entries = st.names.lookup x in
             let value_entries =
@@ -426,7 +774,7 @@ let rec resolve_expr_in st ~group ~locals (e : Kernel.expr) : Kernel.expr =
                 | [] ->
                     (* sibling group members count as near-miss candidates too *)
                     unknown st ~meta:e.Kernel.meta
-                      ~locals:(List.map fst group @ locals)
+                      ~locals:(List.map (fun entry -> entry.group_name) group @ locals)
                       ~what:"name" x;
                     e)))
   | Kernel.Lam (params, body) ->
@@ -436,9 +784,9 @@ let rec resolve_expr_in st ~group ~locals (e : Kernel.expr) : Kernel.expr =
            ( List.map (resolve_pat st ~locals) params,
              resolve_expr_in st ~group ~locals:(bound @ locals) body ))
   | Kernel.App (fn, args) ->
-      mk
-        (Kernel.App
-           (resolve_expr_in st ~group ~locals fn, List.map (resolve_expr_in st ~group ~locals) args))
+      let fn = resolve_expr_in st ~group ~locals fn in
+      let args = List.map (resolve_expr_in st ~group ~locals) args in
+      elaborate_named_call st ~group ~locals e fn args
   | Kernel.Let { isrec; binder; value; body } ->
       let bound = pat_vars st binder in
       let value_locals = if isrec then bound @ locals else locals in
@@ -547,7 +895,16 @@ let resolve_decl_in st (d : Kernel.decl) : Kernel.decl =
   let it =
     match d.Kernel.it with
     | Kernel.DefTerm bindings ->
-        let group = List.mapi (fun i b -> (b.Kernel.bname, i)) bindings in
+        let group =
+          List.mapi
+            (fun index binding ->
+              {
+                group_name = binding.Kernel.bname;
+                group_index = index;
+                group_abi = binding_call_abi st binding;
+              })
+            bindings
+        in
         let seen = Hashtbl.create 8 in
         List.iter
           (fun b ->
@@ -586,6 +943,7 @@ let resolve_decl_in st (d : Kernel.decl) : Kernel.decl =
                 cons;
           }
     | Kernel.DefEffect { ename; evars; ops } ->
+        List.iter (fun operation -> ignore (operation_call_abi st operation)) ops;
         Kernel.DefEffect
           {
             ename;

--- a/src/store.ml
+++ b/src/store.ml
@@ -7,7 +7,9 @@
     - [names.jqd] — the public index, the only mutable file. Named entries are
       [(named <name> <kind> #<hash>)] forms, kinds [term|con|op|type|effect], kept sorted;
       [(hidden #<derived-hash>)] entries persist opaque host-value members that must not be
-      reconstructed by direct hash after reopen.
+      reconstructed by direct hash after reopen; additive
+      [(call-abi-v1 #<derived-hash> (slot positional|named ...)...)] entries persist explicit
+      surface call labels for eligible term and operation identities.
 
     Derived hashes (defterm members, constructors, operations) have no object files of their own; an
     in-memory index from every known hash to its owning declaration is rebuilt by scanning
@@ -16,7 +18,7 @@
 
     Failure modes: E0601 unknown hash, E0602 unknown name, E0603 corrupt object file, E0604
     unnameable target (a defterm group's whole hash), E0605 invalid name, E0607 ambiguous name
-    needing a kind. *)
+    needing a kind, and E0612 conflicting hash-bound call ABI. *)
 
 type role = Whole | Member of int | Constructor of int | Operation of int
 type located = { decl : Kernel.decl; decl_hash : Hash.t; role : role }
@@ -25,6 +27,8 @@ type t = {
   root : string;
   mutable names : (string * Resolve.entry) list; (* sorted by name *)
   mutable hidden : Hash.t list; (* sorted derived hashes intentionally absent from public lookup *)
+  mutable call_abis : (Hash.t * Resolve.call_abi) list;
+      (* sorted, versioned surface-call ABI companions bound to derived hashes *)
   mutable index : (Hash.t * (Hash.t * role)) list; (* any hash -> owning decl hash + role *)
 }
 
@@ -65,6 +69,10 @@ let diagnostic_spec = function
   | "E0610" ->
       ( "A diff source contains a runnable top-level expression.",
         "Compare declaration-only source artifacts or stores." )
+  | "E0612" ->
+      ( "A callable hash already has a different named-call ABI.",
+        "Keep the published labels, or make a semantic code change that gives the callable a new \
+         hash." )
   | code -> raise (Diag.Bug_invalid_diagnostic ("unknown store diagnostic code " ^ code))
 
 let diagnostic ~code cause =
@@ -120,18 +128,28 @@ let sort_names ns =
       | c -> c)
     ns
 
-let render_names names hidden =
+(** [call_abi_slot_form slot] renders one validated v1 positional or named slot. *)
+let call_abi_slot_form = function
+  | None -> Form.form "slot" [ Form.Sym "positional" ]
+  | Some label -> Form.form "slot" [ Form.Sym "named"; Form.Sym label ]
+
+let render_names names hidden call_abis =
   Printer.print_all
     (List.map
        (fun (n, { Resolve.hash; kind }) ->
          Form.form "named" [ Form.Sym n; Form.Sym (kind_sym kind); Form.Hash hash ])
        names
-    @ List.map (fun hash -> Form.form "hidden" [ Form.Hash hash ]) hidden)
+    @ List.map (fun hash -> Form.form "hidden" [ Form.Hash hash ]) hidden
+    @ List.map
+        (fun (hash, slots) ->
+          Form.form "call-abi-v1"
+            (Form.Hash hash :: List.map (fun slot -> Form.F (call_abi_slot_form slot)) slots))
+        call_abis)
 
 let write_names t =
   (* render fully before opening: open_out_bin truncates, and a render failure after
      truncation would destroy the index *)
-  let rendered = render_names t.names t.hidden in
+  let rendered = render_names t.names t.hidden t.call_abis in
   let oc = open_out_bin (names_file t) in
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc rendered)
 
@@ -139,17 +157,49 @@ let parse_names ~file src =
   match Reader.parse_string ~file src with
   | Error ds -> Error ds
   | Ok forms ->
-      let rec go names hidden = function
-        | [] -> Ok (List.rev names, List.sort_uniq Hash.compare hidden)
+      let parse_slot = function
+        | { Form.head = "slot"; args = [ Form.Sym "positional" ]; _ } -> Ok None
+        | { Form.head = "slot"; args = [ Form.Sym "named"; Form.Sym label ]; _ }
+          when Reader.valid_library_symbol label ->
+            Ok (Some label)
+        | _ -> err ~code:"E0603" "corrupt names.jqd: malformed call-abi-v1 slot"
+      in
+      let rec parse_slots acc = function
+        | [] -> Ok (List.rev acc)
+        | Form.F slot :: rest -> (
+            match parse_slot slot with
+            | Ok slot -> parse_slots (slot :: acc) rest
+            | Error _ as error -> error)
+        | _ :: _ -> err ~code:"E0603" "corrupt names.jqd: malformed call-abi-v1 argument"
+      in
+      let rec go names hidden call_abis = function
+        | [] ->
+            Ok
+              ( List.rev names,
+                List.sort_uniq Hash.compare hidden,
+                List.sort (fun (left, _) (right, _) -> Hash.compare left right) call_abis )
         | { Form.head = "named"; args = [ Form.Sym n; Form.Sym k; Form.Hash h ]; _ } :: rest -> (
             match kind_of_sym k with
             | Some _ when scheduler_private_hash h -> Error [ private_name_diagnostic n h ]
-            | Some kind -> go ((n, { Resolve.hash = h; kind }) :: names) hidden rest
+            | Some kind -> go ((n, { Resolve.hash = h; kind }) :: names) hidden call_abis rest
             | None -> err ~code:"E0603" "corrupt names.jqd: unknown kind `%s`" k)
-        | { Form.head = "hidden"; args = [ Form.Hash h ]; _ } :: rest -> go names (h :: hidden) rest
+        | { Form.head = "hidden"; args = [ Form.Hash h ]; _ } :: rest ->
+            go names (h :: hidden) call_abis rest
+        | { Form.head = "call-abi-v1"; args = Form.Hash hash :: slots; _ } :: rest -> (
+            match parse_slots [] slots with
+            | Error _ as error -> error
+            | Ok slots -> (
+                match List.assoc_opt hash call_abis with
+                | Some prior when prior <> slots ->
+                    err ~code:"E0603" "corrupt names.jqd: conflicting call ABI for %s"
+                      (Hash.to_hex hash)
+                | Some _ ->
+                    err ~code:"E0603" "corrupt names.jqd: duplicate call ABI for %s"
+                      (Hash.to_hex hash)
+                | None -> go names hidden ((hash, slots) :: call_abis) rest))
         | f :: _ -> err ~code:"E0603" "corrupt names.jqd: unexpected `%s` form" f.Form.head
       in
-      go [] [] forms
+      go [] [] [] forms
 
 (* --- objects --- *)
 
@@ -189,19 +239,20 @@ let index_entries (decl : Kernel.decl) (hs : Canon.decl_hashes) =
     from the object files. A persisted name exposing a scheduler-private hash is rejected with E0907
     before the index becomes observable. *)
 let open_store root : (t, Diag.t list) result =
-  let t = { root; names = []; hidden = []; index = [] } in
+  let t = { root; names = []; hidden = []; call_abis = []; index = [] } in
   if not (Sys.file_exists root) then Sys.mkdir root 0o755;
   if not (Sys.file_exists (objects_dir t)) then Sys.mkdir (objects_dir t) 0o755;
   let names_res =
     if Sys.file_exists (names_file t) then
       parse_names ~file:(names_file t) (read_file (names_file t))
-    else Ok ([], [])
+    else Ok ([], [], [])
   in
   match names_res with
   | Error ds -> Error ds
-  | Ok (names, hidden) -> (
+  | Ok (names, hidden, call_abis) -> (
       t.names <- names;
       t.hidden <- hidden;
+      t.call_abis <- call_abis;
       let rec scan acc = function
         | [] -> Ok acc
         | file :: rest -> (
@@ -226,7 +277,65 @@ let open_store root : (t, Diag.t list) result =
              store-backed library code can evaluate them. [locate] is the public boundary and
              rejects them; [locate_internal] is reserved for evaluating such stored code. *)
           t.index <- index;
-          Ok t)
+          let valid_slots slots =
+            let labels = List.filter_map Fun.id slots in
+            let rec suffix saw_named = function
+              | [] -> true
+              | Some _ :: rest -> suffix true rest
+              | None :: _ when saw_named -> false
+              | None :: rest -> suffix false rest
+            in
+            labels <> [] && suffix false slots
+            && List.length labels = List.length (List.sort_uniq String.compare labels)
+          in
+          let target_arity hash =
+            match List.find_opt (fun (known, _) -> Hash.equal known hash) index with
+            | None -> None
+            | Some (_, (decl_hash, role)) -> (
+                let path = object_path t decl_hash in
+                match load_object ~file:path (read_file path) with
+                | Error _ -> None
+                | Ok (decl, _) -> (
+                    match (decl.Kernel.it, role) with
+                    | Kernel.DefTerm bindings, Member member -> (
+                        match List.nth_opt bindings member with
+                        | Some { Kernel.value = { it = Kernel.Lam (params, _); _ }; _ }
+                          when List.for_all
+                                 (fun parameter ->
+                                   match parameter.Kernel.it with
+                                   | Kernel.PVar _ -> true
+                                   | Kernel.PWild | Kernel.PLit _ | Kernel.PCon _ | Kernel.PTuple _
+                                   | Kernel.PAs _ ->
+                                       false)
+                                 params ->
+                            Some (List.length params)
+                        | Some _ | None -> None)
+                    | Kernel.DefEffect { ops; _ }, Operation operation ->
+                        Option.map
+                          (fun op -> List.length op.Kernel.op_params)
+                          (List.nth_opt ops operation)
+                    | Kernel.DefTerm _, (Whole | Constructor _ | Operation _)
+                    | Kernel.DefType _, _
+                    | Kernel.DefEffect _, (Whole | Member _ | Constructor _) ->
+                        None))
+          in
+          let rec validate_abis = function
+            | [] -> Ok t
+            | (hash, slots) :: rest -> (
+                match target_arity hash with
+                | Some arity when arity = List.length slots && valid_slots slots ->
+                    validate_abis rest
+                | Some arity ->
+                    err ~code:"E0603"
+                      "corrupt names.jqd: call ABI for %s has %d slots for arity %d or invalid \
+                       labels"
+                      (Hash.to_hex hash) (List.length slots) arity
+                | None ->
+                    err ~code:"E0603"
+                      "corrupt names.jqd: call ABI target %s is not an eligible callable"
+                      (Hash.to_hex hash))
+          in
+          validate_abis call_abis)
 
 let entry_kind (decl : Kernel.decl) = function
   | Whole -> (
@@ -238,12 +347,55 @@ let entry_kind (decl : Kernel.decl) = function
   | Constructor _ -> Resolve.KCon
   | Operation _ -> Resolve.KOp
 
+(** [explicit_slots nodes] returns authored call labels, or [None] when every slot is positional. *)
+let explicit_slots nodes =
+  let slots = List.map (fun node -> Meta.surface_call_label node.Kernel.meta) nodes in
+  if List.for_all Option.is_none slots then None else Some slots
+
+(** [declaration_call_abis decl hashes] binds explicit term/operation labels to the corresponding
+    derived identities. Resolution already validated slot order, labels, and binder eligibility. *)
+let declaration_call_abis (decl : Kernel.decl) (hashes : Canon.decl_hashes) =
+  match decl.Kernel.it with
+  | Kernel.DefTerm bindings ->
+      List.map2
+        (fun binding (_, hash) ->
+          match binding.Kernel.value.it with
+          | Kernel.Lam (parameters, _) ->
+              Option.map (fun slots -> (hash, slots)) (explicit_slots parameters)
+          | _ -> None)
+        bindings hashes.Canon.named
+      |> List.filter_map Fun.id
+  | Kernel.DefEffect { ops; _ } ->
+      let operation_hashes = match hashes.Canon.named with [] -> [] | _effect :: rest -> rest in
+      List.map2
+        (fun operation (_, hash) ->
+          Option.map (fun slots -> (hash, slots)) (explicit_slots operation.Kernel.op_params))
+        ops operation_hashes
+      |> List.filter_map Fun.id
+  | Kernel.DefType _ -> []
+
+(** [merged_call_abis t proposed] adds identical or new companions and returns E0612 before any
+    store mutation when one hash is already bound to different labels. *)
+let merged_call_abis t proposed =
+  let rec merge current = function
+    | [] -> Ok (List.sort (fun (left, _) (right, _) -> Hash.compare left right) current)
+    | (hash, slots) :: rest -> (
+        match List.find_opt (fun (known, _) -> Hash.equal known hash) current with
+        | Some (_, prior) when prior = slots -> merge current rest
+        | Some _ ->
+            err ~code:"E0612" "callable %s is already bound to a different call-abi-v1 companion"
+              (Hash.to_hex hash)
+        | None -> merge ((hash, slots) :: current) rest)
+  in
+  merge t.call_abis proposed
+
 (** [put_decl t decl] canonicalizes, hashes, and stores a resolved declaration, then binds every
     public name it introduces (members, type + constructors, effect + operations) in the name index,
-    replacing existing bindings of the same names. The exact frozen Task opaque carrier is indexed
-    by hash for runtime validation but deliberately receives no public constructor name; any stale
-    private binding already in memory is evicted before [names.jqd] is rewritten. Idempotent on the
-    object file. *)
+    and installs any explicit term/operation [call-abi-v1] companion transactionally, replacing
+    existing bindings of the same names. The exact frozen Task opaque carrier is indexed by hash for
+    runtime validation but deliberately receives no public constructor name; any stale private
+    binding already in memory is evicted before [names.jqd] is rewritten. Idempotent on the object
+    file. *)
 let put_decl ?origin t (decl : Kernel.decl) : (Canon.decl_hashes, Diag.t list) result =
   let hashes =
     if Recovery_marker.decl decl then Error [ Recovery_marker.diagnostic "store insertion" ]
@@ -251,61 +403,66 @@ let put_decl ?origin t (decl : Kernel.decl) : (Canon.decl_hashes, Diag.t list) r
   in
   match hashes with
   | Error ds -> Error ds
-  | Ok hs ->
-      let path = object_path t hs.Canon.decl_hash in
-      if not (Sys.file_exists path) then begin
-        let oc = open_out_bin path in
-        output_string oc (Printer.print_all [ Kernel.decl_to_form decl ]);
-        close_out oc
-      end;
-      (match origin with
-      | Some tag -> (
-          (* first writer wins, matching the object's own immutability: content that
+  | Ok hs -> (
+      match merged_call_abis t (declaration_call_abis decl hs) with
+      | Error _ as error -> error
+      | Ok call_abis ->
+          let path = object_path t hs.Canon.decl_hash in
+          if not (Sys.file_exists path) then begin
+            let oc = open_out_bin path in
+            output_string oc (Printer.print_all [ Kernel.decl_to_form decl ]);
+            close_out oc
+          end;
+          (match origin with
+          | Some tag -> (
+              (* first writer wins, matching the object's own immutability: content that
              already carries provenance keeps it, and a differing re-stamp is noted *)
-          let opath = origin_path t hs.Canon.decl_hash in
-          if Sys.file_exists opath then
-            begin match read_file opath with
-            | existing when String.trim existing <> tag ->
-                Printf.eprintf "note: %s already stamped [%s]; keeping it\n%!"
-                  (String.sub (Hash.to_hex hs.Canon.decl_hash) 0 8)
-                  (String.trim existing)
-            | _ -> ()
-            | exception Sys_error _ -> ()
-            end
-          else
-            try
-              let oc = open_out_bin opath in
-              output_string oc (tag ^ "\n");
-              close_out oc
-            with Sys_error m -> Printf.eprintf "origin sidecar unwritable (%s)\n%!" m)
-      | None -> ());
-      let fresh = index_entries decl hs in
-      t.index <- fresh @ List.filter (fun (h, _) -> not (List.mem_assoc h fresh)) t.index;
-      let new_names =
-        List.filter_map
-          (fun (n, h) ->
-            match List.assoc_opt h fresh with
-            | Some (_, role)
-              when (not (List.exists (Hash.equal h) t.hidden)) && not (scheduler_private_hash h) ->
-                Some (n, { Resolve.hash = h; kind = entry_kind decl role })
-            | Some _ | None -> None)
-          hs.Canon.named
-      in
-      (* replacement is per (name, kind): a term named x does not evict a type named x *)
-      let evicted (n, (e : Resolve.entry)) =
-        List.exists
-          (fun (n', (e' : Resolve.entry)) -> n = n' && e.Resolve.kind = e'.Resolve.kind)
-          new_names
-      in
-      t.names <-
-        sort_names
-          (new_names
-          @ List.filter
-              (fun ((_, entry) as binding) ->
-                (not (scheduler_private_hash entry.Resolve.hash)) && not (evicted binding))
-              t.names);
-      write_names t;
-      Ok hs
+              let opath = origin_path t hs.Canon.decl_hash in
+              if Sys.file_exists opath then
+                begin match read_file opath with
+                | existing when String.trim existing <> tag ->
+                    Printf.eprintf "note: %s already stamped [%s]; keeping it\n%!"
+                      (String.sub (Hash.to_hex hs.Canon.decl_hash) 0 8)
+                      (String.trim existing)
+                | _ -> ()
+                | exception Sys_error _ -> ()
+                end
+              else
+                try
+                  let oc = open_out_bin opath in
+                  output_string oc (tag ^ "\n");
+                  close_out oc
+                with Sys_error m -> Printf.eprintf "origin sidecar unwritable (%s)\n%!" m)
+          | None -> ());
+          let fresh = index_entries decl hs in
+          t.index <- fresh @ List.filter (fun (h, _) -> not (List.mem_assoc h fresh)) t.index;
+          let new_names =
+            List.filter_map
+              (fun (n, h) ->
+                match List.assoc_opt h fresh with
+                | Some (_, role)
+                  when (not (List.exists (Hash.equal h) t.hidden)) && not (scheduler_private_hash h)
+                  ->
+                    Some (n, { Resolve.hash = h; kind = entry_kind decl role })
+                | Some _ | None -> None)
+              hs.Canon.named
+          in
+          (* replacement is per (name, kind): a term named x does not evict a type named x *)
+          let evicted (n, (e : Resolve.entry)) =
+            List.exists
+              (fun (n', (e' : Resolve.entry)) -> n = n' && e.Resolve.kind = e'.Resolve.kind)
+              new_names
+          in
+          t.names <-
+            sort_names
+              (new_names
+              @ List.filter
+                  (fun ((_, entry) as binding) ->
+                    (not (scheduler_private_hash entry.Resolve.hash)) && not (evicted binding))
+                  t.names);
+          t.call_abis <- call_abis;
+          write_names t;
+          Ok hs)
 
 (** [origin t h] reads the provenance sidecar of the declaration owning [h], if any. A
     present-but-unreadable or empty sidecar is ignored with a warning, never fatal. *)
@@ -432,8 +589,9 @@ let hide_derived t hash =
   | Some (_, (_, Whole)) | None -> ()
 
 (** [names_view t] is the resolver's view of this store (the W1.4 seam). Constructor-schema lookup
-    returns declaration-order field labels only for constructor identities present in [t]; missing,
-    malformed, and non-constructor identities return [None]. *)
+    returns declaration-order field labels only for constructor identities present in [t]; callable
+    ABI lookup returns validated hash-bound term/operation companions. Missing, malformed, and
+    ineligible identities return [None]. *)
 let names_view t : Resolve.names =
   let constructor_fields hash =
     match List.find_opt (fun (known, _) -> Hash.equal known hash) t.index with
@@ -451,6 +609,9 @@ let names_view t : Resolve.names =
     Resolve.lookup = (fun n -> lookup_all t n);
     all_names = (fun () -> List.map fst t.names);
     constructor_fields;
+    callable_abi =
+      (fun hash ->
+        Option.map snd (List.find_opt (fun (known, _) -> Hash.equal known hash) t.call_abis));
   }
 
 (** [bind_name t name hash] binds [name] to a hash already known to the store. Fails on an

--- a/src/surface_check.ml
+++ b/src/surface_check.ml
@@ -471,7 +471,7 @@ let deduplicate diagnostics =
       if List.exists (same_diagnostic diagnostic) unique then unique else unique @ [ diagnostic ])
     [] diagnostics
 
-let analysis_names base additions =
+let analysis_names base additions call_abis =
   let lookup name =
     let local =
       List.filter_map
@@ -488,6 +488,11 @@ let analysis_names base additions =
     Resolve.lookup;
     all_names = (fun () -> List.map fst !additions @ base.Resolve.all_names ());
     constructor_fields = base.Resolve.constructor_fields;
+    callable_abi =
+      (fun hash ->
+        match List.find_opt (fun (known, _) -> Hash.equal known hash) !call_abis with
+        | Some (_, abi) -> Some abi
+        | None -> base.Resolve.callable_abi hash);
   }
 
 let recovery_member_hashes identity bindings =
@@ -497,6 +502,15 @@ let recovery_member_hashes identity bindings =
         (Printf.sprintf "surface-recovery-member:%s:%d:%s" identity index binding.Kernel.bname))
     bindings
 
+let binding_call_abi (binding : Kernel.binding) =
+  match binding.value.it with
+  | Kernel.Lam (parameters, _) ->
+      let slots =
+        List.map (fun parameter -> Meta.surface_call_label parameter.Kernel.meta) parameters
+      in
+      if List.for_all Option.is_none slots then None else Some slots
+  | _ -> None
+
 (** [analyze ~names ctx recovered] returns parser diagnostics, surface lints, and at most one
     resolution/checking error per lowered top-level island, all in deterministic source order. Holes
     behave as fresh types and contribute no effects, allowing later independent definitions to be
@@ -505,7 +519,8 @@ let recovery_member_hashes identity bindings =
 let analyze ~names ctx (recovered : Surface_ast.recovered) : report =
   let recovery = Check.start_recovery ctx in
   let additions = ref [] in
-  let evolving_names = analysis_names names additions in
+  let call_abis = ref [] in
+  let evolving_names = analysis_names names additions call_abis in
   let island = ref 0 in
   let diagnostics = ref (recovered.diagnostics @ lint ~names recovered.items) in
   let signatures = ref [] in
@@ -536,7 +551,14 @@ let analyze ~names ctx (recovered : Surface_ast.recovered) : report =
                         (fun binding hash ->
                           (binding.Kernel.bname, { Resolve.hash; kind = Resolve.KTerm }))
                         bindings hashes
-                      @ !additions
+                      @ !additions;
+                    call_abis :=
+                      (List.map2
+                         (fun binding hash ->
+                           Option.map (fun abi -> (hash, abi)) (binding_call_abi binding))
+                         bindings hashes
+                      |> List.filter_map Fun.id)
+                      @ !call_abis
                 | Kernel.Decl { Kernel.it = Kernel.DefType _ | Kernel.DefEffect _; _ }
                 | Kernel.Expr _ ->
                     ())))

--- a/src/surface_lower.ml
+++ b/src/surface_lower.ml
@@ -54,6 +54,11 @@ let diagnostic_spec = function
         "A labeled constructor pattern cannot be quoted.",
         "Use an explicit positional pattern inside `quote`, or move the labeled match outside the \
          quoted payload." )
+  | "E1238" ->
+      ( Diag.Surface,
+        "A named call argument cannot be quoted.",
+        "Use positional arguments inside `quote`, or move the named call outside the quoted \
+         payload." )
   | code -> raise (Diag.Bug_invalid_diagnostic ("unknown surface lowering code " ^ code))
 
 let diagnostic ?span ~code cause =
@@ -94,6 +99,57 @@ let generated_single_meta ~form meta =
 let generated_constructor_meta ~form meta =
   let* meta = generated_single_meta ~form meta in
   Ok (meta |> Meta.with_surface_generated form |> Meta.with_surface_ref_kind "con")
+
+let has_call_labels expressions =
+  List.exists
+    (fun (expression : Surface_ast.expr) ->
+      Option.is_some (Meta.surface_call_label expression.meta))
+    expressions
+
+let rec first_named_call_meta (expression : Surface_ast.expr) =
+  let expressions values = List.find_map first_named_call_meta values in
+  match expression.it with
+  | Surface_ast.Call (_, arguments) when has_call_labels arguments -> Some expression.meta
+  | Surface_ast.Call (fn, arguments) -> (
+      match first_named_call_meta fn with Some _ as found -> found | None -> expressions arguments)
+  | Surface_ast.Interpolation parts ->
+      List.find_map
+        (function
+          | Surface_ast.IText _ -> None | Surface_ast.IExpr item -> first_named_call_meta item)
+        parts
+  | Surface_ast.Fn (_, body) | Surface_ast.Unquote body | Surface_ast.Ann (body, _) ->
+      first_named_call_meta body
+  | Surface_ast.Tuple items | Surface_ast.List items -> expressions items
+  | Surface_ast.Block items ->
+      List.find_map
+        (function
+          | Surface_ast.Expr item -> first_named_call_meta item
+          | Surface_ast.Let binding -> first_named_call_meta binding.value)
+        items
+  | Surface_ast.Match (subject, clauses) -> (
+      match first_named_call_meta subject with
+      | Some _ as found -> found
+      | None ->
+          List.find_map
+            (fun (clause : Surface_ast.clause) -> first_named_call_meta clause.cbody)
+            clauses)
+  | Surface_ast.If (condition, yes, no) -> expressions [ condition; yes; no ]
+  | Surface_ast.Pipe (left, right) -> expressions [ left; right ]
+  | Surface_ast.Handle (body, ret, operations) -> (
+      match first_named_call_meta body with
+      | Some _ as found -> found
+      | None -> (
+          match first_named_call_meta ret.Surface_ast.rbody with
+          | Some _ as found -> found
+          | None ->
+              List.find_map
+                (fun (operation : Surface_ast.op_clause) -> first_named_call_meta operation.obody)
+                operations))
+  | Surface_ast.Quote (Surface_ast.Surface body) -> first_named_call_meta body
+  | Surface_ast.Quote (Surface_ast.Raw _)
+  | Surface_ast.Lit _ | Surface_ast.Name _ | Surface_ast.HashRef _ | Surface_ast.GroupRef _
+  | Surface_ast.Hole _ ->
+      None
 
 let rec lower_pat_at ~quote_depth (pat : Surface_ast.pat) : (Kernel.pat, Diag.t list) result =
   let node it = Kernel.{ it; meta = pat.meta } in
@@ -235,9 +291,16 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
   | Surface_ast.HashRef (hash, kind) -> Ok (node (Kernel.Ref (hash, kind)))
   | Surface_ast.GroupRef index -> Ok (node (Kernel.GroupRef index))
   | Surface_ast.Call (fn, args) ->
-      let* fn = lower_expr_node ~quote_depth fn in
-      let* args = map_results (lower_expr_node ~quote_depth) args in
-      Ok Kernel.{ it = App (fn, args); meta = Meta.with_surface_form "call" expr.meta }
+      let named = has_call_labels args in
+      if quote_depth > 0 && named then
+        error ~meta:expr.meta ~code:"E1238"
+          "quoted code stores positional kernel applications and cannot retain named argument \
+           labels"
+      else
+        let* fn = lower_expr_node ~quote_depth fn in
+        let* args = map_results (lower_expr_node ~quote_depth) args in
+        let surface_form_name = if named then "named-call" else "call" in
+        Ok Kernel.{ it = App (fn, args); meta = Meta.with_surface_form surface_form_name expr.meta }
   | Surface_ast.Fn (params, body) ->
       let* params = lower_lambda_params ~quote_depth params in
       let* body = lower_expr_node ~quote_depth body in
@@ -330,9 +393,16 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
       let* fn, args, right_meta =
         match right.Surface_ast.it with
         | Surface_ast.Call (fn, args) ->
-            let* fn = lower_expr_node ~quote_depth fn in
-            let* args = map_results (lower_expr_node ~quote_depth) args in
-            Ok (fn, args, Meta.with_surface_form "pipe-call" right.meta)
+            let named = has_call_labels args in
+            if quote_depth > 0 && named then
+              error ~meta:right.meta ~code:"E1238"
+                "quoted code stores positional kernel applications and cannot retain named \
+                 argument labels"
+            else
+              let* fn = lower_expr_node ~quote_depth fn in
+              let* args = map_results (lower_expr_node ~quote_depth) args in
+              let form = if named then "pipe-named-call" else "pipe-call" in
+              Ok (fn, args, Meta.with_surface_form form right.meta)
         | _ ->
             let* right = lower_expr_node ~quote_depth right in
             Ok ({ right with Kernel.meta = Meta.without_trivia right.meta }, [], right.meta)
@@ -361,6 +431,14 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
         match quote_body with
         | Surface_ast.Raw payload -> Ok payload
         | Surface_ast.Surface body ->
+            let* () =
+              match first_named_call_meta body with
+              | None -> Ok ()
+              | Some meta ->
+                  error ~meta ~code:"E1238"
+                    "quoted code stores positional kernel applications and cannot retain named \
+                     argument labels"
+            in
             let* body = lower_expr_node ~quote_depth:(quote_depth + 1) body in
             Ok (encode_quote_refs (Kernel.expr_to_form body))
       in

--- a/src/surface_lower.mli
+++ b/src/surface_lower.mli
@@ -21,7 +21,8 @@ val lower_expr : Surface_ast.expr -> (Kernel.expr, Diag.t list) result
     non-final expressions bound to [PWild], while [let rec] shorthand becomes a variable-bound
     [Lam]. Handlers preserve named/hashed operation intent and quote bodies become pre-resolution
     kernel forms with depth-aware unquote splices. Unquote outside quote is E0204, and labeled
-    patterns inside quoted surface syntax are E1237 because their labels have no semantic quoted
+    patterns inside quoted surface syntax are E1237, while named calls anywhere inside a surface
+    quote (including a live unquote) are E1238 because neither label kind has a durable quoted
     carrier. Lambda parameters and nonrecursive let binders retain E0205/E0206 irrefutability
     checks. Recovery holes, malformed local bindings, and spanless generated nodes are diagnostics.
 *)

--- a/src/surface_parse.ml
+++ b/src/surface_parse.ml
@@ -518,30 +518,57 @@ and parse_call state ~allow_newlines =
     match (current state).Surface_lex.token with
     | Surface_lex.LParen ->
         let opening = advance state in
-        let args, closing = within_recovery_container state (fun () -> parse_expr_list state) in
+        let args, closing, labeled =
+          within_recovery_container state (fun () -> parse_call_argument_list state)
+        in
         let meta = meta_with_span (span_between opening closing) in
         let meta = merged_meta fn.Surface_ast.meta meta in
+        let meta = if labeled then Meta.with_surface_form "named-call" meta else meta in
         postfix Surface_ast.{ it = Call (fn, args); meta }
     | _ -> fn
   in
   postfix fn
 
-and parse_expr_list state =
+and parse_call_argument_list state =
   skip_list_space state;
   match (current state).Surface_lex.token with
-  | Surface_lex.RParen -> ([], advance state)
+  | Surface_lex.RParen -> ([], advance state, false)
   | _ ->
+      let saw_label = ref false in
+      let parse_argument () =
+        match pattern_label_ahead state with
+        | None ->
+            if !saw_label then
+              report state (current state)
+                "a positional call argument cannot follow a `label: expression` argument";
+            parse_expr state ~allow_newlines:true
+        | Some label ->
+            saw_label := true;
+            let label_token = advance state in
+            ignore (advance state);
+            skip_continuation state;
+            let expression : Surface_ast.expr = parse_expr state ~allow_newlines:true in
+            let field_meta = meta_from_token_to_meta label_token expression.Surface_ast.meta in
+            Surface_ast.
+              {
+                expression with
+                meta =
+                  expression.meta
+                  |> Meta.with_surface_call_label label
+                  |> Meta.with_surface_container "call-argument" field_meta;
+              }
+      in
       let rec loop acc =
-        let expression = parse_expr state ~allow_newlines:true in
+        let expression = parse_argument () in
         skip_list_space state;
         match (current state).Surface_lex.token with
         | Surface_lex.Comma ->
             ignore (advance state);
             skip_list_space state;
             if (current state).Surface_lex.token = Surface_lex.RParen then
-              (List.rev (expression :: acc), advance state)
+              (List.rev (expression :: acc), advance state, !saw_label)
             else loop (expression :: acc)
-        | Surface_lex.RParen -> (List.rev (expression :: acc), advance state)
+        | Surface_lex.RParen -> (List.rev (expression :: acc), advance state, !saw_label)
         | _ ->
             let token = current state in
             report state token
@@ -552,7 +579,7 @@ and parse_expr_list state =
               | Surface_lex.RParen -> advance state
               | _ -> current state
             in
-            (List.rev (expression :: acc), closing)
+            (List.rev (expression :: acc), closing, !saw_label)
       in
       loop []
 
@@ -935,15 +962,42 @@ and parse_fn state ~allow_newlines keyword =
   in
   Surface_ast.{ it = Fn (params, body); meta }
 
-and parse_pattern_list state _opening =
+and parse_pattern_list ?(callable = false) state _opening =
   skip_list_space state;
   match (current state).Surface_lex.token with
   | Surface_lex.RParen ->
       let closing = advance state in
       ([], closing)
   | _ ->
+      let saw_label = ref false in
+      let parse_item () =
+        if not callable then parse_pattern state ~allow_newlines:true
+        else
+          match pattern_label_ahead state with
+          | None ->
+              if !saw_label then
+                report state (current state)
+                  "an unlabeled callable parameter cannot follow an explicit `label: binder` \
+                   parameter";
+              parse_pattern state ~allow_newlines:true
+          | Some label ->
+              saw_label := true;
+              let label_token = advance state in
+              ignore (advance state);
+              skip_continuation state;
+              let pattern : Surface_ast.pat = parse_pattern state ~allow_newlines:true in
+              let field_meta = meta_from_token_to_meta label_token pattern.Surface_ast.meta in
+              Surface_ast.
+                {
+                  pattern with
+                  meta =
+                    pattern.meta
+                    |> Meta.with_surface_call_label label
+                    |> Meta.with_surface_container "call-parameter" field_meta;
+                }
+      in
       let rec loop acc =
-        let pattern = parse_pattern state ~allow_newlines:true in
+        let pattern = parse_item () in
         skip_list_space state;
         match (current state).Surface_lex.token with
         | Surface_lex.Comma ->
@@ -2153,7 +2207,7 @@ let parse_definition state name_token name equation =
     if equation then
       match expect state Surface_lex.LParen "`(` after the definition name" with
       | Some opening ->
-          let params, closing = parse_pattern_list state opening in
+          let params, closing = parse_pattern_list ~callable:true state opening in
           (params, Some (meta_with_span (span_between opening closing)))
       | None -> ([], None)
     else ([], None)
@@ -2363,8 +2417,33 @@ let parse_operation_types state =
         ([], Some (meta_with_span (span_between opening closing)))
       end
       else
+        let saw_label = ref false in
+        let parse_parameter () =
+          match pattern_label_ahead state with
+          | None ->
+              if !saw_label then
+                report state (current state)
+                  "an unlabeled operation parameter cannot follow an explicit `label: Type` \
+                   parameter";
+              parse_type state ~allow_newlines:true
+          | Some label ->
+              saw_label := true;
+              let label_token = advance state in
+              ignore (advance state);
+              skip_continuation state;
+              let ty : Surface_ast.ty = parse_type state ~allow_newlines:true in
+              let field_meta = meta_from_token_to_meta label_token ty.Surface_ast.meta in
+              Surface_ast.
+                {
+                  ty with
+                  meta =
+                    ty.meta
+                    |> Meta.with_surface_call_label label
+                    |> Meta.with_surface_container "call-parameter" field_meta;
+                }
+        in
         let rec loop acc =
-          let ty = parse_type state ~allow_newlines:true in
+          let ty = parse_parameter () in
           skip_list_space state;
           match (current state).Surface_lex.token with
           | Surface_lex.Comma ->
@@ -2856,7 +2935,9 @@ module Trivia_ownership = struct
       | Ann (subject, annotation) -> expr (depth + 1) subject @ ty (depth + 1) annotation
     in
     container "block" node.meta @ container "params" node.meta @ container "paren" node.meta
-    @ container "list" node.meta @ slot Expr node.meta @ children
+    @ container "list" node.meta
+    @ container "call-argument" node.meta
+    @ slot Expr node.meta @ children
 
   and block_item depth = function
     | Surface_ast.Expr expression -> expr depth expression
@@ -2884,7 +2965,9 @@ module Trivia_ownership = struct
       | PCon (_, args) | PTuple args -> List.concat_map (pat (depth + 1)) args
       | PAs (inner, _) -> pat (depth + 1) inner
     in
-    container "pattern-field" node.meta @ slot Pat node.meta @ children
+    container "pattern-field" node.meta
+    @ container "call-parameter" node.meta
+    @ slot Pat node.meta @ children
 
   and ty depth (node : Surface_ast.ty) =
     let children =
@@ -2898,7 +2981,9 @@ module Trivia_ownership = struct
       | TyTuple items -> List.concat_map (ty (depth + 1)) items
       | TyForall (tvars, rvars, body) -> forall_slots tvars rvars node.meta @ ty (depth + 1) body
     in
-    container "params" node.meta @ container "forall" node.meta @ slot Ty node.meta @ children
+    container "params" node.meta @ container "forall" node.meta
+    @ container "call-parameter" node.meta
+    @ slot Ty node.meta @ children
 
   let field depth (field : Surface_ast.field) = slot Field field.meta @ ty (depth + 1) field.ty
 
@@ -3043,7 +3128,8 @@ module Trivia_ownership = struct
   let is_structured_owner slot =
     match slot.role with
     | Container kind ->
-        String.equal kind "pattern-field"
+        String.equal kind "pattern-field" || String.equal kind "call-argument"
+        || String.equal kind "call-parameter"
         || String.starts_with ~prefix:"row-" kind
         || String.starts_with ~prefix:"forall-" kind
     | _ -> false
@@ -3209,6 +3295,8 @@ module Trivia_ownership = struct
     |> apply_container additions "params"
     |> apply_container additions "block" |> apply_container additions "paren"
     |> apply_container additions "list"
+    |> apply_container additions "call-argument"
+    |> apply_container additions "call-parameter"
     |> apply_container additions "forall"
 
   let rec map_expr additions (expression : Surface_ast.expr) =
@@ -3289,7 +3377,10 @@ module Trivia_ownership = struct
     Surface_ast.
       {
         it;
-        meta = pattern.meta |> apply additions Pat |> apply_container additions "pattern-field";
+        meta =
+          pattern.meta |> apply additions Pat
+          |> apply_container additions "pattern-field"
+          |> apply_container additions "call-parameter";
       }
 
   and map_ty additions (annotation : Surface_ast.ty) =

--- a/src/surface_print.ml
+++ b/src/surface_print.ml
@@ -254,6 +254,16 @@ and pp_labeled_pat context lookup fmt (pattern : Kernel.pat) =
         (pp_pat context lookup) pattern;
       pp_trailing context field_meta fmt
 
+and pp_callable_pat context lookup fmt (pattern : Kernel.pat) =
+  match Meta.surface_call_label pattern.meta with
+  | None -> pp_pat context lookup fmt pattern
+  | Some label ->
+      let field_meta = Meta.surface_container "call-parameter" pattern.meta in
+      pp_leading context field_meta fmt;
+      Format.fprintf fmt "@[<hov 2>%a:@ %a@]" (pp_named Surface_name.Term) label
+        (pp_pat context lookup) pattern;
+      pp_trailing context field_meta fmt
+
 and pp_row context lookup fmt (row : Kernel.row) =
   let opening = owned "row-open" row.wmeta in
   let closing = owned "row-close" row.wmeta in
@@ -402,6 +412,16 @@ and pp_ty_atom context lookup fmt ty =
       Format.fprintf fmt "(%a)" (pp_ty context lookup) ty
   | _ -> pp_ty context lookup fmt ty
 
+and pp_callable_ty context lookup fmt (ty : Kernel.ty) =
+  match Meta.surface_call_label ty.meta with
+  | None -> pp_ty context lookup fmt ty
+  | Some label ->
+      let field_meta = Meta.surface_container "call-parameter" ty.meta in
+      pp_leading context field_meta fmt;
+      Format.fprintf fmt "@[<hov 2>%a:@ %a@]" (pp_named Surface_name.Term) label
+        (pp_ty context lookup) ty;
+      pp_trailing context field_meta fmt
+
 let quote_marker_base payload =
   let rec symbols acc (form : Form.t) =
     List.fold_left
@@ -489,6 +509,12 @@ let surface_quote_expr payload =
     | Ok expr -> Some (restore_quote_splices !splices expr)
 
 let rec pp_expr context lookup fmt (expr : Kernel.expr) =
+  match reordered_named_call expr with
+  | Some (fn, source_arguments) ->
+      pp_reordered_named_call context lookup fmt expr fn source_arguments
+  | None -> pp_expr_regular context lookup fmt expr
+
+and pp_expr_regular context lookup fmt (expr : Kernel.expr) =
   let block_meta = Meta.surface_container "block" expr.meta in
   let paren_meta = Meta.surface_container "paren" expr.meta in
   if context.trivia && (not (Meta.is_empty paren_meta)) && meta_has_comments paren_meta then
@@ -520,6 +546,45 @@ let rec pp_expr context lookup fmt (expr : Kernel.expr) =
     | Some _, _ | None, _ -> pp_kernel_expr context lookup fmt expr);
     match expr.it with Kernel.Let _ -> () | _ -> pp_trailing context expr.meta fmt
   end
+
+and reordered_named_call (expr : Kernel.expr) =
+  if Meta.surface_generated expr.meta <> Some "named-call-reordered" then None
+  else
+    let rec collect bindings (current : Kernel.expr) =
+      match current.it with
+      | Kernel.Let { isrec = false; binder = { it = Kernel.PVar name; _ }; value; body }
+        when bindings = [] || Meta.surface_generated current.meta = Some "named-call-argument-let"
+        ->
+          collect ((name, value) :: bindings) body
+      | Kernel.App (fn, arguments)
+        when Meta.surface_generated current.meta = Some "named-call-positional-app" ->
+          let bindings = List.rev bindings in
+          let names = List.map fst bindings in
+          let referenced =
+            List.filter_map
+              (fun argument ->
+                match argument.Kernel.it with Kernel.Var name -> Some name | _ -> None)
+              arguments
+          in
+          if
+            List.length referenced = List.length arguments
+            && List.sort String.compare referenced = List.sort String.compare names
+          then Some (fn, List.map snd bindings)
+          else None
+      | _ -> None
+    in
+    collect [] expr
+
+and pp_reordered_named_call context lookup fmt (expr : Kernel.expr) fn source_arguments =
+  pp_leading context expr.meta fmt;
+  (match (Meta.surface_form expr.meta, source_arguments) with
+  | Some "pipe", left :: arguments -> pp_pipe context lookup expr.meta fmt left fn arguments
+  | (Some _ | None), _ ->
+      Format.fprintf fmt "@[<hv 2>%a(%a" (pp_expr_atom context lookup) fn
+        (pp_comma_list ~inner_metas:[ expr.meta ] context (pp_call_argument context lookup))
+        source_arguments;
+      Format.fprintf fmt ")@]");
+  pp_trailing context expr.meta fmt
 
 and interpolation_text context lookup fn args =
   let is_text_join =
@@ -592,7 +657,7 @@ and pp_kernel_expr context lookup fmt (expr : Kernel.expr) =
       Format.fprintf fmt " ->@ %a@]" (pp_expr context lookup) body
   | Kernel.App (fn, args) ->
       Format.fprintf fmt "@[<hv 2>%a(%a" (pp_expr_atom context lookup) fn
-        (pp_comma_list ~inner_metas:[ expr.meta ] context (pp_expr context lookup))
+        (pp_comma_list ~inner_metas:[ expr.meta ] context (pp_call_argument context lookup))
         args;
       Format.fprintf fmt ")@]"
   | Kernel.Let _ -> pp_block context lookup fmt expr
@@ -699,7 +764,11 @@ and pp_list context lookup meta fmt items =
 
 and pp_pipe context lookup meta fmt left fn args =
   let rhs_meta = Meta.surface_container "pipe-rhs" meta in
-  let explicit_call = Meta.surface_form rhs_meta = Some "pipe-call" in
+  let explicit_call =
+    match Meta.surface_form rhs_meta with
+    | Some ("pipe-call" | "pipe-named-call") -> true
+    | Some _ | None -> false
+  in
   let pp_operator fmt () =
     if context.trivia && expression_has_trailing_comments left then Format.pp_force_newline fmt ();
     Format.pp_print_string fmt "|> ";
@@ -716,11 +785,21 @@ and pp_pipe context lookup meta fmt left fn args =
   | _ ->
       Format.fprintf fmt "@[<hv 2>%a@ %a%a(%a" (pp_pipe_left context lookup) left pp_operator ()
         (pp_expr_atom context lookup) fn
-        (pp_comma_list ~inner_metas:[ rhs_meta; meta ] context (pp_expr context lookup))
+        (pp_comma_list ~inner_metas:[ rhs_meta; meta ] context (pp_call_argument context lookup))
         args;
       Format.fprintf fmt ")";
       pp_trailing context rhs_meta fmt;
       Format.fprintf fmt "@]"
+
+and pp_call_argument context lookup fmt (argument : Kernel.expr) =
+  match Meta.surface_call_label argument.meta with
+  | None -> pp_expr context lookup fmt argument
+  | Some label ->
+      let field_meta = Meta.surface_container "call-argument" argument.meta in
+      pp_leading context field_meta fmt;
+      Format.fprintf fmt "@[<hov 2>%a:@ %a@]" (pp_named Surface_name.Term) label
+        (pp_expr context lookup) argument;
+      pp_trailing context field_meta fmt
 
 and pp_pipe_left context lookup fmt expr = pp_expr_atom context lookup fmt expr
 
@@ -959,7 +1038,7 @@ let pp_binding context lookup fmt (binding : Kernel.binding) =
         Format.fprintf fmt "@[<hv 2>%a" (pp_named Surface_name.Term) binding.bname;
         pp_leading context params_meta fmt;
         Format.fprintf fmt "(%a"
-          (pp_comma_list ~inner_metas:[ params_meta ] context (pp_pat context lookup))
+          (pp_comma_list ~inner_metas:[ params_meta ] context (pp_callable_pat context lookup))
           params;
         Format.fprintf fmt ")";
         pp_trailing context params_meta fmt;
@@ -1024,7 +1103,8 @@ let pp_operation ?inherited_mode context lookup fmt (operation : Kernel.opspec) 
   (* The signature box may already have broken after [:]. Padding the nested custom breaks keeps
      parameter types two columns inside [(], while [)] returns to the opening delimiter's column. *)
   Format.fprintf fmt "(%a"
-    (pp_comma_list ~break_padding:"  " ~inner_metas:[ params_meta ] context (pp_ty context lookup))
+    (pp_comma_list ~break_padding:"  " ~inner_metas:[ params_meta ] context
+       (pp_callable_ty context lookup))
     operation.op_params;
   Format.fprintf fmt ")";
   pp_trailing context params_meta fmt;

--- a/test/cli/named-args.t
+++ b/test/cli/named-args.t
@@ -1,0 +1,126 @@
+SX.23 named calls use explicit labels and lower to the existing positional App. Reordered
+arguments retain source evaluation order while the final application uses declaration order.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ export JACQUARD_RUNTIME=../../runtime
+  $ export CC=clang
+  $ cat > named-order.jac <<'EOF'
+  > ordered(left: first, right: second) = (first, second)
+  > ordered(
+  >   right: { print("R"); 2 },
+  >   left: { print("L"); 1 },
+  > )
+  > EOF
+  $ jac run named-order.jac --allow console > interpreted.out
+  $ jac build named-order.jac -o named-order-native > /dev/null
+  $ ./named-order-native --allow console > native.out
+  $ cmp interpreted.out native.out && echo identical
+  identical
+  $ cat interpreted.out
+  RL(1, 2)
+
+Formatting retains labels and is idempotent. Explicit bootstrap export contains only positional
+kernel application, and both carriers have identical hashes and behavior.
+
+  $ jac fmt named-order.jac > named-order-formatted.jac
+  $ jac fmt named-order-formatted.jac > named-order-twice.jac
+  $ cmp named-order-formatted.jac named-order-twice.jac && grep -o 'right:' named-order-formatted.jac | wc -l | tr -d ' '
+  2
+  $ jac export named-order.jac -o named-order.jqd
+  $ jac hash named-order.jac > named-order.jac.hash
+  $ jac hash named-order.jqd > named-order.jqd.hash
+  $ cmp named-order.jac.hash named-order.jqd.hash && echo hash-identical
+  hash-identical
+  $ jac run named-order.jqd --allow console
+  RL(1, 2)
+
+Constructors reuse their declared field labels. Operations and top-level terms declare their own
+labels explicitly; each may keep an unlabeled positional prefix.
+
+  $ cat > supported.jac <<'EOF'
+  > type Packet = | Packet(Int, body: Int)
+  > once effect Sending where {
+  >   send : (Int, body: Int) -> Int
+  > }
+  > resize(image, scale: ratio) = (image, ratio)
+  > (
+  >   Packet(1, body: 2),
+  >   resize(3, scale: 4),
+  >   handle `op:send`(5, body: 6) {
+  >     | return value -> value
+  >     | send(path, body) resume continue -> continue(path)
+  >   },
+  > )
+  > EOF
+  $ jac check supported.jac
+  ok
+  $ jac run supported.jac
+  (packet(1, 2), (3, 4), 5)
+
+Unknown, duplicate, missing, opaque/local, malformed-schema, and quoted labels fail closed with
+one focused diagnostic. The unknown-label message names a concrete repair.
+
+  $ cat > bad-unknown.jac <<'EOF'
+  > choose(left: x, right: y) = (x, y)
+  > choose(left: 1, wrong: 2)
+  > EOF
+  $ jac check bad-unknown.jac > bad-unknown.out 2>&1; status=$?; grep -E 'error\[E0310\]|Next step:' bad-unknown.out; echo "exit:$status"
+  bad-unknown.jac:2:17-25: error[E0310]: This callable has no slot with the selected label.
+    Next step: Use one of the callable's declared external labels.
+  exit:1
+  $ sed 's/wrong: 2/left: 2/' bad-unknown.jac > bad-duplicate.jac
+  $ jac check bad-duplicate.jac > duplicate.out 2>&1; status=$?; grep -o 'error\[E0311\]' duplicate.out; echo "exit:$status"
+  error[E0311]
+  exit:1
+  $ sed 's/, wrong: 2//' bad-unknown.jac > bad-missing.jac
+  $ jac check bad-missing.jac > missing.out 2>&1; status=$?; grep -o 'error\[E0312\]' missing.out; echo "exit:$status"
+  error[E0312]
+  exit:1
+  $ cat > bad-local.jac <<'EOF'
+  > { let local = fn (x) -> x; local(value: 1) }
+  > EOF
+  $ jac check bad-local.jac > local.out 2>&1; status=$?; grep -o 'error\[E0309\]' local.out; echo "exit:$status"
+  error[E0309]
+  exit:1
+  $ cat > bad-schema.jac <<'EOF'
+  > type Mixed = | Mixed(left: Int, Int)
+  > Mixed(left: 1, other: 2)
+  > EOF
+  $ jac check bad-schema.jac > schema.out 2>&1; status=$?; grep -o 'error\[E0314\]' schema.out; echo "exit:$status"
+  error[E0314]
+  exit:1
+  $ cat > bad-quote.jac <<'EOF'
+  > quote { unquote(choose(left: 1)) }
+  > EOF
+  $ jac check bad-quote.jac > quote.out 2>&1; status=$?; grep -o 'error\[E1238\]' quote.out; echo "exit:$status"
+  error[E1238]
+  exit:1
+
+When a direct API exposes an applicable label, the checker warns about a positional Bool constructor
+literal, or one definite run of repeated parameter types when no Bool warning already owns the call.
+Named calls and purpose-specific sum types avoid these review warnings.
+
+  $ cat > warnings.jac <<'EOF'
+  > choose-flag(flag: value) = value
+  > sum-pair : (Int, Int) ->{} Int
+  > sum-pair(left: x, right: y) = x
+  > choose-flag(True)
+  > sum-pair(1, 2)
+  > EOF
+  $ jac check warnings.jac > warnings.out 2>&1
+  $ grep -o 'warning\[W120[67]\]' warnings.out
+  warning[W1206]
+  warning[W1207]
+  $ cat > warning-free.jac <<'EOF'
+  > choose-flag(flag: value) = value
+  > sum-pair : (Int, Int) ->{} Int
+  > sum-pair(left: x, right: y) = x
+  > type Mode = | Live | DryRun
+  > deploy(mode: value) = match value { | Live -> 1 | DryRun -> 0 }
+  > choose-flag(flag: True)
+  > sum-pair(left: 1, right: 2)
+  > deploy(Live)
+  > EOF
+  $ jac check warning-free.jac > warning-free.out 2>&1
+  $ grep -c 'warning\[W120[67]\]' warning-free.out || true
+  0

--- a/test/corpus_support.ml
+++ b/test/corpus_support.ml
@@ -404,7 +404,14 @@ let diag_cases : (string * string * string list option) list =
       None );
   ]
 
-let diag_surface_cases = [ ("eta-positive", "condition = True\nbool.and-then(True, condition)\n") ]
+let diag_surface_cases =
+  [
+    ("eta-positive", "condition = True\nbool.and-then(True, condition)\n");
+    ("named-bool-warning", "choose-flag(flag: value) = value\nchoose-flag(True)\n");
+    ( "named-repeated-type-warning",
+      "sum-pair : (Int, Int) ->{} Int\nsum-pair(left: x, right: y) = add(x, y)\nsum-pair(1, 2)\n" );
+  ]
+
 let diag_strict_recovery_cases = [ ("strict-recovery", "fixture-hole") ]
 
 (** Render the golden diagnostic lines: [name | rendered-diagnostic]. *)
@@ -473,6 +480,7 @@ let diag_golden_lines ~prelude_dir : (string list, Diag.t list) result =
           let* resolved = Resolve.resolve (Store.names_view store) top in
           match Check.check_top ctx resolved with
           | Error ds -> Ok (render ds)
+          | Ok { Check.warnings = _ :: _ as warnings; _ } -> Ok (render warnings)
           | Ok _ -> (
               match resolved with
               | Kernel.Decl declaration ->

--- a/test/dune
+++ b/test/dune
@@ -135,6 +135,8 @@
   ../docs/release/surface-syntax/DECISION.md
   ../docs/release/surface-syntax/FOLLOWUPS.md
   ../docs/release/surface-syntax/MANIFEST.sha256
+  ../docs/release/named-call-arguments/DECISION.md
+  ../docs/release/named-call-arguments/EVIDENCE.md
   (glob_files ../playground/governance/fixtures/generated/*.json)
   ../docs/release/structured-concurrency/EVIDENCE.md
   ../docs/release/structured-concurrency/LIMITS.md

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -87,6 +87,7 @@ let () =
       ("surface-lex", Test_surface_lex.suite);
       ("surface-parse", Test_surface_parse.suite);
       ("surface-patterns", Test_surface_patterns.suite);
+      ("surface-named-calls", Test_surface_named_calls.suite);
       ("surface-parse-recovery", Test_surface_parse_recovery.suite);
       ("surface-decls", Test_surface_decls.suite);
       ("surface-handlers-quote", Test_surface_handlers_quote.suite);

--- a/test/test_surface_laws.ml
+++ b/test/test_surface_laws.ml
@@ -57,7 +57,7 @@ let test_one_page_grammar_snapshot () =
   Alcotest.(check bool) "L7 grammar stays within 100 nonblank lines" true (List.length lines <= 100);
   Alcotest.(check string)
     "L7 grammar snapshot (review docs/surface-syntax.md before updating)"
-    "e0793e772b31cf5c2840ab00391f540c4fae7b067904a2687abf0a7273aa6e2d"
+    "1c34c8e7768c18e7787a3caeb86be860bac98ab6eb88a22549d5c072e5e70aac"
     (Hash.to_hex (Hash.of_string grammar))
 
 let format_surface ?width path source =
@@ -1186,6 +1186,17 @@ let validate_release_docs ~decision ~followups ~index =
          `.jac`/`.jqd` hash parity while bootstrap absence remains legacy `Multi`.";
         "none";
       ];
+      [
+        "D76";
+        "shipped";
+        "[named-call cases](../../../test/test_surface_named_calls.ml) and the [CLI \
+         transcript](../../../test/cli/named-args.t) pin explicit labels for direct top-level \
+         terms, constructors, and operations; positional-prefix/labeled-suffix exact arity; \
+         source-order evaluation; positional kernel/hash parity; store reopen/rename/conflict \
+         behavior; quote refusal; diagnostics; formatting; native parity; and advisory review \
+         warnings.";
+        "[named-call decision](../named-call-arguments/DECISION.md)";
+      ];
     ]
     [ "shipped"; "partial"; "adjusted" ];
   (match section "## Evidence Inventories" decision with
@@ -1492,6 +1503,7 @@ let decision_status_mutations =
     ("D40", "shipped", "adjusted");
     ("D41", "shipped", "adjusted");
     ("D42", "shipped", "adjusted");
+    ("D76", "shipped", "adjusted");
   ]
 
 let status_mutation_test (id, expected, replacement) =
@@ -1523,6 +1535,9 @@ let decision_semantic_mutations =
     ( "D42",
       "reject omission, duplication, conflicts, and partially annotated mixed effects",
       "accept omission, duplication, conflicts, and partially annotated mixed effects" );
+    ( "D76",
+      "positional-prefix/labeled-suffix exact arity; source-order evaluation",
+      "arbitrary positional/named mixing; declaration-order evaluation" );
   ]
 
 let law_semantic_mutations =

--- a/test/test_surface_named_calls.ml
+++ b/test/test_surface_named_calls.ml
@@ -1,0 +1,431 @@
+open Jacquard
+
+let fail_diags label diagnostics =
+  Alcotest.failf "%s: %s" label (String.concat "; " (List.map Diag.to_string diagnostics))
+
+let fresh_root =
+  let serial = ref 0 in
+  fun () ->
+    incr serial;
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "jacquard-named-call-%d-%d" (Unix.getpid ()) !serial)
+
+let open_store root =
+  match Store.open_store root with
+  | Ok store -> store
+  | Error diagnostics -> fail_diags "store" diagnostics
+
+let parse source =
+  match Surface_parse.parse_string ~file:"named-calls.jac" source with
+  | Ok tops -> tops
+  | Error diagnostics -> fail_diags "parse" diagnostics
+
+let lower source =
+  match Surface_lower.lower_tops (parse source) with
+  | Ok tops -> tops
+  | Error diagnostics -> fail_diags "lower" diagnostics
+
+let resolve_top store top =
+  match Resolve.resolve (Store.names_view store) top with
+  | Ok top -> top
+  | Error diagnostics -> fail_diags "resolve" diagnostics
+
+let install store source =
+  List.map
+    (fun top ->
+      let top = resolve_top store top in
+      match top with
+      | Kernel.Decl declaration -> (
+          match Store.put_decl store declaration with
+          | Ok _ -> top
+          | Error diagnostics -> fail_diags "put" diagnostics)
+      | Kernel.Expr _ -> top)
+    (lower source)
+
+let make_prelude_checker () =
+  let store = open_store (fresh_root ()) in
+  (match Prelude.load ~dir:"../prelude" store with
+  | Ok _ -> ()
+  | Error diagnostics -> fail_diags "prelude" diagnostics);
+  let checker =
+    match Check.make_ctx store with
+    | Ok checker -> checker
+    | Error diagnostics -> fail_diags "checker" diagnostics
+  in
+  (match Prelude.builtin_signatures store with
+  | Ok signatures -> Check.register_builtin_signatures checker signatures
+  | Error diagnostics -> fail_diags "builtin signatures" diagnostics);
+  (store, checker)
+
+let resolve_expression store source =
+  match lower source with
+  | [ Kernel.Expr expression ] -> (
+      match Resolve.resolve_expr (Store.names_view store) expression with
+      | Ok expression -> expression
+      | Error diagnostics -> fail_diags "resolve expression" diagnostics)
+  | tops -> Alcotest.failf "expected one expression, got %d tops" (List.length tops)
+
+let check_expression checker store source =
+  let expression = resolve_expression store source in
+  match Check.check_top checker (Kernel.Expr expression) with
+  | Ok checked -> checked
+  | Error diagnostics -> fail_diags "check expression" diagnostics
+
+let warnings code checked =
+  List.filter (fun diagnostic -> Diag.code diagnostic = Some code) checked.Check.warnings
+
+let resolution_diagnostics store source =
+  match lower source with
+  | [ Kernel.Expr expression ] -> (
+      match Resolve.resolve_expr (Store.names_view store) expression with
+      | Ok _ -> Alcotest.failf "expected resolution failure for %S" source
+      | Error diagnostics -> diagnostics)
+  | [ Kernel.Decl declaration ] -> (
+      match Resolve.resolve_decl (Store.names_view store) declaration with
+      | Ok _ -> Alcotest.failf "expected declaration resolution failure for %S" source
+      | Error diagnostics -> diagnostics)
+  | tops -> Alcotest.failf "expected one top, got %d" (List.length tops)
+
+let only_diagnostic store source code excerpt =
+  match resolution_diagnostics store source with
+  | [ diagnostic ] ->
+      Alcotest.(check string) "diagnostic code" code (Diag.code_or_uncoded diagnostic);
+      let span =
+        match Diag.span diagnostic with
+        | Some span -> span
+        | None -> Alcotest.fail "diagnostic has no span"
+      in
+      let actual =
+        String.sub source span.Span.start_pos.offset (span.end_pos.offset - span.start_pos.offset)
+      in
+      Alcotest.(check string) "diagnostic span" excerpt actual
+  | diagnostics -> Alcotest.failf "expected one diagnostic, got %d" (List.length diagnostics)
+
+let expression_hash expression =
+  match Canon.hash_expr expression with
+  | Ok hash -> hash
+  | Error diagnostics -> fail_diags "hash" diagnostics
+
+let print_expression expression =
+  match Surface_print.print_top (Kernel.Expr expression) with
+  | Ok text -> text
+  | Error diagnostics -> fail_diags "print" diagnostics
+
+let int_literal expression =
+  match expression.Kernel.it with
+  | Kernel.Lit (Kernel.LInt value) -> value
+  | _ -> Alcotest.fail "int"
+
+let rec named_let_bindings acc expression =
+  match expression.Kernel.it with
+  | Kernel.Let { isrec = false; binder = { it = Kernel.PVar name; _ }; value; body }
+    when Meta.surface_generated expression.meta = Some "named-call-reordered"
+         || Meta.surface_generated expression.meta = Some "named-call-argument-let" ->
+      named_let_bindings ((name, int_literal value) :: acc) body
+  | Kernel.App (_, arguments) -> (List.rev acc, arguments)
+  | _ -> Alcotest.fail "expected generated named-call lets ending in App"
+
+let test_parse_print_quote_and_recovery () =
+  let source =
+    "choose(-- first label\n\
+     left: first, right: second) = (first, second)\n\n\
+     choose(-- first call label\n\
+     right: 2, left: 1)\n"
+  in
+  let recovered = Surface_parse.recover_string ~file:"named-comments.jac" source in
+  let formatted =
+    match Surface_print.print_recovered recovered with
+    | Ok text -> text
+    | Error diagnostics -> fail_diags "format" diagnostics
+  in
+  Alcotest.(check int)
+    "parameter comment once" 1
+    (Test_surface_trivia.count_occurrences formatted "-- first label");
+  Alcotest.(check int)
+    "argument comment once" 1
+    (Test_surface_trivia.count_occurrences formatted "-- first call label");
+  let formatted_again =
+    match
+      Surface_print.print_recovered
+        (Surface_parse.recover_string ~file:"named-comments.jac" formatted)
+    with
+    | Ok text -> text
+    | Error diagnostics -> fail_diags "format twice" diagnostics
+  in
+  Alcotest.(check string) "formatter idempotent" formatted formatted_again;
+  let narrow_source = "combine(important-left: first-value, important-right: second-value)\n" in
+  let narrow =
+    match
+      Surface_print.print_recovered ~width:30
+        (Surface_parse.recover_string ~file:"named-width.jac" narrow_source)
+    with
+    | Ok text -> text
+    | Error diagnostics -> fail_diags "narrow format" diagnostics
+  in
+  Alcotest.(check bool)
+    "named call wraps at narrow width" true
+    (Test_surface_trivia.count_occurrences narrow "\n" > 1);
+  let narrow_again =
+    match
+      Surface_print.print_recovered ~width:30
+        (Surface_parse.recover_string ~file:"named-width.jac" narrow)
+    with
+    | Ok text -> text
+    | Error diagnostics -> fail_diags "narrow format twice" diagnostics
+  in
+  Alcotest.(check string) "narrow formatter idempotent" narrow narrow_again;
+  List.iter
+    (fun source ->
+      match Surface_parse.parse_string ~file:"bad-order.jac" source with
+      | Error diagnostics ->
+          Alcotest.(check bool)
+            source true
+            (List.exists (fun diagnostic -> Diag.code diagnostic = Some "E1220") diagnostics)
+      | Ok _ -> Alcotest.failf "expected ordering parse error for %S" source)
+    [
+      "choose(left: 1, 2)";
+      "choose(left: first, second) = first";
+      "once effect E a where { op : (left: a, a) -> a }";
+    ];
+  List.iter
+    (fun source ->
+      match Surface_lower.lower_tops (parse source) with
+      | Error [ diagnostic ] ->
+          Alcotest.(check string) "quote code" "E1238" (Diag.code_or_uncoded diagnostic)
+      | Error diagnostics -> fail_diags "quoted named call" diagnostics
+      | Ok _ -> Alcotest.failf "quoted named call lowered: %s" source)
+    [ "quote { choose(left: 1) }"; "quote { unquote(choose(left: 1)) }" ];
+  ignore (lower "quote { choose(1) }")
+
+let test_direct_calls_hashes_and_source_order () =
+  let store = open_store (fresh_root ()) in
+  ignore (install store "choose(left: first, right: second) = (first, second)\n");
+  let reordered = resolve_expression store "choose(right: 2, left: 1)" in
+  let bindings, final_arguments = named_let_bindings [] reordered in
+  Alcotest.(check (list int)) "source evaluation order" [ 2; 1 ] (List.map snd bindings);
+  let final_names =
+    List.map
+      (fun argument ->
+        match argument.Kernel.it with
+        | Kernel.Var name -> name
+        | _ -> Alcotest.fail "final named call argument is not a temporary")
+      final_arguments
+  in
+  Alcotest.(check (list string))
+    "declaration-order application"
+    (List.rev (List.map fst bindings))
+    final_names;
+  Alcotest.(check string)
+    "printer restores source call" "choose(right: 2, left: 1)" (print_expression reordered);
+  let bootstrap = Printer.print_all [ Kernel.expr_to_form reordered ] in
+  Alcotest.(check bool)
+    "generated temporaries export as bootstrap symbols" true
+    (String.length bootstrap > 0);
+  let named = resolve_expression store "choose(left: 1, right: 2)" in
+  let positional = resolve_expression store "choose(1, 2)" in
+  Alcotest.(check bool)
+    "declaration-order hash twin" true
+    (Hash.equal (expression_hash named) (expression_hash positional));
+  let explicit_lets =
+    resolve_expression store
+      "{ let right-value = 2; let left-value = 1; choose(left-value, right-value) }"
+  in
+  Alcotest.(check bool)
+    "reordered explicit-let hash twin" true
+    (Hash.equal (expression_hash reordered) (expression_hash explicit_lets));
+  ignore (install store "resize(img, scale: ratio) = (ratio, img)\n");
+  let mixed = resolve_expression store "resize(1, scale: 2)" in
+  Alcotest.(check string)
+    "positional prefix and labeled suffix" "resize(1, scale: 2)" (print_expression mixed);
+  Alcotest.(check bool)
+    "mixed call hash twin" true
+    (Hash.equal (expression_hash mixed) (expression_hash (resolve_expression store "resize(1, 2)")));
+  match lower "first(value: x) = second(value: x)\nsecond(value: y) = first(value: y)\n" with
+  | [ Kernel.Decl declaration ] -> (
+      match Resolve.resolve_decl Resolve.empty_names declaration with
+      | Ok { Kernel.it = Kernel.DefTerm [ first; second ]; _ } ->
+          let callee binding =
+            match binding.Kernel.value.it with
+            | Kernel.Lam (_, { it = Kernel.App ({ it = Kernel.GroupRef index; _ }, _); _ }) -> index
+            | _ -> Alcotest.fail "same-SCC named call did not become GroupRef App"
+          in
+          Alcotest.(check int) "first to second" 1 (callee first);
+          Alcotest.(check int) "second to first" 0 (callee second)
+      | Ok _ -> Alcotest.fail "unexpected same-SCC declaration"
+      | Error diagnostics -> fail_diags "same SCC" diagnostics)
+  | _ -> Alcotest.fail "mutual fixture did not form one declaration"
+
+let test_constructor_and_operation_calls () =
+  let store = open_store (fresh_root ()) in
+  ignore (install store "type Packet a = | Packet(left: a, right: a)\n");
+  let packet = resolve_expression store "Packet(right: 2, left: 1)" in
+  Alcotest.(check string)
+    "constructor labels print" "Packet(right: 2, left: 1)" (print_expression packet);
+  ignore (install store "type Envelope a = | Envelope(a, payload: a)\n");
+  let envelope = resolve_expression store "Envelope(1, payload: 2)" in
+  Alcotest.(check string)
+    "constructor positional prefix" "Envelope(1, payload: 2)" (print_expression envelope);
+  ignore (install store "once effect Sending a where { send : (path: a, body: a) -> a }\n");
+  let operation = resolve_expression store "`op:send`(body: 2, path: 1)" in
+  Alcotest.(check string)
+    "operation labels print" "`op:send`(body: 2, path: 1)" (print_expression operation);
+  ignore (install store "once effect Appending a where { append : (a, suffix: a) -> a }\n");
+  let operation_prefix = resolve_expression store "`op:append`(1, suffix: 2)" in
+  Alcotest.(check string)
+    "operation positional prefix" "`op:append`(1, suffix: 2)"
+    (print_expression operation_prefix)
+
+let test_fail_closed_diagnostics () =
+  let store = open_store (fresh_root ()) in
+  ignore (install store "choose(left: first, right: second) = (first, second)\nplain(x) = x\n");
+  only_diagnostic store "plain(value: 1)" "E0309" "plain(value: 1)";
+  only_diagnostic store "choose(left: 1, wrong: 2)" "E0310" "wrong: 2";
+  only_diagnostic store "choose(left: 1, left: 2)" "E0311" "left: 2";
+  only_diagnostic store "choose(1, left: 2)" "E0311" "left: 2";
+  only_diagnostic store "choose(left: 1)" "E0312" "choose(left: 1)";
+  only_diagnostic store "bad(label: (x, y)) = x" "E0313" "label: (x, y)";
+  only_diagnostic store "bad(value: x, value: y) = x" "E0313" "value: y";
+  only_diagnostic store "{ let f = fn (x) -> x; f(value: 1) }" "E0309" "f(value: 1)";
+  ignore (install store "type Ambiguous a = | Ambiguous(value: a, value: a)\n");
+  only_diagnostic store "Ambiguous(value: 1, value: 2)" "E0314" "Ambiguous(value: 1, value: 2)";
+  ignore (install store "type MixedFields a = | MixedFields(left: a, a)\n");
+  only_diagnostic store "MixedFields(left: 1, other: 2)" "E0314" "MixedFields(left: 1, other: 2)"
+
+let resolved_declaration store source =
+  match lower source with
+  | [ Kernel.Decl declaration ] -> (
+      match Resolve.resolve_decl (Store.names_view store) declaration with
+      | Ok declaration -> declaration
+      | Error diagnostics -> fail_diags "resolve declaration" diagnostics)
+  | tops -> Alcotest.failf "expected one declaration, got %d" (List.length tops)
+
+let test_store_identity_reopen_and_conflict () =
+  let root = fresh_root () in
+  let store = open_store root in
+  let original =
+    resolved_declaration store "choose(left: first, right: second) = (first, second)"
+  in
+  let hashes =
+    match Store.put_decl store original with
+    | Ok hashes -> hashes
+    | Error diagnostics -> fail_diags "put original" diagnostics
+  in
+  let member = List.assoc "choose" hashes.Canon.named in
+  Alcotest.(check (option (list (option string))))
+    "ABI installed"
+    (Some [ Some "left"; Some "right" ])
+    ((Store.names_view store).Resolve.callable_abi member);
+  (match Store.rename store ~old_name:"choose" ~new_name:"select" () with
+  | Ok () -> ()
+  | Error diagnostics -> fail_diags "rename" diagnostics);
+  let reopened = open_store root in
+  Alcotest.(check (option (list (option string))))
+    "ABI survives rename and reopen"
+    (Some [ Some "left"; Some "right" ])
+    ((Store.names_view reopened).Resolve.callable_abi member);
+  let renamed_binders = resolved_declaration reopened "select(left: x, right: y) = (x, y)" in
+  (match Store.put_decl reopened renamed_binders with
+  | Ok renamed_hashes ->
+      Alcotest.(check bool)
+        "binder rename keeps member hash" true
+        (Hash.equal member (List.assoc "select" renamed_hashes.Canon.named))
+  | Error diagnostics -> fail_diags "binder rename" diagnostics);
+  let relabeled = resolved_declaration reopened "select(first: x, second: y) = (x, y)" in
+  (match Store.put_decl reopened relabeled with
+  | Error [ diagnostic ] ->
+      Alcotest.(check string) "ABI conflict" "E0612" (Diag.code_or_uncoded diagnostic)
+  | Error diagnostics -> fail_diags "ABI conflict" diagnostics
+  | Ok _ -> Alcotest.fail "conflicting relabel replaced a hash-bound ABI");
+  Alcotest.(check (option (list (option string))))
+    "conflict is transactional"
+    (Some [ Some "left"; Some "right" ])
+    ((Store.names_view reopened).Resolve.callable_abi member)
+
+let test_checker_review_warnings_and_recovery_names () =
+  let store, checker = make_prelude_checker () in
+  ignore
+    (install store
+       "choose-flag(flag: value) = value\n\
+        sum-pair : (Int, Int) ->{} Int\n\
+        sum-pair(left: x, right: y) = add(x, y)\n\
+        later-pair : (Int, Int, Text, Text) ->{} Int\n\
+        later-pair(first, second, left: x, right: y) = add(first, second)\n\
+        mixed : (Int, Text) ->{} Int\n\
+        mixed(number: n, text: t) = n\n\
+        plain-flag : (Bool) ->{} Int\n\
+        plain-flag(value) = if value then 1 else 0\n\
+        plain-pair : (Int, Int) ->{} Int\n\
+        plain-pair(x, y) = sub(x, y)\n\
+        type Mode = | Live | DryRun\n\
+        deploy(mode: value) = match value { | Live -> 1 | DryRun -> 0 }\n");
+  let bool_warning = check_expression checker store "choose-flag(True)" |> warnings "W1206" in
+  (match bool_warning with
+  | [ warning ] ->
+      Alcotest.(check string)
+        "boolean warning span" "True"
+        (match Diag.span warning with
+        | Some span ->
+            String.sub "choose-flag(True)" span.start_pos.offset
+              (span.end_pos.offset - span.start_pos.offset)
+        | None -> Alcotest.fail "boolean warning has no span");
+      Alcotest.(check bool)
+        "boolean remediation names sum type" true
+        (Test_surface_trivia.count_occurrences (Diag.next_step warning) "Mode = | Live | DryRun" = 1)
+  | warnings -> Alcotest.failf "expected one W1206, got %d" (List.length warnings));
+  let repeated_warning = check_expression checker store "sum-pair(1, 2)" |> warnings "W1207" in
+  (match repeated_warning with
+  | [ warning ] ->
+      Alcotest.(check string)
+        "same-type warning cause"
+        "Parameters 1 through 2 all have type int, so a reordered call can still typecheck."
+        (Diag.cause warning)
+  | warnings -> Alcotest.failf "expected one W1207, got %d" (List.length warnings));
+  let later_warning =
+    check_expression checker store "later-pair(1, 2, \"left\", \"right\")" |> warnings "W1207"
+  in
+  (match later_warning with
+  | [ warning ] ->
+      Alcotest.(check string)
+        "later labeled same-type run"
+        "Parameters 3 through 4 all have type text, so a reordered call can still typecheck."
+        (Diag.cause warning)
+  | warnings -> Alcotest.failf "expected one later W1207, got %d" (List.length warnings));
+  List.iter
+    (fun source ->
+      let checked = check_expression checker store source in
+      Alcotest.(check int) (source ^ " W1206") 0 (List.length (warnings "W1206" checked));
+      Alcotest.(check int) (source ^ " W1207") 0 (List.length (warnings "W1207" checked)))
+    [
+      "choose-flag(flag: True)";
+      "{ let flag = True; choose-flag(flag) }";
+      "sum-pair(left: 1, right: 2)";
+      "mixed(1, \"purpose\")";
+      "plain-flag(True)";
+      "plain-pair(1, 2)";
+      "deploy(Live)";
+    ];
+  let recovered =
+    Surface_parse.recover_string ~file:"analysis-named.jac"
+      "local-pair(left: x, right: y) = (x, y)\nlocal-pair(right: 2, left: 1)\n"
+  in
+  let report = Surface_check.analyze ~names:(Store.names_view store) checker recovered in
+  Alcotest.(check bool)
+    "recovery carries the local named-call ABI" true
+    (not
+       (List.exists
+          (fun diagnostic ->
+            List.mem (Diag.code_or_uncoded diagnostic) [ "E0309"; "E0310"; "E0311"; "E0312" ])
+          report.diagnostics))
+
+let suite =
+  [
+    Alcotest.test_case "parse print quote recovery" `Quick test_parse_print_quote_and_recovery;
+    Alcotest.test_case "direct hashes and source order" `Quick
+      test_direct_calls_hashes_and_source_order;
+    Alcotest.test_case "constructors and operations" `Quick test_constructor_and_operation_calls;
+    Alcotest.test_case "fail-closed diagnostics" `Quick test_fail_closed_diagnostics;
+    Alcotest.test_case "store identity reopen conflict" `Quick
+      test_store_identity_reopen_and_conflict;
+    Alcotest.test_case "checker warnings and recovery names" `Quick
+      test_checker_review_warnings_and_recovery_names;
+  ]


### PR DESCRIPTION
## Summary

- add explicit named arguments for direct `.jac` terms, constructors, and
  effect operations while preserving the positional 27-form kernel
- persist term/operation labels in an additive `call-abi-v1` companion keyed by
  exact callable identity; preserve it across reopen/rename and reject
  conflicting relabels with E0612
- preserve source evaluation order through generated left-to-right lets,
  retain authored labels/order in formatting, and keep `jac export` positional
- fail closed for locals/HOFs, malformed or incomplete label sets, and named
  syntax anywhere inside quotes
- add narrowly companion-gated W1206/W1207 review guidance, executable
  interpreter/native/hash/store evidence, and bounded human/agent docs without
  claiming a readability result

## Contract and limits

The supported grammar is a positional prefix followed by a labeled suffix.
Labels may be called in any order, but every exact-arity slot is filled once.
There are no defaults, puns, partial calls, or positional arguments after a
label.

Top-level equations declare `label: binder`; operations declare `label: Type`;
constructors reuse field labels. Binder names are never inferred as API labels.
Local, anonymous, higher-order, patterned, variadic, unlabeled, and opaque
callees remain positional-only.

Named calls lower solely to existing `App`/`Let` forms. Declaration-order calls
hash exactly like positional twins; reordered calls hash like explicit-let
positional twins and evaluate each argument once in authored order. The kernel,
canonical serialization, evaluator, native ABI, prelude identities, and
bootstrap `.jqd` grammar do not change.

Named surface calls in quotes, including live unquotes, are E1238 because the
quoted carrier cannot durably preserve the external label contract. Exported
`.jqd` remains positional and cannot itself republish a companion ABI.

The preregistered readability study has no SX.23 cohort. Its passing gate is a
regression check only; this PR makes no measured readability claim.

The cross-layer diff exceeds the usual size checkpoint. The reviewed
architecture keeps it atomic because parser semantics without durable identity
would be unsafe, while a stored companion without call elaboration has no
independent user value.

## Verification

Exact reviewed head: `3a0598e9e6f80d4ce2c2633225c4e2bc81a43dee`

- [x] `eval "$(opam env)"`
- [x] `opam exec -- dune build --root "$PWD" @all`
- [x] `opam exec -- dune build --root "$PWD" @doc`
- [x] exact-head `opam exec -- dune runtest --root "$PWD" --force` outside
  ptrace: PASS in 419.483s, including native sanitizer/parity lanes, 59 crams,
  28 doctest examples across 8 documents, and all 877 Alcotest/QCheck cases
- [x] focused six-case `surface-named-calls` suite and forced
  `test/cli/named-args.t`
- [x] 51 surface release-law cases, including D76 status/semantic mutation
  guards and the reviewed 99-line grammar digest
- [x] readability protocol regression: 5 jobs, 3 carriers, 15 dry-run
  conditions; schedule generation: 480 human assignments and 450 M0 trials
- [x] historical-manifest verification and adversarial mutation suite
- [x] immutable SS.22 surface-manifest verification
- [x] `opam exec -- dune fmt --root "$PWD"` and the repository whitespace check
  with a clean committed worktree

The frozen 0.2 distribution reproduction is not redefined by this post-0.2
successor overlay: its complete-diff manifest intentionally describes the
published release artifacts. This PR instead supplies a separate reconstructible
SX.23 decision/evidence pack and runs the current successor gates above.

Independent Claude Code 2.1.235 review using Fable 5 at xhigh effort returned
**PASS** on the exact head, with no blockers, disputed tests, or architecture
conflicts. Its nonblocking notes were a safe untested pipe reconstruction path,
one unreachable defensive diagnostic branch, one redundant weak assertion, a
small E0311 docs-example ambiguity to clean up in the already-separated docs
accuracy MR, and the pre-existing analysis lane's lack of same-file effect
publication.

## Checklist

- [x] I updated tests with behavior changes.
- [x] I kept public contracts documented.
- [x] I preserved the 27-form kernel and permanent `.jqd` carrier.
- [x] I did not add defaults, records, accessors, macros, package behavior, or
  other out-of-scope language features.
