### PR TITLE
HB.1: freeze host protocol v0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,11 @@ When adding valid corpus files, regenerate the golden hashes with
   `src/prelude.ml`.
 - Handlers and evaluation: `src/eval.ml`, `test/test_handlers.ml`,
   `test/test_gauntlet_handlers.ml`.
-- Future host integration contract: `docs/host-boundary.md`. Existing evaluator
-  capture and host-readiness modules are internal seams, not a public ABI;
-  adapters and application servers belong outside this repository.
+- Host integration contracts: `docs/host-boundary.md` and
+  `spec/host-protocol-v0.md`. HB.1 freezes envelopes and schema/state vectors,
+  but no executable carrier ships yet. Existing evaluator capture and
+  host-readiness modules are internal seams, not a public ABI; adapters and
+  application servers belong outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,
   `src/infer_dist.ml`, `test/test_infer.ml`.
 - Warp: `prelude/15-warp.jqd`, `prelude/16-gen.jqd`, `src/warp.ml`,

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 877
+semantic boundary remains historical; the current successor is pinned by 882
 Alcotest/QCheck cases, 59 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
@@ -580,7 +580,7 @@ Key release docs:
 - `docs/`: design docs, tutorial, CI/CD, Warp, stdlib, errors, release evidence.
 - `prelude/`: Jacquard standard library and effect declarations.
 - `scripts/release/`: reproducible release evidence script.
-- `spec/`: kernel AST and canonical serialization specs.
+- `spec/`: kernel AST, canonical serialization, and frozen host-protocol specs.
 - `src/`: OCaml implementation.
 - `test/`: Alcotest/QCheck suites plus cram CLI transcripts.
 - `jacquard.opam`, `dune-project`: package and build metadata.
@@ -619,6 +619,9 @@ Deeper design references:
 - `docs/ast.md`: implemented kernel AST contract and retained design reasoning.
 - `spec/jacquard-kernel-ast-m0.md`: implemented kernel source-of-truth spec.
 - `spec/serialization.md`: canonical byte format.
+- `docs/host-boundary.md`: host/Core ownership and trust boundary.
+- `spec/host-protocol-v0.md`: frozen experimental host envelopes, process
+  framing, limits, failures, and conformance-vector contract.
 - `docs/stdlib.md`: prelude and ringed standard library.
 - `docs/warp-testing.md`: Warp testing model.
 - `docs/errors.md`: diagnostic catalog.
@@ -710,9 +713,10 @@ proofs also do not ship. World grants remain coarse. See
 `docs/release/0.2/LIMITS.md` for the current integrated boundary,
 `docs/release/0.1/LIMITS.md` for the historical Core 0.1 boundary, and
 `docs/release/structured-concurrency/LIMITS.md` for the successor C0-C3 boundary.
-`docs/host-boundary.md` freezes the ownership and trust model for future
-language-neutral integration, but no host ABI, process protocol, adapter, or
-HTTP server ships in this repository today.
+`docs/host-boundary.md` freezes the ownership and trust model, and
+`spec/host-protocol-v0.md` freezes the experimental language-neutral envelopes,
+process framing, limits, and schema/state vectors. No executable host carrier,
+stable ABI, adapter, or HTTP server ships in this repository today.
 The deterministic Workspace v0 governance boundary is separately advertised
 as an evidence-backed research reference implementation, not as a sandbox or
 production security system; its exact claim and trusted-host limits are in

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,11 +30,14 @@ project shape from file names alone.
 - `../spec/jacquard-kernel-ast-m0.md`: implemented kernel AST source-of-truth
   specification.
 - `../spec/serialization.md`: canonical byte serialization and hashing.
+- `../spec/host-protocol-v0.md`: frozen HB.1 transport-neutral envelopes,
+  provisional stdio framing, boundary values, limits, stable failures, and
+  positive/hostile vectors. It is a contract, not a shipped carrier.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,
-  lifecycle, repository, and limitation contract for future integrations. No
-  foreign-host ABI or adapter ships from that design document.
+  lifecycle, repository, and limitation contract for integrations. Read it
+  before the concrete HB.1 protocol spec; neither document ships an adapter.
 - `concurrency.md`: phase-zero pure parallel hints, the staged
   structured-concurrency design, and SC.17 transitive cancellation semantics.
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -895,11 +895,13 @@ Do not invent new kernel forms for surface sugar.
   Channels. It does not ship preemption, host threads, asynchronous host I/O,
   native Task scheduling, native Channels, select/timeouts, actors, or
   supervision.
-- HB.0 documents a future language-neutral host ownership and trust boundary,
-  but no foreign-host ABI, process protocol, adapter, or HTTP server ships.
-  Internal evaluator-capture and host-readiness OCaml APIs are not supported
-  embedding contracts; consume only a future versioned protocol and its
-  conformance fixtures.
+- HB.0 documents the language-neutral host ownership and trust boundary, and
+  HB.1 freezes `jacquard-host-v0` envelopes, provisional process framing,
+  limits, stable failures, and schema/state vectors. No executable carrier,
+  stable foreign-host ABI, adapter, or HTTP server ships. Internal
+  evaluator-capture and host-readiness OCaml APIs are not supported embedding
+  contracts; future adapters must consume the implemented versioned protocol
+  and its executable conformance fixtures, not those OCaml seams.
 - The frozen Workspace v0 governed membrane ships as an evidence-backed
   research reference. It is not a general isolation mechanism, production
   authorization system, or operating-system sandbox; trusted host code still

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -496,6 +496,36 @@ accepting client JSON. E1542 fails closed when the typed report cannot support
 that exact presentation. The browser receives no report on this failure and
 cannot replace or reinterpret the diagnostic.
 
+## Host protocol v0 (E16xx)
+
+HB.1 freezes these `process` diagnostics for the experimental
+`jacquard-host-v0` contract. No executable carrier ships yet. Before invocation
+a trustworthy carrier may return them in `fatal`; after invocation they appear
+in the single error `outcome`. Carrier loss can prevent Core from emitting a
+diagnostic, in which case E1611 belongs to host/operator evidence rather than a
+fabricated Core result.
+
+| Code | Meaning | Example |
+|---|---|---|
+| E1600 | unsupported host protocol version or carrier | selecting `jacquard-host-v1` from a v0-only hello |
+| E1601 | malformed frame or envelope | duplicate JSON keys, invalid UTF-8, or an unknown field |
+| E1602 | host protocol limit exceeded | a 1,048,577-byte frame or a nonpositive selected limit |
+| E1603 | target or pinned interface is invalid | an unresolved callable hash or mismatched parameter type |
+| E1604 | type or value is unsupported at the v0 boundary | trying to transport a Secret, Task, closure, or open type |
+| E1605 | capability envelope is invalid | an extra effect, duplicate operation, or `multi` registry entry |
+| E1606 | root operation is not configured | evaluation reaches an operation absent from the closed host registry |
+| E1607 | host refused authority before action | the adapter rejects a requested resource without starting I/O |
+| E1608 | response/order/finish-once invariant is invalid | the wrong request ID or a message after outcome |
+| E1609 | host reported a non-ambiguous timeout | a deadline expires before an outside action starts |
+| E1610 | host reported non-ambiguous shutdown | shutdown cancels the current response slot before action |
+| E1611 | carrier was lost | EOF inside a frame or process death without a terminal message |
+| E1612 | outside completion is unknown | a timed-out write may have committed and must not be retried |
+| E1613 | outside action definitely failed | the adapter reports a completed failure with no successful value |
+| E1614 | host cancelled non-ambiguously | explicit cancellation before an outside action starts |
+
+See `spec/host-protocol-v0.md` and its checked vector corpus for exact schemas,
+ordering, limits, terminal mapping, and non-retry behavior.
+
 ## Appendix: the W5.3 audit (ten message rewrites)
 
 Before/after wording improvements applied during the audit:

--- a/docs/host-boundary.md
+++ b/docs/host-boundary.md
@@ -1,8 +1,10 @@
 # Language-neutral host boundary
 
 Status: HB.0 design contract, August 2026. This document freezes the roles,
-trust boundary, and compatibility rules for later host integration. It does
-not ship a foreign-host ABI, process protocol, adapter, HTTP server, or host
+trust boundary, and compatibility rules for host integration. HB.1's concrete
+envelopes and vectors are frozen in
+[`spec/host-protocol-v0.md`](../spec/host-protocol-v0.md). Neither document
+ships a foreign-host ABI, executable carrier, adapter, HTTP server, or host
 scheduler.
 
 Read alongside:
@@ -45,9 +47,10 @@ that a malicious host obeyed them.
 implemented in `jacquard-lang`.
 
 **Program artifact** is checked Jacquard code selected by exact canonical
-identity. HB.0 does not introduce modules or a package format. HB.1 must define
-how one checked source/store artifact and one callable entry point are selected
-without treating a mutable display name as identity.
+identity. HB.0 does not introduce modules or a package format. HB.1 selects one
+checked callable by exact stored term-member hash without treating a mutable
+display name as identity; it explicitly declines to invent a module or
+export-name identity.
 
 **Host** is the trusted application or process that invokes Core and owns
 operating-system resources. There is no `Host` effect. A host services exact
@@ -93,8 +96,9 @@ host -> Core: one typed response or refusal for the current request
 Core -> host: one successful value or one structured failure
 ```
 
-This sequence describes meaning, not bytes. HB.1 will freeze the concrete
-envelopes, framing, version negotiation, limits, and conformance vectors.
+This sequence describes meaning, not bytes. HB.1 freezes the concrete
+envelopes, framing, version negotiation, limits, and schema/state conformance
+vectors in [`spec/host-protocol-v0.md`](../spec/host-protocol-v0.md).
 
 The following invariants already apply:
 
@@ -169,11 +173,11 @@ actually happened.
 
 ## 6. Failure, cancellation, and retry
 
-Host failures do not become arbitrary successful Jacquard values. HB.1 must
-define structured categories for at least unsupported operation, refused
-authority, invalid response, timeout, host shutdown, carrier failure, and an
-outside action whose completion is unknown. Exact diagnostic codes and value
-schemas belong to that next contract.
+Host failures do not become arbitrary successful Jacquard values. HB.1 defines
+stable E16xx categories for unsupported operation, refused authority, invalid
+response, timeout, host shutdown, carrier failure, and an outside action whose
+completion is unknown. Their exact envelopes and boundary-value subset are in
+the protocol spec.
 
 Cancellation is cooperative:
 
@@ -214,10 +218,10 @@ more.
 
 Strict schedule replay and world-response replay are different claims. The
 existing deterministic scheduler can validate recorded runnable queues and
-choices; it does not reconstruct arbitrary external state. HB.1 must state
-which host observations a fixture supplies, and later C4 work must state which
-readiness events a host schedule records. Replay must never fall back to live
-I/O after drift.
+choices; it does not reconstruct arbitrary external state. HB.1's labeled
+evidence schema states which host observations a fixture supplies, and later
+C4 work must state which readiness events a host schedule records. Replay must
+never fall back to live I/O after drift.
 
 ## 8. Existing implementation seams are not the boundary
 
@@ -239,9 +243,9 @@ matrix.
 
 ## 9. Repository and product boundary
 
-`jacquard-lang` owns this contract, its carrier implementation inside Core,
-canonical fixtures, and language/runtime evidence. It may contain a tiny fake
-host used only to prove conformance.
+`jacquard-lang` owns this contract, the HB.1 schema/state vectors, its later
+carrier implementation inside Core, executable fixtures, and language/runtime
+evidence. It may contain a tiny fake host used only to prove conformance.
 
 The private `jacquard-host` repository owns real adapters, sockets,
 persistence, the minimal serial HTTP integration, and the requirements report
@@ -264,7 +268,7 @@ headers are not smuggled into HB.0.
 |---|---|---|
 | First-party programs | safety for hostile uploaded Jacquard code | separate-process or equivalent isolation design, hostile resource tests, and reviewed threat model |
 | Trusted adapter and OS | protection from a lying host or broader OS credentials | independently enforced isolation/authentication plus external security review |
-| No carrier yet | interoperability or embedding support | HB.1 schema, implementation, canonical fixtures, and evidence |
+| No carrier implementation yet | interoperability or embedding support | HB.2 implementation followed by HB.3 executable cross-language fixtures and evidence |
 | Experimental process carrier first | permanent ABI stability or low-overhead embedding | two independent adapters and one real integration pass the frozen fixtures before v1 |
 | One serial invocation | concurrent requests, streaming, or throughput | demonstrated need followed by the C4 scheduler contract and resource evidence |
 | No automatic side-effect retry | transparent recovery from ambiguous completion | per-operation idempotency, receipt, and crash/recovery contract |
@@ -281,8 +285,9 @@ exact reviewed change that removes one. Silence never widens the claim.
 HB.0 closes when this role/trust contract is reviewed. It authorizes no runtime
 code by itself.
 
-HB.1 freezes concrete values, envelopes, framing, version negotiation,
-resource ceilings, failure schemas, and canonical positive/hostile vectors.
+HB.1 is frozen by [`spec/host-protocol-v0.md`](../spec/host-protocol-v0.md):
+concrete values, envelopes, framing, version negotiation, resource ceilings,
+failure schemas, and canonical positive/hostile schema/state vectors.
 
 HB.2 implements the opt-in serial carrier and interpreter seam without HTTP,
 SQLite, concurrency, or a new kernel form.

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `877`
+Test count: `882`
 
 Cram count: `59`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `877`
+- Alcotest/QCheck cases: `882`
 - Cram transcript files: `59`
 - Documentation examples: `28` named examples across `8` documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `877`
+- Alcotest/QCheck cases: `882`
 - Cram transcript files: `59`
 - Doctest examples: `28` across 8 documents
 
@@ -61,8 +61,9 @@ and direct/fail-fast transitive-cancellation sentinel safety. It extends the
 existing concurrency transcript and adds no cram or doctest entry.
 Task 171 adds one labeled-pattern contract case. SX.23 then adds six compiled
 named-call cases, two D76 decision-mutation cases, and one CLI transcript,
-producing the current `877 / 59 / 28` successor inventory without changing the
-historical DX.2 publication.
+producing `877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract
+cases, producing the current `882 / 59 / 28` successor inventory without
+changing the historical DX.2 publication.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 877 compiled Alcotest/QCheck cases, 59 recursive
+The current successor inventory is exactly 882 compiled Alcotest/QCheck cases, 59 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `877`
+- Alcotest/QCheck cases: `882`
 - Cram transcript files: `59`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -814,8 +814,9 @@ producing the then-current `865 / 58 / 28` inventory. RW.7 adds the three-case
 registered relational regression net without adding a cram file or doctest,
 producing the `868 / 58 / 28` inventory. Task 171 adds the labeled-pattern
 contract case, producing `869 / 58 / 28`. SX.23 then adds six named-call cases,
-two D76 decision-mutation cases, and one transcript, producing the current
-`877 / 59 / 28` inventory.
+two D76 decision-mutation cases, and one transcript, producing
+`877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract cases,
+producing the current `882 / 59 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -1,0 +1,617 @@
+# Jacquard host protocol v0
+
+Status: frozen HB.1 contract, August 2026.
+
+This specification turns the abstract boundary in
+[`docs/host-boundary.md`](../docs/host-boundary.md) into concrete envelopes and
+test vectors. It defines one transport-neutral invocation model and one
+provisional process carrier. It does not ship the carrier, an adapter, a
+module system, HTTP, persistence, asynchronous I/O, or a security sandbox.
+
+The version name is `jacquard-host-v0`. The provisional carrier name is
+`stdio-u32-json-v0`.
+
+## 1. Contract at a glance
+
+One trusted host starts one Core worker and performs at most one invocation:
+
+```text
+Core -> host  core_hello
+host -> Core  host_select
+host -> Core  invoke
+Core -> host  effect_request       zero or more times
+host -> Core  effect_ok | effect_failure | cancel
+Core -> host  outcome              exactly once
+```
+
+After negotiation, the host may send `shutdown` instead of `invoke`; Core
+answers `shutdown_ack` and exits. There is never more than one live invocation
+or one outstanding effect request. A second invocation, a response for the
+wrong request, or any message after a terminal frame is a protocol error.
+
+The first version deliberately chooses these constraints:
+
+- the target is one checked, content-addressed term, not a mutable module or
+  export name;
+- the callable interface is closed, monomorphic, positional, and
+  first-order;
+- the capability set is the callable's exact closed effect row;
+- the host registry contains exact `once` operation identities;
+- Core chooses when and how a continuation resumes;
+- protocol IDs are deterministic ordinals scoped to this one worker; and
+- Core evidence and relayed host observations remain visibly separate.
+
+Ordinary `jac run`, native artifacts, and the interpreted scheduler do not use
+this protocol unless a later HB.2 entry point opts in explicitly.
+
+## 2. Trust and non-claims
+
+The host and operating system are trusted. Core validates the selected
+artifact, interface, values, capabilities, operation identities, ordering, and
+limits. It cannot prove that the host performed the stated outside action,
+used only the stated OS authority, reported an honest result, or retained no
+private data.
+
+This is an application capability boundary, not hostile-code containment.
+The protocol has no authentication, encryption, remote transport, TLS,
+reverse-proxy semantics, vendor headers, public-listener policy, or
+production-deployment claim. The process carrier is local integration
+evidence. Its bytes are not `HASH_V0`, an artifact identity, or a permanent
+ABI.
+
+## 3. Framing and process behavior
+
+`stdio-u32-json-v0` uses the child process's standard streams:
+
+- host-to-Core frames travel on stdin;
+- Core-to-host frames travel on stdout; and
+- stderr is bounded human/operator output and is never a protocol or evidence
+  channel.
+
+The worker starts against one host-selected local Core store. Store location,
+artifact copying, process environment, and launch credentials are startup
+configuration, not envelope fields or Core evidence. The target hash and its
+complete reachable closure must resolve in that store before evaluation.
+
+Each frame is four bytes of unsigned big-endian payload length followed by
+exactly that many payload bytes. The length must be between 1 and the active
+`max_frame_bytes`, inclusive. The payload is one UTF-8 JSON object. There is no
+compression, byte-order marker, trailing newline, or data after the JSON
+value. A writer emits and flushes one complete frame before another writer may
+act.
+
+Before `host_select`, both directions use the hard limits in section 6. After
+selection, both directions use the selected limits. EOF inside a length or
+payload, invalid UTF-8, a non-object JSON value, duplicate object keys, an
+unknown or missing field, a disallowed JSON value, or trailing payload data
+fails closed.
+
+JSON object key order and insignificant whitespace do not carry meaning.
+Implementations must not hash raw frame bytes as semantic evidence. Protocol
+strings are decoded Unicode scalar values; lone surrogate escapes and invalid
+UTF-8 are rejected. Jacquard `Text` bytes are not normalized.
+
+Core writes nothing to stdout except frames. A valid `outcome`, `fatal`, or
+`shutdown_ack` that is completely flushed is a structured terminal result and
+permits process exit 0. Exit 64 means that a protocol failure prevented a
+trustworthy terminal frame, exit 70 means an internal Core invariant failed,
+and exit 74 means carrier I/O was lost. Exit status alone never upgrades a
+missing terminal frame into Core evidence.
+
+Core writes at most the selected `max_stderr_bytes` over the worker lifetime.
+It truncates further operator text at a valid UTF-8 boundary. Truncation never
+changes, supplements, or substitutes for a structured protocol result.
+
+## 4. Common validation rules
+
+Every object has an exact field set. “Optional” means that the field's presence
+rule is stated explicitly; otherwise omission and addition are errors. Every
+post-selection message carries `"protocol":"jacquard-host-v0"`.
+
+Hashes are exactly 64 lowercase hexadecimal characters. They identify
+existing `HASH_V0` objects; this protocol does not define another Jacquard
+hash. Lists described as sets are strictly sorted by raw hash bytes and contain
+no duplicates. Because the text is lowercase hexadecimal, byte order and text
+order agree.
+
+The invocation ID is exactly `0000000000000000`. The first effect request ID
+is `0000000000000001`; later IDs increase by one and use 16 lowercase
+hexadecimal digits. These IDs are deterministic, worker-local correlation
+ordinals, not globally unique evidence identities. A deployment may attach a
+separate host-owned run ID outside Core evidence.
+
+JSON integers appear only in bounded protocol counters, limits, and the
+existing diagnostic-v1 span object. Jacquard `Int` and `Real` values use the
+lossless encodings below.
+
+Validation is fail-fast in this order: framing and carrier loss; UTF-8, JSON,
+nesting, and exact envelope shape; protocol version; message state and IDs;
+target/interface/value preflight; capability preflight; then evaluation and
+typed effect responses. A lower-level failure is not relabeled by material
+that could not yet be trusted. The hostile vectors each isolate one primary
+failure under this order.
+
+## 5. Boundary types and values
+
+### 5.1 Type descriptions
+
+The callable itself must check as one closed monomorphic `TArrow`. Its
+parameters and result use only these recursive descriptions:
+
+```json
+{"arguments":[],"identity":"1111111111111111111111111111111111111111111111111111111111111111","kind":"nominal"}
+```
+
+```json
+{"items":[],"kind":"tuple"}
+```
+
+A `nominal` description is one exact declared type identity plus zero or more
+type arguments. A `tuple` is the existing Jacquard tuple type; zero items is
+unit. The same depth, node, and collection limits as values apply.
+
+Type variables, open rows, arrows nested in data, `Resume`, variadic arrows,
+checker-internal exact thunks, and unresolved identities are not boundary-safe
+in v0. Core derives the callable's actual type and requires structural equality
+with the supplied interface before evaluation. Display names and
+`call-abi-v1` labels are not part of this positional interface.
+
+### 5.2 Value descriptions
+
+The following exact object variants map to existing runtime values:
+
+```json
+{"kind":"int","value":"-12"}
+{"bits":"8000000000000000","kind":"real"}
+{"kind":"text","value":"hello"}
+{"kind":"hash","value":"2222222222222222222222222222222222222222222222222222222222222222"}
+{"items":[],"kind":"tuple"}
+{"arguments":[],"identity":"3333333333333333333333333333333333333333333333333333333333333333","kind":"constructor"}
+```
+
+An `int` value is canonical decimal text in the released OCaml 63-bit range
+`-4611686018427387904` through `4611686018427387903`. Zero is `0`; leading
+zeros, a plus sign, and negative zero are rejected.
+
+A `real` value is exactly 16 lowercase hexadecimal digits containing the raw
+IEEE-754 binary64 bits. This preserves infinities, NaNs, and negative zero. It
+is intentionally not the normalized real encoding used as `HASH_V0` input.
+
+A `text` value is valid UTF-8 after JSON decoding and receives no Unicode
+normalization. A `hash` becomes the existing validated opaque `VHash`. A
+`tuple` is ordered. A `constructor` is a saturated `VCon`; Core resolves the
+exact constructor identity, checks arity and field types, and ignores no
+display name because none crosses the boundary.
+
+`Code`, `Secret`, `Task`, `ChannelHandle`, `Resume`, closures, builtins,
+operation values, and unapplied constructors have no v0 encoding. They fail
+with E1604 rather than being rendered to text, assigned a remote handle, or
+silently redacted into a different value. Later versions may add a value only
+with an exact ownership, lifetime, type, and conformance contract.
+
+Every incoming argument and successful operation response is checked against
+its expected Jacquard type before use. Every outgoing result and operation
+argument is checked before encoding. A syntactically valid value with the
+wrong type is an invalid response or outcome, not a coercion opportunity.
+
+## 6. Fixed and selected limits
+
+Core's first frame advertises these hard maxima:
+
+| Field | Hard maximum | Meaning |
+|---|---:|---|
+| `max_frame_bytes` | 1,048,576 | four-byte length excludes the prefix |
+| `max_json_depth` | 64 | object/array nesting after JSON decoding |
+| `max_value_nodes` | 4,096 | aggregate type/value nodes in one frame |
+| `max_text_bytes` | 262,144 | UTF-8 bytes in one Jacquard `Text` |
+| `max_collection_items` | 1,024 | items in one array-valued field |
+| `max_arguments` | 64 | callable or operation arguments |
+| `max_effects` | 64 | exact effect grants |
+| `max_operations` | 256 | configured host operation entries |
+| `max_effect_requests` | 1,024 | requests in the invocation |
+| `max_diagnostics` | 32 | diagnostics in one terminal result |
+| `max_diagnostic_bytes` | 65,536 | aggregate UTF-8 diagnostic string bytes |
+| `max_host_message_bytes` | 4,096 | one redacted host failure message |
+| `max_stderr_bytes` | 65,536 | aggregate operator bytes over one worker |
+
+`host_select` repeats every field with a positive integer no greater than the
+advertised maximum. The selected object is the component-wise operational
+ceiling; it is not a request to allocate every maximum. A deployment may
+choose smaller values, but the selection is frozen before the target or any
+argument is accepted.
+
+Core accepts a selection only when its limits can represent the mandatory
+smallest `fatal` and `shutdown_ack`; otherwise it returns E1602 under the hard
+pre-selection limits. Before accepting an `invoke`, Core likewise verifies
+that the selected limits can represent one bounded error `outcome` containing
+that invocation's validated evidence. This prevents an accepted invocation
+whose failure could never be reported structurally.
+
+Limits apply before allocation when possible. A frame cannot evade a node,
+text, collection, or depth limit merely because it is below the byte limit.
+Limit diagnostics themselves use small fixed prose and must not echo the
+refused payload.
+
+Counting is exact. The root JSON object has depth 1; each nested object or
+array adds 1, while a scalar adds no container depth. Each occurrence of a
+boundary type or value variant object is one value node, including repeated
+occurrences in an outcome's evidence. Collection and argument limits apply to
+each corresponding array; effect-request count is cumulative for the
+invocation. Diagnostic bytes are the sum of decoded UTF-8 bytes in all string
+values of the diagnostic objects, including span paths and contrasts but not
+fixed JSON keys. The stderr limit counts bytes actually written, including any
+truncation marker when one fits.
+
+## 7. Handshake and target selection
+
+### 7.1 `core_hello`
+
+Core's first frame has exactly `carrier`, `kind`, `limits`, and `versions`:
+
+```json
+{
+  "carrier": "stdio-u32-json-v0",
+  "kind": "core_hello",
+  "limits": { "...": "all hard-limit fields from section 6" },
+  "versions": ["jacquard-host-v0"]
+}
+```
+
+The versions list is nonempty and ordered from most to least preferred. v0
+contains only the value shown.
+
+### 7.2 `host_select`
+
+The host answers with exactly `kind`, `limits`, and `protocol`:
+
+```json
+{
+  "kind": "host_select",
+  "limits": { "...": "all selected-limit fields from section 6" },
+  "protocol": "jacquard-host-v0"
+}
+```
+
+An unsupported version is E1600. A missing, extra, nonpositive, or excessive
+limit is E1601 or E1602 as appropriate. No version fallback occurs after this
+frame.
+
+### 7.3 `invoke`
+
+The host then sends exactly these fields:
+
+```json
+{
+  "arguments": [],
+  "capabilities": {
+    "effects": [],
+    "operations": []
+  },
+  "interface": {
+    "effects": [],
+    "parameters": [],
+    "result": {"items": [], "kind": "tuple"}
+  },
+  "invocation_id": "0000000000000000",
+  "kind": "invoke",
+  "protocol": "jacquard-host-v0",
+  "target": {
+    "callable": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "kind": "store-term-v0"
+  }
+}
+```
+
+`target.callable` is an exact stored term-member hash. Its resolved references
+transitively bind the code it can directly reach. Core requires the complete
+reachable store closure to be present and valid. v0 has no module, package,
+export, source-path, or display-name identity; any such field is rejected.
+Artifact distribution and provenance remain host-owned.
+
+`interface` is the host's pinned expectation. `parameters` and `result` must
+equal Core's derived boundary-safe arrow, and `effects` must equal its exact
+closed row. Arguments are positional, have the same count as parameters, and
+must validate against them.
+
+`capabilities.effects` must exactly equal `interface.effects`. The equality
+prevents both missing grants and undeclared whole-effect authority. Each
+operation entry has exactly `effect`, `mode`, and `operation`; entries sort by `(effect,
+operation)`, are unique, resolve in the selected store, name an operation of
+that exact effect, and use `"mode":"once"`. An entry cannot introduce an
+effect absent from the grant. Every configured operation must have closed,
+monomorphic parameter and result types expressible by section 5; generic or
+boundary-unsafe operation signatures fail E1604 during preflight. The registry
+may cover only part of a granted effect; reaching another operation fails
+E1606 before a request is sent.
+
+The closed registry narrows adapter availability but does not turn Core 0.2's
+whole-effect grant into path, host, port, or database-row containment. Correct
+adapter enforcement and OS authority remain trusted.
+
+## 8. Effect exchange
+
+When a configured root operation is reached, Core emits exactly:
+
+```json
+{
+  "arguments": [],
+  "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "invocation_id": "0000000000000000",
+  "kind": "effect_request",
+  "mode": "once",
+  "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "protocol": "jacquard-host-v0",
+  "request_id": "0000000000000001"
+}
+```
+
+Core derives the identity, mode, argument count, argument types, and result
+type from the checked store. The host dispatches only by its pinned registry;
+names or strings inside arguments never select an adapter by themselves. Core
+emits requests in evaluation order and never emits another until the current
+request has one accepted response.
+
+For success, the host sends exactly:
+
+```json
+{
+  "invocation_id": "0000000000000000",
+  "kind": "effect_ok",
+  "protocol": "jacquard-host-v0",
+  "request_id": "0000000000000001",
+  "value": {"items": [], "kind": "tuple"}
+}
+```
+
+For a valid outside failure, the host sends exactly:
+
+```json
+{
+  "category": "refused_authority",
+  "completion": "not_started",
+  "invocation_id": "0000000000000000",
+  "kind": "effect_failure",
+  "message": "redacted host-owned detail",
+  "protocol": "jacquard-host-v0",
+  "request_id": "0000000000000001"
+}
+```
+
+The allowed `(category, completion)` pairs are exact:
+
+| Category | Completion | Meaning |
+|---|---|---|
+| `unsupported_operation` | `not_started` | host registry drift; E1606 |
+| `refused_authority` | `not_started` | host refused before action; E1607 |
+| `outside_failure` | `failed` | action ran and failed definitely; E1613 |
+| `completion_unknown` | `unknown` | action may have happened; E1612 |
+
+`message` is host-authored, already redacted, valid UTF-8 detail no larger than
+the selected `max_host_message_bytes` after JSON decoding. Core places those
+exact decoded bytes in a bounded diagnostic-cause suffix; it performs no
+secret detection and trusts the host to redact them. The message is not
+canonical evidence and must not contain secrets, raw participant data, or an
+entire outside response. Typed receipts belong in an operation's declared
+result, not an untyped protocol side channel.
+
+An invalid ID, duplicate or late response, invalid pair, malformed value, or
+value of the wrong result type terminates with E1608. Core does not send the
+request again or let the host choose whether to reuse the continuation.
+
+## 9. Cancellation, timeout, and shutdown
+
+During the one response slot, the host may send `cancel` instead of an effect
+response:
+
+```json
+{
+  "completion": "unknown",
+  "invocation_id": "0000000000000000",
+  "kind": "cancel",
+  "protocol": "jacquard-host-v0",
+  "reason": "timeout",
+  "request_id": "0000000000000001"
+}
+```
+
+`reason` is exactly `cancelled`, `timeout`, or `host_shutdown`.
+`completion` is exactly `not_started`, `failed`, or `unknown`. Unknown
+completion takes precedence as E1612; otherwise the reason maps to E1614,
+E1609, or E1610. All nine combinations and their terminal evidence values are
+enumerated in the vector corpus's `terminal_mappings`. Core consumes no
+successful operation result, releases invocation-owned resources, emits one
+error outcome, and never retries.
+
+The serial carrier reads host control only at protocol boundaries. It does not
+preempt a pure computation and does not create a reader thread or event loop.
+If a host deadline expires while Core is not awaiting a response, the host may
+terminate the worker; that is host-owned carrier-failure evidence, not a
+fabricated Core outcome.
+
+After selection but before invocation, the host may send exactly
+`{"kind":"shutdown","protocol":"jacquard-host-v0"}`. Core answers the same
+two fields with kind `shutdown_ack`, flushes, and exits. After `invoke`,
+shutdown is represented by `cancel` with reason `host_shutdown`; an
+out-of-band process kill may leave only host evidence.
+
+Cancellation and shutdown cannot undo an outside action. An `unknown`
+completion is terminal. Automatic invocation, request, or continuation retry
+is forbidden. A later operation-specific version may permit retry only by
+binding idempotency keys, authenticated receipts, and crash/recovery behavior.
+
+## 10. Outcomes, diagnostics, and evidence
+
+Core emits one `outcome` with exactly `evidence`, `invocation_id`, `kind`,
+`protocol`, and `result`.
+
+A successful result is
+`{"kind":"ok","value":VALUE}`. An error result is
+`{"diagnostics":[DIAGNOSTIC...],"kind":"error"}`. Diagnostics use the
+existing `jacquard-diagnostic-v1` JSON object from `Diag.to_yojson`; this
+protocol does not flatten or replace its domain, code, span, summary, cause,
+next step, or optional contrast. Host failures are converted by Core into the
+stable codes in section 11.
+
+`evidence` has exactly two labeled parts:
+
+```json
+{
+  "core": {
+    "capabilities": {
+      "effects": [],
+      "operations": []
+    },
+    "effect_requests": [],
+    "interface": {
+      "effects": [],
+      "parameters": [],
+      "result": {"items": [], "kind": "tuple"}
+    },
+    "invocation_id": "0000000000000000",
+    "schema": "jacquard-host-core-evidence-v0",
+    "target": {
+      "callable": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "kind": "store-term-v0"
+    },
+    "terminal": "ok"
+  },
+  "host_observations": {
+    "responses": [],
+    "schema": "jacquard-host-observations-v0"
+  }
+}
+```
+
+Core evidence repeats the exact validated target, interface, and complete
+capability envelope, plus deterministic request order. It deliberately omits
+argument and result values from the evidence section; those remain in their
+typed protocol messages and may be retained only under the host's separate
+privacy policy. Each `effect_requests` item has exactly `effect`, `operation`,
+and one-based integer `ordinal`. `terminal` is exactly `ok`, `diagnostic`,
+`cancelled`, `host_failure`, or `completion_unknown`.
+
+Each relayed accepted host response has exactly `category`, `completion`, and
+`ordinal`. Successful responses use category `ok` and completion `completed`;
+effect failures retain their `category` and `completion`; cancellation uses
+its `reason` as the observation category and retains its `completion`.
+Malformed or rejected messages are not accepted observations. The host
+observation section excludes message text, argument values, result values,
+timestamps, peer identity, receipts, credentials, and deployment IDs. It
+records what the trusted host claimed, not what `HASH_V0` proved.
+
+The terminal result and evidence object are deterministic for the same exact
+target, interface, arguments, registry, and sequence of host messages. No
+timestamp, random ID, process ID, display name, source path, or environment
+field enters Core evidence. A host may bind separate authenticated operational
+evidence to this transcript, but must label it as host-owned.
+
+After `outcome`, `fatal`, or `shutdown_ack`, Core closes the protocol without
+waiting for another frame. A conforming host adapter rejects any attempted
+post-terminal send locally as E1608 and does not write it. If Core happens to
+observe already-buffered material, it may classify it as E1608 but never emits
+a second terminal frame.
+
+## 11. Stable protocol diagnostics
+
+These codes extend the existing structured diagnostic catalog. They use domain
+`process`, severity `error`, and a specific next step. Payload excerpts are
+bounded and never copied wholesale.
+
+| Code | Condition |
+|---|---|
+| E1600 | unsupported protocol version or carrier selection |
+| E1601 | malformed framing, UTF-8, JSON, field set, scalar, or envelope shape |
+| E1602 | selected or observed byte, depth, node, text, collection, count, or diagnostic limit exceeded |
+| E1603 | target is absent, unresolved, non-callable, store-incomplete, or disagrees with the pinned interface |
+| E1604 | interface or runtime value uses an unsupported or non-first-order boundary kind |
+| E1605 | capability effects/operations are missing, extra, unsorted, duplicated, mismatched, non-`once`, or unresolved |
+| E1606 | a root operation is not in the configured registry or the host reports it unsupported |
+| E1607 | the host reports authority refusal before an outside action starts |
+| E1608 | message order, protocol/invocation/request ID, response shape, response type, or finish-once invariant is invalid |
+| E1609 | the host reports a timeout with known non-ambiguous completion |
+| E1610 | the host reports shutdown with known non-ambiguous completion |
+| E1611 | EOF, process death, write failure, or carrier loss prevents a trustworthy terminal exchange |
+| E1612 | the host reports that an outside action's completion is unknown |
+| E1613 | the host reports that an outside action definitely failed |
+| E1614 | the host cancels with known non-ambiguous completion |
+
+A violation before a received `invoke` has passed all target, interface,
+argument, and capability preflight uses a `fatal` frame containing one or more
+diagnostic-v1 objects when framing remains trustworthy. This includes a
+malformed or rejected `invoke`: no checked invocation began. Once preflight
+succeeds and evaluation starts, a violation uses the single error `outcome`.
+Carrier loss may make either frame impossible; E1611 then belongs in
+host/operator evidence and must not be pretended to have come from Core.
+
+The pre-invocation terminal frame has exactly
+`{"diagnostics":[DIAGNOSTIC...],"kind":"fatal","protocol":"jacquard-host-v0"}`.
+The diagnostics array is nonempty. It obeys the selected diagnostic count/byte
+limits when selection succeeded and the hard limits otherwise. It carries no
+invocation ID or evidence because no checked invocation began. An error
+`outcome` likewise contains a nonempty diagnostics array.
+
+## 12. Compatibility and evolution
+
+v0 readers reject every unknown version, kind, field, enum member, value
+variant, type variant, operation mode, and response shape. Writers emit only
+the selected version. There is no ignore-unknown-field rule and no negotiation
+inside an invocation.
+
+An additive field, value kind, type kind, mode, message, or relaxed ordering
+rule requires a new protocol version because v0's exact schemas reject it. A
+new carrier may implement the same abstract sequence without changing v0
+meaning, but it needs its own framing and ownership contract. A stable v1
+claim remains gated by two independent adapters and one real serial
+integration passing the same semantic fixtures.
+
+This protocol changes no kernel form, canonical serializer byte, `HASH_V0`
+derivation, type/effect rule, operation mode, continuation rule, diagnostic-v1
+shape, ordinary CLI behavior, or existing native/interpreter claim.
+
+## 13. Conformance vectors
+
+[`host-protocol-v0/vectors.json`](host-protocol-v0/vectors.json) is the
+normative HB.1 schema/state corpus. Positive cases contain complete semantic
+transcripts. Hostile cases name the exact phase, mutation, and E16xx result.
+Raw framing cases carry hexadecimal bytes so truncated lengths and invalid
+UTF-8 survive JSON transport.
+
+Hostile `framing`, `host_select`, and `invoke` phases are Core preflight cases
+and produce one `fatal` in the controlled harness. `evaluation` and
+`effect_response` phases begin after accepted preflight and produce one error
+`outcome`. The `terminal` phase is a host-state-machine case: the host rejects
+the attempted send locally after the already-recorded Core outcome. Raw input
+loss assumes Core's stdout remains writable; a real bidirectional carrier loss
+may instead leave only host/operator E1611 evidence.
+
+The identities in HB.1 vectors are explicit synthetic 64-digit hashes. They
+test framing, envelopes, ordering, limits, failure mapping, and evidence
+separation; they do not claim that a Core store contains those objects. HB.2
+adds the executable Core carrier fixtures. HB.3 packages the final executable
+fixtures for independent adapters and replaces no HB.1 expectation.
+
+A conforming implementation must:
+
+- accept every positive transcript through its stated terminal result;
+- reject every hostile case with the stated primary code and before the stated
+  forbidden action;
+- never emit an effect request for a preflight failure;
+- never retry or emit a second terminal result; and
+- compare semantic JSON objects, not insignificant whitespace or key order.
+
+## 14. Frozen decisions
+
+| ID | Decision | Frozen result |
+|---|---|---|
+| HP0.1 | invocation unit | one worker, one selected version, at most one invocation, one outstanding request |
+| HP0.2 | first carrier | local stdio, four-byte big-endian length, bounded UTF-8 JSON object |
+| HP0.3 | target identity | exact stored term-member `HASH_V0`; no mutable module/export/path identity |
+| HP0.4 | callable shape | closed monomorphic positional first-order arrow with an exact closed effect row |
+| HP0.5 | values | lossless Int/Real/Text/Hash/tuple/saturated-constructor subset; every opaque or callable value fails closed |
+| HP0.6 | authority | capability effects equal the row; exact sorted `once` registry with monomorphic boundary-safe operations; no universal RPC or resource-containment claim |
+| HP0.7 | ordering | deterministic worker-local invocation/request ordinals and strict source-order lockstep |
+| HP0.8 | cancellation | cooperative only at protocol boundaries; pure-compute kill is host carrier evidence |
+| HP0.9 | ambiguity | unknown outside completion is terminal E1612 and is never retried automatically |
+| HP0.10 | evidence | deterministic Core facts and relayed host observations use separate labeled schemas |
+| HP0.11 | compatibility | exact schemas, fail-closed unknowns, version bump for any shape or semantic extension |
+| HP0.12 | implementation gate | HB.1 freezes schema/state vectors; HB.2 implements Core; HB.3 publishes cross-language evidence |

--- a/spec/host-protocol-v0/README.md
+++ b/spec/host-protocol-v0/README.md
@@ -1,0 +1,59 @@
+# Host protocol v0 vectors
+
+`vectors.json` is the normative HB.1 schema and state-machine corpus for
+`jacquard-host-v0`. Read it with [`../host-protocol-v0.md`](../host-protocol-v0.md).
+
+The file is data, not a transcript of a released carrier. Its 64-digit
+identities are deliberately synthetic and well formed; they do not claim that
+a Jacquard store contains those objects. HB.2 adds executable Core artifacts,
+and HB.3 packages those artifacts for independent adapters.
+
+## Format
+
+- `hard_limits` repeats the exact maxima in the specification.
+- `templates` contains complete semantic frames. Each template records its
+  direction and message. An exact object `{"$ref":"hard_limits"}` expands to
+  the top-level `hard_limits` object before use.
+- `positive` contains valid success, refusal, ambiguous-timeout, and graceful
+  shutdown template sequences with the expected terminal result. A conforming
+  state machine accepts every sequence.
+- `terminal_mappings` exhaustively maps the four valid host-failure pairs and
+  all nine cancellation `(reason, completion)` pairs to a diagnostic and Core
+  terminal category.
+- `hostile` starts from a named positive sequence and applies exactly one
+  mutation. JSON-pointer paths address the expanded message at the stated
+  zero-based frame index. `append` adds one named template after the base
+  sequence. `raw_wire` supplies complete or deliberately incomplete bytes as
+  lowercase hexadecimal and does not use a semantic template.
+
+Each hostile expectation states the primary E16xx code, the number of effect
+requests Core may have emitted before refusing the case, and the maximum
+number of structured terminal frames. `forbid_outside_action` means the case
+must fail before adapter execution, even if its malformed envelope contains
+plausible action text.
+
+Phase also fixes the rejecting side and terminal shape. `framing`,
+`host_select`, and `invoke` are rejected by Core with one `fatal` in the
+controlled harness. `evaluation` and `effect_response` are rejected by Core
+with one error `outcome`. `terminal` is rejected locally by the host state
+machine before it writes after the already-recorded outcome. Raw truncated
+input assumes stdout remains writable; bidirectional loss may prevent the
+fatal outside the controlled vector harness.
+
+JSON object order and insignificant whitespace are not conformance inputs.
+Duplicate-key and invalid-UTF-8 cases use `raw_wire` because an ordinary parsed
+JSON object cannot retain those defects.
+
+## Updating
+
+Changing a template field, state sequence, mutation, limit, expected code, or
+forbidden-action boundary changes the frozen protocol. It requires a reviewed
+protocol-version decision, not a mechanical golden refresh. Additive cases
+that expose an already-specified edge may remain v0 when they do not make a
+previously rejected message valid.
+
+The OCaml test suite checks the vector document's schema, identities, limits,
+template directions, positive state sequences, authority evidence echoes,
+the complete terminal matrix, resolvable mutation pointers, raw hex, unique
+names, and complete E1600-E1614 case coverage. HB.2 must make the same cases
+executable rather than weakening these checks.

--- a/spec/host-protocol-v0/vectors.json
+++ b/spec/host-protocol-v0/vectors.json
@@ -1,0 +1,775 @@
+{
+  "schema": "jacquard-host-vectors-v0",
+  "hard_limits": {
+    "max_arguments": 64,
+    "max_collection_items": 1024,
+    "max_diagnostic_bytes": 65536,
+    "max_diagnostics": 32,
+    "max_effect_requests": 1024,
+    "max_effects": 64,
+    "max_frame_bytes": 1048576,
+    "max_host_message_bytes": 4096,
+    "max_json_depth": 64,
+    "max_operations": 256,
+    "max_stderr_bytes": 65536,
+    "max_text_bytes": 262144,
+    "max_value_nodes": 4096
+  },
+  "templates": {
+    "core_hello": {
+      "direction": "core_to_host",
+      "message": {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {"$ref": "hard_limits"},
+        "versions": ["jacquard-host-v0"]
+      }
+    },
+    "host_select": {
+      "direction": "host_to_core",
+      "message": {
+        "kind": "host_select",
+        "limits": {"$ref": "hard_limits"},
+        "protocol": "jacquard-host-v0"
+      }
+    },
+    "pure_invoke": {
+      "direction": "host_to_core",
+      "message": {
+        "arguments": [],
+        "capabilities": {"effects": [], "operations": []},
+        "interface": {
+          "effects": [],
+          "parameters": [],
+          "result": {"items": [], "kind": "tuple"}
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "invoke",
+        "protocol": "jacquard-host-v0",
+        "target": {
+          "callable": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "kind": "store-term-v0"
+        }
+      }
+    },
+    "pure_outcome": {
+      "direction": "core_to_host",
+      "message": {
+        "evidence": {
+          "core": {
+            "capabilities": {"effects": [], "operations": []},
+            "effect_requests": [],
+            "interface": {
+              "effects": [],
+              "parameters": [],
+              "result": {"items": [], "kind": "tuple"}
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "kind": "store-term-v0"
+            },
+            "terminal": "ok"
+          },
+          "host_observations": {
+            "responses": [],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {"kind": "ok", "value": {"items": [], "kind": "tuple"}}
+      }
+    },
+    "effect_invoke": {
+      "direction": "host_to_core",
+      "message": {
+        "arguments": [{"kind": "text", "value": "ping"}],
+        "capabilities": {
+          "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+          "operations": [
+            {
+              "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "mode": "once",
+              "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            }
+          ]
+        },
+        "interface": {
+          "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+          "parameters": [
+            {
+              "arguments": [],
+              "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+              "kind": "nominal"
+            }
+          ],
+          "result": {
+            "arguments": [],
+            "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+            "kind": "nominal"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "invoke",
+        "protocol": "jacquard-host-v0",
+        "target": {
+          "callable": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "kind": "store-term-v0"
+        }
+      }
+    },
+    "effect_request": {
+      "direction": "core_to_host",
+      "message": {
+        "arguments": [{"kind": "text", "value": "ping"}],
+        "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_request",
+        "mode": "once",
+        "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      }
+    },
+    "effect_ok": {
+      "direction": "host_to_core",
+      "message": {
+        "invocation_id": "0000000000000000",
+        "kind": "effect_ok",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001",
+        "value": {"kind": "text", "value": "pong"}
+      }
+    },
+    "effect_outcome": {
+      "direction": "core_to_host",
+      "message": {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+              "operations": [
+                {
+                  "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                  "mode": "once",
+                  "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              "kind": "store-term-v0"
+            },
+            "terminal": "ok"
+          },
+          "host_observations": {
+            "responses": [{"category": "ok", "completion": "completed", "ordinal": 1}],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {"kind": "ok", "value": {"kind": "text", "value": "pong"}}
+      }
+    },
+    "effect_refused": {
+      "direction": "host_to_core",
+      "message": {
+        "category": "refused_authority",
+        "completion": "not_started",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_failure",
+        "message": "policy denied",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      }
+    },
+    "refused_outcome": {
+      "direction": "core_to_host",
+      "message": {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+              "operations": [
+                {
+                  "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                  "mode": "once",
+                  "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              "kind": "store-term-v0"
+            },
+            "terminal": "host_failure"
+          },
+          "host_observations": {
+            "responses": [
+              {"category": "refused_authority", "completion": "not_started", "ordinal": 1}
+            ],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "diagnostics": [
+            {
+              "schema": "jacquard-diagnostic-v1",
+              "domain": "process",
+              "code": "E1607",
+              "severity": "error",
+              "span": null,
+              "summary": "The host refused the requested authority.",
+              "cause": "The host refused operation cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc before starting an outside action: policy denied.",
+              "next_step": "Grant the required host authority or choose an invocation that does not request this operation."
+            }
+          ],
+          "kind": "error"
+        }
+      }
+    },
+    "timeout_unknown_cancel": {
+      "direction": "host_to_core",
+      "message": {
+        "completion": "unknown",
+        "invocation_id": "0000000000000000",
+        "kind": "cancel",
+        "protocol": "jacquard-host-v0",
+        "reason": "timeout",
+        "request_id": "0000000000000001"
+      }
+    },
+    "timeout_unknown_outcome": {
+      "direction": "core_to_host",
+      "message": {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+              "operations": [
+                {
+                  "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                  "mode": "once",
+                  "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "operation": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "1111111111111111111111111111111111111111111111111111111111111111",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+              "kind": "store-term-v0"
+            },
+            "terminal": "completion_unknown"
+          },
+          "host_observations": {
+            "responses": [{"category": "timeout", "completion": "unknown", "ordinal": 1}],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "diagnostics": [
+            {
+              "schema": "jacquard-diagnostic-v1",
+              "domain": "process",
+              "code": "E1612",
+              "severity": "error",
+              "span": null,
+              "summary": "The outside action may have completed.",
+              "cause": "The host reported that operation cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc may have completed before its timeout cancellation was observed.",
+              "next_step": "Do not retry automatically; reconcile the outside system before deciding what to do next."
+            }
+          ],
+          "kind": "error"
+        }
+      }
+    },
+    "shutdown": {
+      "direction": "host_to_core",
+      "message": {"kind": "shutdown", "protocol": "jacquard-host-v0"}
+    },
+    "shutdown_ack": {
+      "direction": "core_to_host",
+      "message": {"kind": "shutdown_ack", "protocol": "jacquard-host-v0"}
+    },
+    "late_effect_ok": {
+      "direction": "host_to_core",
+      "message": {
+        "invocation_id": "0000000000000000",
+        "kind": "effect_ok",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001",
+        "value": {"kind": "text", "value": "late"}
+      }
+    }
+  },
+  "positive": [
+    {
+      "name": "pure-success",
+      "sequence": ["core_hello", "host_select", "pure_invoke", "pure_outcome"],
+      "terminal": "ok"
+    },
+    {
+      "name": "one-once-effect-success",
+      "sequence": [
+        "core_hello",
+        "host_select",
+        "effect_invoke",
+        "effect_request",
+        "effect_ok",
+        "effect_outcome"
+      ],
+      "terminal": "ok"
+    },
+    {
+      "name": "refused-authority",
+      "sequence": [
+        "core_hello",
+        "host_select",
+        "effect_invoke",
+        "effect_request",
+        "effect_refused",
+        "refused_outcome"
+      ],
+      "terminal": "host_failure"
+    },
+    {
+      "name": "timeout-with-unknown-completion",
+      "sequence": [
+        "core_hello",
+        "host_select",
+        "effect_invoke",
+        "effect_request",
+        "timeout_unknown_cancel",
+        "timeout_unknown_outcome"
+      ],
+      "terminal": "completion_unknown"
+    },
+    {
+      "name": "selected-shutdown",
+      "sequence": ["core_hello", "host_select", "shutdown", "shutdown_ack"],
+      "terminal": "shutdown"
+    }
+  ],
+  "terminal_mappings": [
+    {
+      "category": "unsupported_operation",
+      "completion": "not_started",
+      "kind": "effect_failure",
+      "primary_code": "E1606",
+      "terminal": "host_failure"
+    },
+    {
+      "category": "refused_authority",
+      "completion": "not_started",
+      "kind": "effect_failure",
+      "primary_code": "E1607",
+      "terminal": "host_failure"
+    },
+    {
+      "category": "outside_failure",
+      "completion": "failed",
+      "kind": "effect_failure",
+      "primary_code": "E1613",
+      "terminal": "host_failure"
+    },
+    {
+      "category": "completion_unknown",
+      "completion": "unknown",
+      "kind": "effect_failure",
+      "primary_code": "E1612",
+      "terminal": "completion_unknown"
+    },
+    {
+      "completion": "not_started",
+      "kind": "cancel",
+      "primary_code": "E1614",
+      "reason": "cancelled",
+      "terminal": "cancelled"
+    },
+    {
+      "completion": "failed",
+      "kind": "cancel",
+      "primary_code": "E1614",
+      "reason": "cancelled",
+      "terminal": "cancelled"
+    },
+    {
+      "completion": "unknown",
+      "kind": "cancel",
+      "primary_code": "E1612",
+      "reason": "cancelled",
+      "terminal": "completion_unknown"
+    },
+    {
+      "completion": "not_started",
+      "kind": "cancel",
+      "primary_code": "E1609",
+      "reason": "timeout",
+      "terminal": "cancelled"
+    },
+    {
+      "completion": "failed",
+      "kind": "cancel",
+      "primary_code": "E1609",
+      "reason": "timeout",
+      "terminal": "cancelled"
+    },
+    {
+      "completion": "unknown",
+      "kind": "cancel",
+      "primary_code": "E1612",
+      "reason": "timeout",
+      "terminal": "completion_unknown"
+    },
+    {
+      "completion": "not_started",
+      "kind": "cancel",
+      "primary_code": "E1610",
+      "reason": "host_shutdown",
+      "terminal": "cancelled"
+    },
+    {
+      "completion": "failed",
+      "kind": "cancel",
+      "primary_code": "E1610",
+      "reason": "host_shutdown",
+      "terminal": "cancelled"
+    },
+    {
+      "completion": "unknown",
+      "kind": "cancel",
+      "primary_code": "E1612",
+      "reason": "host_shutdown",
+      "terminal": "completion_unknown"
+    }
+  ],
+  "hostile": [
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1600",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 1,
+        "op": "replace",
+        "path": "/protocol",
+        "value": "jacquard-host-v1"
+      },
+      "name": "unknown-version",
+      "phase": "host_select"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1601",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "add",
+        "path": "/display_name",
+        "value": "mutable-name"
+      },
+      "name": "unknown-invoke-field",
+      "phase": "invoke"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1601",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 1,
+        "op": "raw_wire",
+        "wire_hex": "000000267b226b696e64223a22686f73745f73656c656374222c226b696e64223a22696e766f6b65227d"
+      },
+      "name": "duplicate-json-key",
+      "phase": "framing"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1601",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {"frame": 1, "op": "raw_wire", "wire_hex": "000000037bff7d"},
+      "name": "invalid-utf8",
+      "phase": "framing"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1602",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {"frame": 1, "op": "raw_wire", "wire_hex": "00100001"},
+      "name": "oversized-frame-prefix",
+      "phase": "framing"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1602",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 1,
+        "op": "replace",
+        "path": "/limits/max_frame_bytes",
+        "value": 0
+      },
+      "name": "nonpositive-selected-limit",
+      "phase": "host_select"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1603",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "replace",
+        "path": "/target/callable",
+        "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      },
+      "name": "noncanonical-target-hash",
+      "phase": "invoke"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1603",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "replace",
+        "path": "/interface/parameters/0",
+        "value": {"items": [], "kind": "tuple"}
+      },
+      "name": "interface-mismatch",
+      "phase": "invoke"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1604",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "replace",
+        "path": "/arguments/0",
+        "value": {"kind": "secret", "value": "must-not-cross"}
+      },
+      "name": "unsupported-secret-value",
+      "phase": "invoke"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1605",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "add",
+        "path": "/capabilities/effects/1",
+        "value": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "name": "extra-capability",
+      "phase": "invoke"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1605",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "replace",
+        "path": "/capabilities/operations/0/mode",
+        "value": "multi"
+      },
+      "name": "multi-operation-registry-entry",
+      "phase": "invoke"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1606",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 2,
+        "op": "remove",
+        "path": "/capabilities/operations/0"
+      },
+      "name": "unconfigured-root-operation",
+      "phase": "evaluation"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1608",
+        "effect_requests_before_failure": 1,
+        "forbid_outside_action": false,
+        "terminal_frames_max": 1
+      },
+      "mutation": {
+        "frame": 4,
+        "op": "replace",
+        "path": "/request_id",
+        "value": "0000000000000002"
+      },
+      "name": "wrong-response-id",
+      "phase": "effect_response"
+    },
+    {
+      "base": "one-once-effect-success",
+      "expect": {
+        "code": "E1608",
+        "effect_requests_before_failure": 1,
+        "forbid_outside_action": false,
+        "terminal_frames_max": 1
+      },
+      "mutation": {"op": "append", "template": "late_effect_ok"},
+      "name": "message-after-outcome",
+      "phase": "terminal"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1611",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {"frame": 1, "op": "raw_wire", "wire_hex": "0000"},
+      "name": "truncated-length-prefix",
+      "phase": "framing"
+    },
+    {
+      "base": "pure-success",
+      "expect": {
+        "code": "E1611",
+        "effect_requests_before_failure": 0,
+        "forbid_outside_action": true,
+        "terminal_frames_max": 1
+      },
+      "mutation": {"frame": 1, "op": "raw_wire", "wire_hex": "000000057b7d"},
+      "name": "truncated-frame-payload",
+      "phase": "framing"
+    }
+  ]
+}

--- a/test/dune
+++ b/test/dune
@@ -100,11 +100,22 @@
  (modules governance_review_diff_focused)
  (libraries governance_review_diff_test_support alcotest))
 
+(library
+ (name host_protocol_vectors_test_support)
+ (wrapped false)
+ (modules test_host_protocol_vectors)
+ (libraries alcotest yojson))
+
+(executable
+ (name host_protocol_vectors_focused)
+ (modules host_protocol_vectors_focused)
+ (libraries host_protocol_vectors_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused))
- (libraries jacquard governance_review_diff_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)
@@ -128,6 +139,9 @@
   ../docs/effect-membranes.md
   ../docs/client-playground.md
   ../docs/effect-taxonomy.md
+  ../spec/host-protocol-v0.md
+  ../spec/host-protocol-v0/README.md
+  ../spec/host-protocol-v0/vectors.json
   ../docs/concurrency.md
   ../docs/README.md
   ../docs/release/0.2/DECISION.md

--- a/test/host_protocol_vectors_focused.ml
+++ b/test/host_protocol_vectors_focused.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "host-protocol-v0" [ ("vectors", Test_host_protocol_vectors.suite) ]

--- a/test/test_host_protocol_vectors.ml
+++ b/test/test_host_protocol_vectors.ml
@@ -1,0 +1,384 @@
+open Yojson.Safe
+
+let vector_file = "../spec/host-protocol-v0/vectors.json"
+let spec_file = "../spec/host-protocol-v0.md"
+let fail context message = Alcotest.failf "%s: %s" context message
+let assoc context = function `Assoc fields -> fields | _ -> fail context "expected an object"
+let list context = function `List items -> items | _ -> fail context "expected an array"
+let string context = function `String value -> value | _ -> fail context "expected a string"
+let int context = function `Int value -> value | _ -> fail context "expected an integer"
+let bool context = function `Bool value -> value | _ -> fail context "expected a boolean"
+
+let field context name fields =
+  match List.assoc_opt name fields with
+  | Some value -> value
+  | None -> fail context (Printf.sprintf "missing field %S" name)
+
+let sorted_strings values = List.sort String.compare values
+
+let check_fields context expected fields =
+  let actual = fields |> List.map fst |> sorted_strings in
+  Alcotest.(check (list string)) context (sorted_strings expected) actual
+
+let check_unique context values =
+  let unique = List.sort_uniq String.compare values in
+  Alcotest.(check int) (context ^ " unique count") (List.length values) (List.length unique)
+
+let load () = from_file vector_file |> assoc "vector document"
+
+let hard_limits =
+  [
+    ("max_arguments", 64);
+    ("max_collection_items", 1024);
+    ("max_diagnostic_bytes", 65536);
+    ("max_diagnostics", 32);
+    ("max_effect_requests", 1024);
+    ("max_effects", 64);
+    ("max_frame_bytes", 1048576);
+    ("max_host_message_bytes", 4096);
+    ("max_json_depth", 64);
+    ("max_operations", 256);
+    ("max_stderr_bytes", 65536);
+    ("max_text_bytes", 262144);
+    ("max_value_nodes", 4096);
+  ]
+
+let test_document_and_limits () =
+  let document = load () in
+  check_fields "document fields"
+    [ "schema"; "hard_limits"; "templates"; "positive"; "terminal_mappings"; "hostile" ]
+    document;
+  Alcotest.(check string)
+    "schema" "jacquard-host-vectors-v0"
+    (field "document" "schema" document |> string "schema");
+  let limits = field "document" "hard_limits" document |> assoc "hard limits" in
+  check_fields "hard limit fields" (List.map fst hard_limits) limits;
+  List.iter
+    (fun (name, expected) ->
+      Alcotest.(check int) name expected (field "hard limits" name limits |> int name))
+    hard_limits
+
+type state = Start | Hello | Selected | Running | Waiting | Shutting_down | Finished of string
+
+let template_info templates name =
+  let fields = field "templates" name templates |> assoc ("template " ^ name) in
+  check_fields ("template " ^ name) [ "direction"; "message" ] fields;
+  let direction = field name "direction" fields |> string (name ^ " direction") in
+  let message = field name "message" fields |> assoc (name ^ " message") in
+  let kind = field name "kind" message |> string (name ^ " kind") in
+  (direction, kind, message)
+
+let outcome_terminal name message =
+  let evidence = field name "evidence" message |> assoc (name ^ " evidence") in
+  let core = field name "core" evidence |> assoc (name ^ " core evidence") in
+  field name "terminal" core |> string (name ^ " terminal")
+
+let step_state name templates state =
+  let direction, kind, message = template_info templates name in
+  let expected_direction =
+    match kind with
+    | "core_hello" | "effect_request" | "outcome" | "fatal" | "shutdown_ack" -> "core_to_host"
+    | "host_select" | "invoke" | "effect_ok" | "effect_failure" | "cancel" | "shutdown" ->
+        "host_to_core"
+    | other -> fail name ("unknown message kind " ^ other)
+  in
+  Alcotest.(check string) (name ^ " direction") expected_direction direction;
+  match (state, kind) with
+  | Start, "core_hello" -> Hello
+  | Hello, "host_select" -> Selected
+  | Selected, "invoke" -> Running
+  | Selected, "shutdown" -> Shutting_down
+  | Running, "effect_request" -> Waiting
+  | Waiting, "effect_ok" | Waiting, "effect_failure" | Waiting, "cancel" -> Running
+  | Running, "outcome" -> Finished (outcome_terminal name message)
+  | Shutting_down, "shutdown_ack" -> Finished "shutdown"
+  | _ -> fail name ("invalid state transition for " ^ kind)
+
+let check_evidence_echo name templates sequence =
+  let messages = List.map (fun item -> template_info templates (string name item)) sequence in
+  let by_kind expected =
+    List.filter_map
+      (fun (_, kind, message) -> if String.equal kind expected then Some message else None)
+      messages
+  in
+  match (by_kind "invoke", by_kind "outcome") with
+  | [ invoke ], [ outcome ] ->
+      let evidence = field name "evidence" outcome |> assoc (name ^ " evidence") in
+      let core = field name "core" evidence |> assoc (name ^ " core evidence") in
+      List.iter
+        (fun key ->
+          Alcotest.(check bool)
+            (name ^ " evidence echoes " ^ key)
+            true
+            (field name key invoke = field name key core))
+        [ "target"; "interface"; "capabilities" ]
+  | [], [] -> ()
+  | _ -> fail name "expected exactly one invoke/outcome pair or a shutdown transcript"
+
+let test_positive_sequences () =
+  let document = load () in
+  let templates = field "document" "templates" document |> assoc "templates" in
+  let positives = field "document" "positive" document |> list "positive" in
+  let names =
+    List.map
+      (fun item ->
+        let fields = assoc "positive case" item in
+        check_fields "positive case" [ "name"; "sequence"; "terminal" ] fields;
+        let name = field "positive case" "name" fields |> string "positive name" in
+        let sequence = field name "sequence" fields |> list (name ^ " sequence") in
+        check_evidence_echo name templates sequence;
+        let final =
+          List.fold_left
+            (fun state item -> step_state (string (name ^ " template") item) templates state)
+            Start sequence
+        in
+        let actual_terminal =
+          match final with
+          | Finished terminal -> terminal
+          | _ -> fail name "positive transcript did not finish exactly once"
+        in
+        Alcotest.(check string)
+          (name ^ " terminal")
+          (field name "terminal" fields |> string (name ^ " terminal"))
+          actual_terminal;
+        name)
+      positives
+  in
+  check_unique "positive names" names
+
+let is_lower_hex value =
+  String.length value mod 2 = 0
+  && String.for_all (function '0' .. '9' | 'a' .. 'f' -> true | _ -> false) value
+
+let rec check_template_hashes context = function
+  | `String value when String.length value = 64 ->
+      Alcotest.(check bool) (context ^ " canonical hash") true (is_lower_hex value)
+  | `Assoc fields ->
+      List.iter (fun (name, value) -> check_template_hashes (context ^ "/" ^ name) value) fields
+  | `List items ->
+      List.iteri
+        (fun index value -> check_template_hashes (context ^ "/" ^ string_of_int index) value)
+        items
+  | _ -> ()
+
+let test_template_identities () =
+  let document = load () in
+  field "document" "templates" document |> check_template_hashes "templates"
+
+let expected_codes = List.init 15 (fun index -> Printf.sprintf "E%04d" (1600 + index))
+
+let terminal_mapping item =
+  let fields = assoc "terminal mapping" item in
+  let kind = field "terminal mapping" "kind" fields |> string "mapping kind" in
+  let expected =
+    match kind with
+    | "effect_failure" -> [ "category"; "completion"; "kind"; "primary_code"; "terminal" ]
+    | "cancel" -> [ "completion"; "kind"; "primary_code"; "reason"; "terminal" ]
+    | other -> fail "terminal mapping" ("unknown kind " ^ other)
+  in
+  check_fields "terminal mapping fields" expected fields;
+  let category_field = if String.equal kind "effect_failure" then "category" else "reason" in
+  let category = field "terminal mapping" category_field fields |> string "mapping category" in
+  let completion = field "terminal mapping" "completion" fields |> string "mapping completion" in
+  let code = field "terminal mapping" "primary_code" fields |> string "mapping code" in
+  let terminal = field "terminal mapping" "terminal" fields |> string "mapping terminal" in
+  (Printf.sprintf "%s/%s/%s=%s/%s" kind category completion code terminal, code)
+
+let expected_terminal_mappings =
+  [
+    "effect_failure/unsupported_operation/not_started=E1606/host_failure";
+    "effect_failure/refused_authority/not_started=E1607/host_failure";
+    "effect_failure/outside_failure/failed=E1613/host_failure";
+    "effect_failure/completion_unknown/unknown=E1612/completion_unknown";
+    "cancel/cancelled/not_started=E1614/cancelled";
+    "cancel/cancelled/failed=E1614/cancelled";
+    "cancel/cancelled/unknown=E1612/completion_unknown";
+    "cancel/timeout/not_started=E1609/cancelled";
+    "cancel/timeout/failed=E1609/cancelled";
+    "cancel/timeout/unknown=E1612/completion_unknown";
+    "cancel/host_shutdown/not_started=E1610/cancelled";
+    "cancel/host_shutdown/failed=E1610/cancelled";
+    "cancel/host_shutdown/unknown=E1612/completion_unknown";
+  ]
+
+let check_raw_hex context wire_hex =
+  Alcotest.(check bool) (context ^ " nonempty") true (String.length wire_hex > 0);
+  Alcotest.(check bool) (context ^ " lowercase even hex") true (is_lower_hex wire_hex)
+
+let rec expand_refs hard_limits = function
+  | `Assoc [ ("$ref", `String "hard_limits") ] -> hard_limits
+  | `Assoc fields ->
+      `Assoc (List.map (fun (name, value) -> (name, expand_refs hard_limits value)) fields)
+  | `List items -> `List (List.map (expand_refs hard_limits) items)
+  | value -> value
+
+let pointer_tokens context path =
+  match String.split_on_char '/' path with
+  | "" :: tokens when tokens <> [] ->
+      List.iter
+        (fun token ->
+          if String.contains token '~' then
+            fail context "fixture pointers use no escaped JSON-pointer token")
+        tokens;
+      tokens
+  | _ -> fail context "expected a non-root JSON pointer"
+
+let pointer_index context token =
+  match int_of_string_opt token with
+  | Some index when index >= 0 && String.equal token (string_of_int index) -> index
+  | _ -> fail context (Printf.sprintf "invalid array index %S" token)
+
+let check_mutation_pointer context op message path =
+  let rec parent value = function
+    | [ final ] -> (value, final)
+    | token :: rest -> (
+        match value with
+        | `Assoc fields -> (
+            match List.assoc_opt token fields with
+            | Some child -> parent child rest
+            | None -> fail context (Printf.sprintf "pointer member %S does not exist" token))
+        | `List items -> (
+            match List.nth_opt items (pointer_index context token) with
+            | Some child -> parent child rest
+            | None -> fail context (Printf.sprintf "pointer index %S does not exist" token))
+        | _ -> fail context "pointer traverses a scalar")
+    | [] -> fail context "expected a non-root mutation pointer"
+  in
+  let container, final = parent message (pointer_tokens context path) in
+  match container with
+  | `Assoc fields ->
+      if (not (String.equal op "add")) && not (List.mem_assoc final fields) then
+        fail context (Printf.sprintf "pointer member %S does not exist" final)
+  | `List items ->
+      let index = pointer_index context final in
+      let maximum = if String.equal op "add" then List.length items else List.length items - 1 in
+      if index > maximum then fail context (Printf.sprintf "pointer index %d does not exist" index)
+  | _ -> fail context "mutation pointer parent is a scalar"
+
+let test_hostile_cases () =
+  let document = load () in
+  let hard_limits = field "document" "hard_limits" document in
+  let templates = field "document" "templates" document |> assoc "templates" in
+  let positives = field "document" "positive" document |> list "positive" in
+  let positive_sequences =
+    List.map
+      (fun item ->
+        let fields = assoc "positive" item in
+        ( field "positive" "name" fields |> string "positive name",
+          field "positive" "sequence" fields |> list "positive sequence" ))
+      positives
+  in
+  let hostile = field "document" "hostile" document |> list "hostile" in
+  let names, hostile_codes =
+    List.split
+      (List.map
+         (fun item ->
+           let fields = assoc "hostile case" item in
+           check_fields "hostile case fields"
+             [ "base"; "expect"; "mutation"; "name"; "phase" ]
+             fields;
+           let name = field "hostile" "name" fields |> string "hostile name" in
+           let base = field name "base" fields |> string (name ^ " base") in
+           let sequence =
+             match List.assoc_opt base positive_sequences with
+             | Some value -> value
+             | None -> fail name ("unknown positive base " ^ base)
+           in
+           let phase = field name "phase" fields |> string (name ^ " phase") in
+           (match phase with
+           | "framing" | "host_select" | "invoke" | "evaluation" | "effect_response" | "terminal" ->
+               ()
+           | other -> fail name ("unknown rejection phase " ^ other));
+           let expectation = field name "expect" fields |> assoc (name ^ " expectation") in
+           check_fields (name ^ " expectation fields")
+             [
+               "code";
+               "effect_requests_before_failure";
+               "forbid_outside_action";
+               "terminal_frames_max";
+             ]
+             expectation;
+           let code = field name "code" expectation |> string (name ^ " code") in
+           ignore (field name "effect_requests_before_failure" expectation |> int name);
+           ignore (field name "forbid_outside_action" expectation |> bool name);
+           let terminal_max = field name "terminal_frames_max" expectation |> int name in
+           Alcotest.(check int) (name ^ " one terminal frame") 1 terminal_max;
+           let mutation = field name "mutation" fields |> assoc (name ^ " mutation") in
+           let op = field name "op" mutation |> string (name ^ " mutation op") in
+           (match op with
+           | "replace" | "add" ->
+               check_fields (name ^ " mutation fields") [ "frame"; "op"; "path"; "value" ] mutation;
+               let frame = field name "frame" mutation |> int name in
+               Alcotest.(check bool)
+                 (name ^ " frame exists") true
+                 (frame >= 0 && frame < List.length sequence);
+               let path = field name "path" mutation |> string name in
+               Alcotest.(check bool)
+                 (name ^ " JSON pointer") true
+                 (String.starts_with ~prefix:"/" path);
+               let template = List.nth sequence frame |> string name in
+               let _, _, message = template_info templates template in
+               check_mutation_pointer name op (expand_refs hard_limits (`Assoc message)) path
+           | "remove" ->
+               check_fields (name ^ " mutation fields") [ "frame"; "op"; "path" ] mutation;
+               let frame = field name "frame" mutation |> int name in
+               Alcotest.(check bool)
+                 (name ^ " frame exists") true
+                 (frame >= 0 && frame < List.length sequence);
+               let path = field name "path" mutation |> string name in
+               let template = List.nth sequence frame |> string name in
+               let _, _, message = template_info templates template in
+               check_mutation_pointer name op (expand_refs hard_limits (`Assoc message)) path
+           | "append" ->
+               check_fields (name ^ " mutation fields") [ "op"; "template" ] mutation;
+               let template = field name "template" mutation |> string name in
+               ignore (template_info templates template)
+           | "raw_wire" ->
+               check_fields (name ^ " mutation fields") [ "frame"; "op"; "wire_hex" ] mutation;
+               let frame = field name "frame" mutation |> int name in
+               Alcotest.(check bool)
+                 (name ^ " frame exists") true
+                 (frame >= 0 && frame < List.length sequence);
+               field name "wire_hex" mutation |> string name |> check_raw_hex name
+           | other -> fail name ("unknown mutation op " ^ other));
+           (name, code))
+         hostile)
+  in
+  check_unique "hostile names" names;
+  let mappings =
+    field "document" "terminal_mappings" document
+    |> list "terminal mappings" |> List.map terminal_mapping
+  in
+  let mapping_names, mapping_codes = List.split mappings in
+  Alcotest.(check (list string))
+    "complete terminal mapping matrix"
+    (List.sort String.compare expected_terminal_mappings)
+    (List.sort String.compare mapping_names);
+  Alcotest.(check (list string))
+    "complete E1600-E1614 coverage" expected_codes
+    (List.sort_uniq String.compare (hostile_codes @ mapping_codes))
+
+let read_file path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+
+let test_spec_lists_codes () =
+  let source = read_file spec_file in
+  List.iter
+    (fun code ->
+      Alcotest.(check bool)
+        (code ^ " is documented") true
+        (String.split_on_char ' ' source
+        |> List.exists (fun token -> String.starts_with ~prefix:code token)))
+    expected_codes
+
+let suite =
+  [
+    Alcotest.test_case "document and hard limits" `Quick test_document_and_limits;
+    Alcotest.test_case "positive state sequences" `Quick test_positive_sequences;
+    Alcotest.test_case "template identities" `Quick test_template_identities;
+    Alcotest.test_case "hostile cases and code coverage" `Quick test_hostile_cases;
+    Alcotest.test_case "stable codes are documented" `Quick test_spec_lists_codes;
+  ]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -23,6 +23,7 @@ let () =
       ("quote", Test_quote.suite);
       ("prelude", Test_prelude.suite);
       ("effect-taxonomy", Test_effect_taxonomy.suite);
+      ("host-protocol-v0", Test_host_protocol_vectors.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Context

Jacquard has a documented trust boundary between Core, which owns language meaning, and a trusted host, which owns operating-system actions. Until now, independent host implementations had no concrete, versioned process contract to build against.

## What changed

- Freezes `jacquard-host-v0`, a transport-neutral single-invocation protocol.
- Specifies the provisional `stdio-u32-json-v0` carrier: bounded, big-endian length-framed UTF-8 JSON.
- Defines exact callable, type, value, effect, capability, operation, request, result, diagnostic, cancellation, shutdown, and evidence envelopes.
- Adds stable E1600–E1614 protocol failure categories.
- Adds complete success, refusal, ambiguous-timeout, and graceful-shutdown transcripts; all host-failure/cancellation mappings; and hostile mutations.
- Wires a focused and integrated OCaml oracle that prevents the spec and vectors from drifting.
- Updates human and agent documentation plus mechanically checked successor test counts.

## Contract and invariants

- One checked stored callable, one worker, at most one invocation, and one outstanding request.
- Closed monomorphic positional first-order boundary.
- Exact closed effect row and sorted closed registry of boundary-safe `once` operations.
- Strict order, deterministic local IDs, one terminal result, and no automatic retry after ambiguous completion.
- Core evidence remains separate from host-reported observations.
- Unknown fields, versions, values, operations, modes, and invalid state transitions fail closed.
- No kernel form, HASH_V0 rule, checker/evaluator semantics, diagnostic-v1 shape, ordinary CLI, scheduler, or native/interpreter claim changes.

## Deliberately excluded

This does **not** ship an executable carrier, stable foreign ABI, adapter, HTTP server, socket integration, SQLite support, SDK, streaming, concurrency, module/package system, resource attenuation, TLS/proxy behavior, sandbox, or production-security claim. HB.2 implements Core; HB.3 packages executable conformance evidence. The synthetic hashes in these schema vectors do not claim that those objects exist in a Core store.

## Review size

The diff is larger than the usual review target (+1,947/-48). The protocol, full semantic transcript corpus, hostile vectors, and drift oracle are one freeze boundary: splitting them would merge either an unproved normative contract or vectors without an authoritative contract. Most of the volume is explicit JSON transcript data.

## Validation

Exact head: `a40ae136f976c27b388d3b5dc4899f03289da4dd`

- `jq empty spec/host-protocol-v0/vectors.json`
- `opam exec -- dune fmt --root .`
- focused protocol oracle: 5/5 passed
- `opam exec -- dune build --root . @all`
- `opam exec -- dune build --root . @doc`
- `opam exec -- dune runtest --root .`: 882 tests passed in 431.117s; the repository gate also covers 59 cram transcripts and 28 documentation examples
- Fable 5/xhigh independent review: **PASS**, exact head, no blockers or architecture conflicts

## Risks and follow-up

HB.2 executable fixtures will add edge pins for field-specific malformed-hash codes, Core-detected outcome terminal categories, and adjacent response-shape choices. Those are additive cases for already-specified failure domains; they do not widen this protocol.
