### PR TITLE
HB.2a: add strict host transport codec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,10 +118,11 @@ When adding valid corpus files, regenerate the golden hashes with
 - Handlers and evaluation: `src/eval.ml`, `test/test_handlers.ml`,
   `test/test_gauntlet_handlers.ml`.
 - Host integration contracts: `docs/host-boundary.md` and
-  `spec/host-protocol-v0.md`. HB.1 freezes envelopes and schema/state vectors,
-  but no executable carrier ships yet. Existing evaluator capture and
-  host-readiness modules are internal seams, not a public ABI; adapters and
-  application servers belong outside this repository.
+  `spec/host-protocol-v0.md`; strict framing and selection codec:
+  `src/host_protocol_v0.ml`, `test/test_host_protocol_codec.ml`. No runnable
+  worker ships yet. Existing evaluator capture and host-readiness modules are
+  internal seams, not a public ABI; adapters and application servers belong
+  outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,
   `src/infer_dist.ml`, `test/test_infer.ml`.
 - Warp: `prelude/15-warp.jqd`, `prelude/16-gen.jqd`, `src/warp.ml`,

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 882
+semantic boundary remains historical; the current successor is pinned by 900
 Alcotest/QCheck cases, 59 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
@@ -600,6 +600,8 @@ Key release docs:
 - `src/infer_dist.ml`: exact enumeration and likelihood weighting.
 - `src/diff.ml`: canonical-structure diff over stores.
 - `src/warp.ml`: Warp test discovery, running, cache, and properties.
+- `src/host_protocol_v0.ml`: strict library-only framing, JSON, limit-selection,
+  and shutdown codec for the experimental host protocol; no worker entry point.
 
 ## Documentation Map
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ project shape from file names alone.
 - `../spec/serialization.md`: canonical byte serialization and hashing.
 - `../spec/host-protocol-v0.md`: frozen HB.1 transport-neutral envelopes,
   provisional stdio framing, boundary values, limits, stable failures, and
-  positive/hostile vectors. It is a contract, not a shipped carrier.
+  positive/hostile vectors. HB.2a implements its strict library codec, but no
+  runnable carrier ships yet.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -897,11 +897,13 @@ Do not invent new kernel forms for surface sugar.
   supervision.
 - HB.0 documents the language-neutral host ownership and trust boundary, and
   HB.1 freezes `jacquard-host-v0` envelopes, provisional process framing,
-  limits, stable failures, and schema/state vectors. No executable carrier,
-  stable foreign-host ABI, adapter, or HTTP server ships. Internal
+  limits, stable failures, and schema/state vectors. `Host_protocol_v0`
+  implements the strict framing/selection/shutdown codec for HB.2a; reuse it
+  instead of recreating JSON or u32 framing. No runnable worker, stable
+  foreign-host ABI, adapter, or HTTP server ships yet. Internal
   evaluator-capture and host-readiness OCaml APIs are not supported embedding
-  contracts; future adapters must consume the implemented versioned protocol
-  and its executable conformance fixtures, not those OCaml seams.
+  contracts; future adapters must consume the versioned protocol and its
+  executable conformance fixtures, not those OCaml seams.
 - The frozen Workspace v0 governed membrane ships as an evidence-backed
   research reference. It is not a general isolation mechanism, production
   authorization system, or operating-system sandbox; trusted host code still

--- a/docs/host-boundary.md
+++ b/docs/host-boundary.md
@@ -243,9 +243,10 @@ matrix.
 
 ## 9. Repository and product boundary
 
-`jacquard-lang` owns this contract, the HB.1 schema/state vectors, its later
-carrier implementation inside Core, executable fixtures, and language/runtime
-evidence. It may contain a tiny fake host used only to prove conformance.
+`jacquard-lang` owns this contract, the HB.1 schema/state vectors, the
+`Host_protocol_v0` strict framing/selection codec, its later runnable carrier
+inside Core, executable fixtures, and language/runtime evidence. It may
+contain a tiny fake host used only to prove conformance.
 
 The private `jacquard-host` repository owns real adapters, sockets,
 persistence, the minimal serial HTTP integration, and the requirements report
@@ -268,7 +269,7 @@ headers are not smuggled into HB.0.
 |---|---|---|
 | First-party programs | safety for hostile uploaded Jacquard code | separate-process or equivalent isolation design, hostile resource tests, and reviewed threat model |
 | Trusted adapter and OS | protection from a lying host or broader OS credentials | independently enforced isolation/authentication plus external security review |
-| No carrier implementation yet | interoperability or embedding support | HB.2 implementation followed by HB.3 executable cross-language fixtures and evidence |
+| No runnable carrier yet | interoperability or embedding support | completion of HB.2 descriptor/evaluator/lifecycle slices followed by HB.3 executable cross-language fixtures and evidence |
 | Experimental process carrier first | permanent ABI stability or low-overhead embedding | two independent adapters and one real integration pass the frozen fixtures before v1 |
 | One serial invocation | concurrent requests, streaming, or throughput | demonstrated need followed by the C4 scheduler contract and resource evidence |
 | No automatic side-effect retry | transparent recovery from ambiguous completion | per-operation idempotency, receipt, and crash/recovery contract |

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `882`
+Test count: `900`
 
 Cram count: `59`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `882`
+- Alcotest/QCheck cases: `900`
 - Cram transcript files: `59`
 - Documentation examples: `28` named examples across `8` documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `882`
+- Alcotest/QCheck cases: `900`
 - Cram transcript files: `59`
 - Doctest examples: `28` across 8 documents
 
@@ -62,8 +62,9 @@ existing concurrency transcript and adds no cram or doctest entry.
 Task 171 adds one labeled-pattern contract case. SX.23 then adds six compiled
 named-call cases, two D76 decision-mutation cases, and one CLI transcript,
 producing `877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract
-cases, producing the current `882 / 59 / 28` successor inventory without
-changing the historical DX.2 publication.
+cases, producing `882 / 59 / 28`. HB.2a adds eighteen bounded framing and
+selection codec cases, producing the current `900 / 59 / 28` successor
+inventory without changing the historical DX.2 publication.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 882 compiled Alcotest/QCheck cases, 59 recursive
+The current successor inventory is exactly 900 compiled Alcotest/QCheck cases, 59 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `882`
+- Alcotest/QCheck cases: `900`
 - Cram transcript files: `59`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -816,7 +816,8 @@ producing the `868 / 58 / 28` inventory. Task 171 adds the labeled-pattern
 contract case, producing `869 / 58 / 28`. SX.23 then adds six named-call cases,
 two D76 decision-mutation cases, and one transcript, producing
 `877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract cases,
-producing the current `882 / 59 / 28` inventory.
+producing `882 / 59 / 28`. HB.2a adds eighteen bounded framing and selection
+codec cases, producing the current `900 / 59 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -590,6 +590,12 @@ separation; they do not claim that a Core store contains those objects. HB.2
 adds the executable Core carrier fixtures. HB.3 packages the final executable
 fixtures for independent adapters and replaces no HB.1 expectation.
 
+Implementation status: HB.2a now provides the library-only strict framing and
+selection codec in `Host_protocol_v0`, including bounded u32 framing, Unicode
+scalar UTF-8, recursive duplicate-key checks, exact hard/selected limits, and
+the shutdown envelope. It does not expose a runnable worker; descriptor
+preflight, evaluation, and effect exchange remain later HB.2 slices.
+
 A conforming implementation must:
 
 - accept every positive transcript through its stated terminal result;

--- a/src/host_protocol_v0.ml
+++ b/src/host_protocol_v0.ml
@@ -1,0 +1,433 @@
+let protocol = "jacquard-host-v0"
+let carrier = "stdio-u32-json-v0"
+
+type limits = {
+  max_frame_bytes : int;
+  max_json_depth : int;
+  max_value_nodes : int;
+  max_text_bytes : int;
+  max_collection_items : int;
+  max_arguments : int;
+  max_effects : int;
+  max_operations : int;
+  max_effect_requests : int;
+  max_diagnostics : int;
+  max_diagnostic_bytes : int;
+  max_host_message_bytes : int;
+  max_stderr_bytes : int;
+}
+
+let hard_limits =
+  {
+    max_frame_bytes = 1_048_576;
+    max_json_depth = 64;
+    max_value_nodes = 4_096;
+    max_text_bytes = 262_144;
+    max_collection_items = 1_024;
+    max_arguments = 64;
+    max_effects = 64;
+    max_operations = 256;
+    max_effect_requests = 1_024;
+    max_diagnostics = 32;
+    max_diagnostic_bytes = 65_536;
+    max_host_message_bytes = 4_096;
+    max_stderr_bytes = 65_536;
+  }
+
+let diagnostic_spec = function
+  | "E1600" ->
+      ( "The host selected an unsupported protocol version.",
+        "Select jacquard-host-v0 with the advertised stdio-u32-json-v0 carrier." )
+  | "E1601" ->
+      ( "The host protocol frame is malformed.",
+        "Send one exact UTF-8 JSON object using the frozen jacquard-host-v0 envelope." )
+  | "E1602" ->
+      ( "The host protocol limit was exceeded or cannot represent a mandatory result.",
+        "Choose positive advertised limits and keep the frame within the selected ceilings." )
+  | "E1608" ->
+      ( "The host protocol message is invalid in the current state.",
+        "Send only the next message permitted by the serial jacquard-host-v0 state machine." )
+  | "E1611" ->
+      ( "The host carrier was lost before a trustworthy frame completed.",
+        "Treat the missing terminal exchange as host-owned carrier-failure evidence." )
+  | code -> raise (Diag.Bug_invalid_diagnostic ("unknown host protocol diagnostic code " ^ code))
+
+let diagnostic ~code cause =
+  let summary, next_step = diagnostic_spec code in
+  Diag.error ~domain:Process ~code ~summary ~cause ~next_step ~contrast:None ()
+
+let error ~code cause = Error [ diagnostic ~code cause ]
+
+let limit_fields =
+  [
+    "max_arguments";
+    "max_collection_items";
+    "max_diagnostic_bytes";
+    "max_diagnostics";
+    "max_effect_requests";
+    "max_effects";
+    "max_frame_bytes";
+    "max_host_message_bytes";
+    "max_json_depth";
+    "max_operations";
+    "max_stderr_bytes";
+    "max_text_bytes";
+    "max_value_nodes";
+  ]
+
+let limits_to_yojson limits =
+  `Assoc
+    [
+      ("max_arguments", `Int limits.max_arguments);
+      ("max_collection_items", `Int limits.max_collection_items);
+      ("max_diagnostic_bytes", `Int limits.max_diagnostic_bytes);
+      ("max_diagnostics", `Int limits.max_diagnostics);
+      ("max_effect_requests", `Int limits.max_effect_requests);
+      ("max_effects", `Int limits.max_effects);
+      ("max_frame_bytes", `Int limits.max_frame_bytes);
+      ("max_host_message_bytes", `Int limits.max_host_message_bytes);
+      ("max_json_depth", `Int limits.max_json_depth);
+      ("max_operations", `Int limits.max_operations);
+      ("max_stderr_bytes", `Int limits.max_stderr_bytes);
+      ("max_text_bytes", `Int limits.max_text_bytes);
+      ("max_value_nodes", `Int limits.max_value_nodes);
+    ]
+
+let core_hello () =
+  `Assoc
+    [
+      ("carrier", `String carrier);
+      ("kind", `String "core_hello");
+      ("limits", limits_to_yojson hard_limits);
+      ("versions", `List [ `String protocol ]);
+    ]
+
+let shutdown_ack () = `Assoc [ ("kind", `String "shutdown_ack"); ("protocol", `String protocol) ]
+let continuation byte = byte land 0xc0 = 0x80
+
+(** [valid_utf8 bytes] recognizes scalar-value UTF-8, excluding overlong forms, surrogate code
+    points, and values above U+10FFFF. *)
+let valid_utf8 bytes =
+  let length = String.length bytes in
+  let byte index = Char.code bytes.[index] in
+  let rec scan index =
+    if index = length then true
+    else
+      let first = byte index in
+      if first <= 0x7f then scan (index + 1)
+      else if first >= 0xc2 && first <= 0xdf then
+        index + 1 < length && continuation (byte (index + 1)) && scan (index + 2)
+      else if first = 0xe0 then
+        index + 2 < length
+        && byte (index + 1) >= 0xa0
+        && byte (index + 1) <= 0xbf
+        && continuation (byte (index + 2))
+        && scan (index + 3)
+      else if (first >= 0xe1 && first <= 0xec) || (first >= 0xee && first <= 0xef) then
+        index + 2 < length
+        && continuation (byte (index + 1))
+        && continuation (byte (index + 2))
+        && scan (index + 3)
+      else if first = 0xed then
+        index + 2 < length
+        && byte (index + 1) >= 0x80
+        && byte (index + 1) <= 0x9f
+        && continuation (byte (index + 2))
+        && scan (index + 3)
+      else if first = 0xf0 then
+        index + 3 < length
+        && byte (index + 1) >= 0x90
+        && byte (index + 1) <= 0xbf
+        && continuation (byte (index + 2))
+        && continuation (byte (index + 3))
+        && scan (index + 4)
+      else if first >= 0xf1 && first <= 0xf3 then
+        index + 3 < length
+        && continuation (byte (index + 1))
+        && continuation (byte (index + 2))
+        && continuation (byte (index + 3))
+        && scan (index + 4)
+      else if first = 0xf4 then
+        index + 3 < length
+        && byte (index + 1) >= 0x80
+        && byte (index + 1) <= 0x8f
+        && continuation (byte (index + 2))
+        && continuation (byte (index + 3))
+        && scan (index + 4)
+      else false
+  in
+  scan 0
+
+let duplicate_field fields =
+  let sorted = List.map fst fields |> List.sort String.compare in
+  let rec find = function
+    | left :: right :: _ when String.equal left right -> Some left
+    | _ :: rest -> find rest
+    | [] -> None
+  in
+  find sorted
+
+(** [validate_json ~limits json] enforces carrier-wide JSON invariants after decoding. It does not
+    validate a message-specific envelope or count boundary-value nodes. *)
+let validate_json ~limits json =
+  let rec walk depth = function
+    | `Assoc fields -> (
+        if depth > limits.max_json_depth then
+          error ~code:"E1602" "The JSON object nesting exceeds max_json_depth."
+        else
+          match duplicate_field fields with
+          | Some _ -> error ~code:"E1601" "A JSON object contains a duplicate field name."
+          | None ->
+              let rec fields_valid = function
+                | [] -> Ok ()
+                | (key, value) :: rest ->
+                    if not (valid_utf8 key) then
+                      error ~code:"E1601" "A decoded JSON field name is not Unicode scalar UTF-8."
+                    else Result.bind (walk (depth + 1) value) (fun () -> fields_valid rest)
+              in
+              fields_valid fields)
+    | `List items ->
+        if depth > limits.max_json_depth then
+          error ~code:"E1602" "The JSON array nesting exceeds max_json_depth."
+        else if List.length items > limits.max_collection_items then
+          error ~code:"E1602" "A JSON array exceeds max_collection_items."
+        else
+          let rec items_valid = function
+            | [] -> Ok ()
+            | item :: rest -> Result.bind (walk (depth + 1) item) (fun () -> items_valid rest)
+          in
+          items_valid items
+    | `String value when not (valid_utf8 value) ->
+        error ~code:"E1601" "A decoded JSON string is not Unicode scalar UTF-8."
+    | `Float _ | `Intlit _ ->
+        error ~code:"E1601" "The protocol does not accept an unbounded or floating JSON number."
+    | `String _ | `Int _ | `Bool _ | `Null -> Ok ()
+    | `Tuple _ | `Variant _ ->
+        error ~code:"E1601" "The payload contains a non-JSON Yojson extension value."
+  in
+  if limits.max_json_depth <= 0 || limits.max_collection_items <= 0 then
+    error ~code:"E1602" "The active structural limits are not positive."
+  else
+    match json with
+    | `Assoc _ -> walk 1 json
+    | _ -> error ~code:"E1601" "A frame payload must contain one JSON object."
+
+let decode_payload ~limits payload =
+  if not (valid_utf8 payload) then
+    error ~code:"E1601" "The frame payload is not valid Unicode scalar UTF-8."
+  else
+    match Yojson.Safe.from_string payload with
+    | exception Yojson.Json_error _ ->
+        error ~code:"E1601" "The frame payload is not exactly one valid JSON value."
+    | json -> Result.map (fun () -> json) (validate_json ~limits json)
+
+let encode_length length =
+  let bytes = Bytes.create 4 in
+  Bytes.set bytes 0 (Char.chr ((length lsr 24) land 0xff));
+  Bytes.set bytes 1 (Char.chr ((length lsr 16) land 0xff));
+  Bytes.set bytes 2 (Char.chr ((length lsr 8) land 0xff));
+  Bytes.set bytes 3 (Char.chr (length land 0xff));
+  Bytes.unsafe_to_string bytes
+
+let decode_length bytes offset =
+  let byte index = Char.code bytes.[offset + index] in
+  (byte 0 lsl 24) lor (byte 1 lsl 16) lor (byte 2 lsl 8) lor byte 3
+
+let validate_frame_length ~limits length =
+  if length = 0 then error ~code:"E1601" "A frame payload length must be at least one byte."
+  else if limits.max_frame_bytes <= 0 || length > limits.max_frame_bytes then
+    error ~code:"E1602" "The frame payload length exceeds max_frame_bytes."
+  else Ok ()
+
+let encode_frame_bytes ~limits json =
+  Result.bind (validate_json ~limits json) (fun () ->
+      let payload = Yojson.Safe.to_string json in
+      Result.bind
+        (validate_frame_length ~limits (String.length payload))
+        (fun () -> Ok (encode_length (String.length payload) ^ payload)))
+
+let decode_frame_bytes ~limits bytes =
+  if String.length bytes < 4 then
+    error ~code:"E1611" "The carrier ended before the four-byte frame length completed."
+  else
+    let length = decode_length bytes 0 in
+    Result.bind (validate_frame_length ~limits length) (fun () ->
+        let available = String.length bytes - 4 in
+        if available < length then
+          error ~code:"E1611" "The carrier ended before the declared frame payload completed."
+        else if available > length then
+          error ~code:"E1601" "Bytes remain after the one declared frame payload."
+        else decode_payload ~limits (String.sub bytes 4 length))
+
+let read_exact input length =
+  let buffer = Bytes.create length in
+  let rec loop offset =
+    if offset = length then Ok (Bytes.unsafe_to_string buffer)
+    else
+      match Stdlib.input input buffer offset (length - offset) with
+      | 0 -> error ~code:"E1611" "The carrier ended before the declared frame completed."
+      | count -> loop (offset + count)
+      | (exception Sys_error _) | (exception Unix.Unix_error _) ->
+          error ~code:"E1611" "The carrier failed while Core was reading a frame."
+  in
+  loop 0
+
+let read_frame ~limits input =
+  Result.bind (read_exact input 4) (fun prefix ->
+      let length = decode_length prefix 0 in
+      Result.bind (validate_frame_length ~limits length) (fun () ->
+          Result.bind (read_exact input length) (decode_payload ~limits)))
+
+let write_frame ~limits output json =
+  Result.bind (encode_frame_bytes ~limits json) (fun frame ->
+      match
+        output_string output frame;
+        flush output
+      with
+      | () -> Ok ()
+      | (exception Sys_error _) | (exception Unix.Unix_error _) ->
+          error ~code:"E1611" "The carrier failed while Core was writing a frame.")
+
+let exact_fields expected fields =
+  let actual = List.map fst fields |> List.sort String.compare in
+  let expected = List.sort String.compare expected in
+  if actual = expected then Ok ()
+  else error ~code:"E1601" "The protocol envelope has a missing or unknown field."
+
+let field name fields = List.assoc_opt name fields
+
+let parse_protocol fields =
+  match field "protocol" fields with
+  | Some (`String version) when String.equal version protocol -> Ok ()
+  | Some (`String _) -> error ~code:"E1600" "The selected protocol version is not advertised."
+  | Some _ | None -> error ~code:"E1601" "The protocol field must be one version string."
+
+let parse_kind expected fields =
+  match field "kind" fields with
+  | Some (`String kind) when String.equal kind expected -> Ok ()
+  | Some (`String _) -> error ~code:"E1608" "The message kind is not valid in this protocol state."
+  | Some _ | None -> error ~code:"E1601" "The kind field must be one message string."
+
+let parse_limit_field name hard fields =
+  match field name fields with
+  | Some (`Int value) when value > 0 && value <= hard -> Ok value
+  | Some (`Int _) ->
+      error ~code:"E1602" (Printf.sprintf "The selected %s is not positive and advertised." name)
+  | Some _ | None ->
+      error ~code:"E1601" (Printf.sprintf "The selected %s is missing or not an integer." name)
+
+let ( let* ) result continuation = Result.bind result continuation
+
+let parse_limits = function
+  | `Assoc fields ->
+      let* () = exact_fields limit_fields fields in
+      let* max_arguments = parse_limit_field "max_arguments" hard_limits.max_arguments fields in
+      let* max_collection_items =
+        parse_limit_field "max_collection_items" hard_limits.max_collection_items fields
+      in
+      let* max_diagnostic_bytes =
+        parse_limit_field "max_diagnostic_bytes" hard_limits.max_diagnostic_bytes fields
+      in
+      let* max_diagnostics =
+        parse_limit_field "max_diagnostics" hard_limits.max_diagnostics fields
+      in
+      let* max_effect_requests =
+        parse_limit_field "max_effect_requests" hard_limits.max_effect_requests fields
+      in
+      let* max_effects = parse_limit_field "max_effects" hard_limits.max_effects fields in
+      let* max_frame_bytes =
+        parse_limit_field "max_frame_bytes" hard_limits.max_frame_bytes fields
+      in
+      let* max_host_message_bytes =
+        parse_limit_field "max_host_message_bytes" hard_limits.max_host_message_bytes fields
+      in
+      let* max_json_depth = parse_limit_field "max_json_depth" hard_limits.max_json_depth fields in
+      let* max_operations = parse_limit_field "max_operations" hard_limits.max_operations fields in
+      let* max_stderr_bytes =
+        parse_limit_field "max_stderr_bytes" hard_limits.max_stderr_bytes fields
+      in
+      let* max_text_bytes = parse_limit_field "max_text_bytes" hard_limits.max_text_bytes fields in
+      let* max_value_nodes =
+        parse_limit_field "max_value_nodes" hard_limits.max_value_nodes fields
+      in
+      Ok
+        {
+          max_frame_bytes;
+          max_json_depth;
+          max_value_nodes;
+          max_text_bytes;
+          max_collection_items;
+          max_arguments;
+          max_effects;
+          max_operations;
+          max_effect_requests;
+          max_diagnostics;
+          max_diagnostic_bytes;
+          max_host_message_bytes;
+          max_stderr_bytes;
+        }
+  | _ -> error ~code:"E1601" "The limits field must be one exact JSON object."
+
+let rec json_depth = function
+  | `Assoc fields ->
+      1 + List.fold_left (fun depth (_, value) -> max depth (json_depth value)) 0 fields
+  | `List items -> 1 + List.fold_left (fun depth value -> max depth (json_depth value)) 0 items
+  | `String _ | `Int _ | `Float _ | `Intlit _ | `Bool _ | `Null -> 0
+  | `Tuple _ | `Variant _ -> 0
+
+let rec json_string_bytes = function
+  | `String value -> String.length value
+  | `Assoc fields ->
+      List.fold_left (fun total (_, value) -> total + json_string_bytes value) 0 fields
+  | `List items -> List.fold_left (fun total value -> total + json_string_bytes value) 0 items
+  | `Int _ | `Float _ | `Intlit _ | `Bool _ | `Null | `Tuple _ | `Variant _ -> 0
+
+let capacity_diagnostic =
+  diagnostic ~code:"E1602" "The selected limits cannot represent a mandatory terminal frame."
+
+let minimum_fatal =
+  `Assoc
+    [
+      ("diagnostics", `List [ Diag.to_yojson capacity_diagnostic ]);
+      ("kind", `String "fatal");
+      ("protocol", `String protocol);
+    ]
+
+let validate_terminal_capacity limits =
+  let fatal_bytes = String.length (Yojson.Safe.to_string minimum_fatal) in
+  let ack_bytes = String.length (Yojson.Safe.to_string (shutdown_ack ())) in
+  let diagnostic_bytes = json_string_bytes (Diag.to_yojson capacity_diagnostic) in
+  if limits.max_diagnostics < 1 || limits.max_collection_items < 1 then
+    error ~code:"E1602" "The selected limits cannot carry one mandatory diagnostic."
+  else if limits.max_json_depth < json_depth minimum_fatal then
+    error ~code:"E1602" "The selected max_json_depth cannot carry a mandatory fatal frame."
+  else if limits.max_diagnostic_bytes < diagnostic_bytes then
+    error ~code:"E1602" "The selected diagnostic byte limit cannot carry a mandatory diagnostic."
+  else if limits.max_frame_bytes < max fatal_bytes ack_bytes then
+    error ~code:"E1602" "The selected frame byte limit cannot carry a mandatory terminal frame."
+  else Ok ()
+
+let parse_host_select json =
+  Result.bind (validate_json ~limits:hard_limits json) (fun () ->
+      match json with
+      | `Assoc fields ->
+          Result.bind
+            (exact_fields [ "kind"; "limits"; "protocol" ] fields)
+            (fun () ->
+              Result.bind (parse_protocol fields) (fun () ->
+                  Result.bind (parse_kind "host_select" fields) (fun () ->
+                      match field "limits" fields with
+                      | None -> error ~code:"E1601" "The limits field is missing."
+                      | Some json ->
+                          Result.bind (parse_limits json) (fun limits ->
+                              Result.map (fun () -> limits) (validate_terminal_capacity limits)))))
+      | _ -> error ~code:"E1601" "The host selection must be one JSON object.")
+
+let parse_shutdown ~limits json =
+  Result.bind (validate_json ~limits json) (fun () ->
+      match json with
+      | `Assoc fields ->
+          Result.bind
+            (exact_fields [ "kind"; "protocol" ] fields)
+            (fun () -> Result.bind (parse_protocol fields) (fun () -> parse_kind "shutdown" fields))
+      | _ -> error ~code:"E1601" "The shutdown message must be one JSON object.")

--- a/src/host_protocol_v0.mli
+++ b/src/host_protocol_v0.mli
@@ -1,0 +1,71 @@
+(** Strict bounded codecs for the provisional [jacquard-host-v0] process carrier.
+
+    This module implements only transport framing, structural JSON checks, limit negotiation, and
+    the selected shutdown envelope. It does not select a store target, decode Jacquard values,
+    evaluate code, dispatch host operations, or expose a runnable worker. *)
+
+val protocol : string
+(** The one protocol version accepted by this codec. *)
+
+val carrier : string
+(** The provisional four-byte big-endian length-prefixed JSON carrier name. *)
+
+type limits = {
+  max_frame_bytes : int;
+  max_json_depth : int;
+  max_value_nodes : int;
+  max_text_bytes : int;
+  max_collection_items : int;
+  max_arguments : int;
+  max_effects : int;
+  max_operations : int;
+  max_effect_requests : int;
+  max_diagnostics : int;
+  max_diagnostic_bytes : int;
+  max_host_message_bytes : int;
+  max_stderr_bytes : int;
+}
+(** Frozen hard or host-selected ceilings. Every selected field is positive and no greater than the
+    corresponding {!hard_limits} field. *)
+
+val hard_limits : limits
+(** The fixed maxima advertised before selection. *)
+
+val limits_to_yojson : limits -> Yojson.Safe.t
+(** [limits_to_yojson limits] emits every limit field once in deterministic lexical order. *)
+
+val core_hello : unit -> Yojson.Safe.t
+(** [core_hello ()] is the exact first Core envelope under the hard limits. *)
+
+val parse_host_select : Yojson.Safe.t -> (limits, Diag.t list) result
+(** [parse_host_select json] validates the exact selection envelope, version, positive
+    component-wise bounds, and capacity for the mandatory smallest terminal frames. Shape failures
+    return E1601, an unknown version returns E1600, state errors return E1608, and limit failures
+    return E1602. *)
+
+val parse_shutdown : limits:limits -> Yojson.Safe.t -> (unit, Diag.t list) result
+(** [parse_shutdown ~limits json] accepts only the exact selected pre-invocation shutdown envelope
+    under [limits]. Unknown versions return E1600, envelope-shape failures E1601, another message
+    kind E1608, and a selected structural-limit violation E1602. *)
+
+val shutdown_ack : unit -> Yojson.Safe.t
+(** [shutdown_ack ()] is the exact terminal acknowledgement for a selected pre-invocation shutdown.
+*)
+
+val encode_frame_bytes : limits:limits -> Yojson.Safe.t -> (string, Diag.t list) result
+(** [encode_frame_bytes ~limits json] returns one complete u32-big-endian frame. The value must be a
+    structurally valid JSON object within [limits]; invalid shape returns E1601 and an exceeded
+    limit returns E1602. *)
+
+val decode_frame_bytes : limits:limits -> string -> (Yojson.Safe.t, Diag.t list) result
+(** [decode_frame_bytes ~limits bytes] decodes exactly one complete frame and rejects extra carrier
+    bytes. Truncated framing returns E1611; malformed framing/JSON returns E1601; an exceeded limit
+    returns E1602. *)
+
+val read_frame : limits:limits -> in_channel -> (Yojson.Safe.t, Diag.t list) result
+(** [read_frame ~limits input] reads exactly one frame from [input]. EOF or I/O loss before the
+    frame is complete returns E1611; malformed data and exceeded limits retain E1601/E1602. *)
+
+val write_frame : limits:limits -> out_channel -> Yojson.Safe.t -> (unit, Diag.t list) result
+(** [write_frame ~limits output json] writes and flushes one complete frame. Encoding failures
+    retain E1601/E1602; an output or flush failure returns E1611. *)

--- a/test/dune
+++ b/test/dune
@@ -111,11 +111,22 @@
  (modules host_protocol_vectors_focused)
  (libraries host_protocol_vectors_test_support alcotest))
 
+(library
+ (name host_protocol_codec_test_support)
+ (wrapped false)
+ (modules test_host_protocol_codec)
+ (libraries jacquard alcotest qcheck-core qcheck-alcotest yojson))
+
+(executable
+ (name host_protocol_codec_focused)
+ (modules host_protocol_codec_focused)
+ (libraries host_protocol_codec_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused))
- (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)

--- a/test/host_protocol_codec_focused.ml
+++ b/test/host_protocol_codec_focused.ml
@@ -1,0 +1,3 @@
+let () =
+  Alcotest.run "jacquard-host-protocol-codec"
+    [ ("host-protocol-codec", Test_host_protocol_codec.suite) ]

--- a/test/test_host_protocol_codec.ml
+++ b/test/test_host_protocol_codec.ml
@@ -1,0 +1,340 @@
+open Jacquard
+module Host = Host_protocol_v0
+
+let fail_diagnostics diagnostics = String.concat "\n" (List.map Diag.to_string diagnostics)
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error diagnostics -> Alcotest.failf "%s failed:\n%s" label (fail_diagnostics diagnostics)
+
+let expect_code label expected = function
+  | Error (diagnostic :: _) ->
+      Alcotest.(check string) label expected (Diag.code_or_uncoded diagnostic)
+  | Error [] -> Alcotest.failf "%s returned an empty diagnostic list" label
+  | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
+
+let byte value = String.make 1 (Char.chr value)
+
+let prefix length =
+  byte ((length lsr 24) land 0xff)
+  ^ byte ((length lsr 16) land 0xff)
+  ^ byte ((length lsr 8) land 0xff)
+  ^ byte (length land 0xff)
+
+let raw_frame payload = prefix (String.length payload) ^ payload
+
+let select limits =
+  `Assoc
+    [
+      ("kind", `String "host_select");
+      ("limits", Host.limits_to_yojson limits);
+      ("protocol", `String Host.protocol);
+    ]
+
+let member name json = Yojson.Safe.Util.member name json
+
+let test_hello_exact () =
+  let hello = Host.core_hello () in
+  Alcotest.(check string)
+    "carrier" Host.carrier
+    Yojson.Safe.Util.(hello |> member "carrier" |> to_string);
+  Alcotest.(check (list string))
+    "versions" [ Host.protocol ]
+    Yojson.Safe.Util.(hello |> member "versions" |> to_list |> filter_string);
+  let expected_limits =
+    [
+      ("max_arguments", 64);
+      ("max_collection_items", 1_024);
+      ("max_diagnostic_bytes", 65_536);
+      ("max_diagnostics", 32);
+      ("max_effect_requests", 1_024);
+      ("max_effects", 64);
+      ("max_frame_bytes", 1_048_576);
+      ("max_host_message_bytes", 4_096);
+      ("max_json_depth", 64);
+      ("max_operations", 256);
+      ("max_stderr_bytes", 65_536);
+      ("max_text_bytes", 262_144);
+      ("max_value_nodes", 4_096);
+    ]
+  in
+  let limits = member "limits" hello in
+  List.iter
+    (fun (name, expected) ->
+      Alcotest.(check int) name expected Yojson.Safe.Util.(limits |> member name |> to_int))
+    expected_limits;
+  Alcotest.(check (list string))
+    "exact limit fields" (List.map fst expected_limits)
+    (match limits with `Assoc fields -> List.map fst fields | _ -> []);
+  Alcotest.(check (list string))
+    "exact hello fields"
+    [ "carrier"; "kind"; "limits"; "versions" ]
+    (match hello with `Assoc fields -> List.map fst fields |> List.sort String.compare | _ -> [])
+
+let test_u32_frame_is_deterministic () =
+  let json = `Assoc [ ("kind", `String "probe") ] in
+  let first = expect_ok "first encode" (Host.encode_frame_bytes ~limits:Host.hard_limits json) in
+  let second = expect_ok "second encode" (Host.encode_frame_bytes ~limits:Host.hard_limits json) in
+  let payload = Yojson.Safe.to_string json in
+  Alcotest.(check string) "deterministic bytes" first second;
+  Alcotest.(check string)
+    "big-endian prefix"
+    (prefix (String.length payload))
+    (String.sub first 0 4);
+  Alcotest.(check string) "payload bytes" payload (String.sub first 4 (String.length first - 4))
+
+let prop_frame_round_trip =
+  QCheck.Test.make ~count:300 ~name:"bounded u32 JSON frames round-trip semantically"
+    QCheck.(make Gen.(string_size ~gen:printable (int_bound 512)))
+    (fun value ->
+      let json = `Assoc [ ("kind", `String "probe"); ("value", `String value) ] in
+      match Host.encode_frame_bytes ~limits:Host.hard_limits json with
+      | Error _ -> false
+      | Ok bytes -> (
+          match Host.decode_frame_bytes ~limits:Host.hard_limits bytes with
+          | Ok decoded -> Yojson.Safe.equal json decoded
+          | Error _ -> false))
+
+let test_stream_round_trip () =
+  let path = Filename.temp_file "jacquard-host-frame-" ".bin" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      let json = `Assoc [ ("kind", `String "probe"); ("value", `String "stream") ] in
+      let output = open_out_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr output)
+        (fun () -> expect_ok "stream write" (Host.write_frame ~limits:Host.hard_limits output json));
+      let input = open_in_bin path in
+      let decoded =
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr input)
+          (fun () -> expect_ok "stream read" (Host.read_frame ~limits:Host.hard_limits input))
+      in
+      Alcotest.(check bool) "semantic stream value" true (Yojson.Safe.equal json decoded);
+      let closed_input = open_in_bin path in
+      close_in closed_input;
+      expect_code "closed input carrier" "E1611"
+        (Host.read_frame ~limits:Host.hard_limits closed_input);
+      let closed_output = open_out_bin path in
+      close_out closed_output;
+      expect_code "closed output carrier" "E1611"
+        (Host.write_frame ~limits:Host.hard_limits closed_output json))
+
+let test_zero_and_oversized_prefixes () =
+  expect_code "zero frame" "E1601" (Host.decode_frame_bytes ~limits:Host.hard_limits (prefix 0));
+  let oversized = Host.hard_limits.max_frame_bytes + 1 in
+  expect_code "oversized frame" "E1602"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (prefix oversized))
+
+let test_truncated_frame_parts () =
+  List.iter
+    (fun bytes ->
+      expect_code "truncated prefix" "E1611"
+        (Host.decode_frame_bytes ~limits:Host.hard_limits bytes))
+    [ ""; "\x00"; "\x00\x00"; "\x00\x00\x00" ];
+  expect_code "truncated payload" "E1611"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (prefix 4 ^ "{}"))
+
+let test_extra_bytes_and_trailing_json () =
+  expect_code "bytes after frame" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame "{}" ^ "x"));
+  expect_code "second JSON value in payload" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame "{}{}"))
+
+let test_utf8_and_surrogate_rejection () =
+  let invalid_utf8 = "{\"value\":\"" ^ byte 0x80 ^ "\"}" in
+  expect_code "invalid raw UTF-8" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame invalid_utf8));
+  expect_code "escaped lone surrogate" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame "{\"value\":\"\\ud800\"}"));
+  let pair =
+    expect_ok "escaped surrogate pair"
+      (Host.decode_frame_bytes ~limits:Host.hard_limits
+         (raw_frame "{\"value\":\"\\ud83d\\ude00\"}"))
+  in
+  Alcotest.(check string)
+    "surrogate pair becomes one scalar" "😀"
+    Yojson.Safe.Util.(pair |> member "value" |> to_string)
+
+let test_duplicate_keys_rejected_recursively () =
+  expect_code "duplicate root key" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame "{\"a\":1,\"a\":2}"));
+  expect_code "duplicate nested key" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame "{\"outer\":{\"a\":1,\"a\":2}}"))
+
+let test_object_depth_and_collection_limits () =
+  expect_code "non-object payload" "E1601"
+    (Host.decode_frame_bytes ~limits:Host.hard_limits (raw_frame "[]"));
+  let shallow = { Host.hard_limits with max_json_depth = 2 } in
+  expect_code "JSON depth" "E1602"
+    (Host.decode_frame_bytes ~limits:shallow (raw_frame "{\"a\":{\"b\":{}}}"));
+  let exact_depth = { Host.hard_limits with max_json_depth = 3 } in
+  ignore
+    (expect_ok "exact JSON depth"
+       (Host.decode_frame_bytes ~limits:exact_depth (raw_frame "{\"a\":{\"b\":{}}}")));
+  let one_item = { Host.hard_limits with max_collection_items = 1 } in
+  expect_code "collection items" "E1602"
+    (Host.decode_frame_bytes ~limits:one_item (raw_frame "{\"a\":[1,2]}"));
+  ignore
+    (expect_ok "exact collection items"
+       (Host.decode_frame_bytes ~limits:one_item (raw_frame "{\"a\":[1]}")))
+
+let test_select_accepts_exact_limits_and_key_reordering () =
+  let accepted = expect_ok "exact selection" (Host.parse_host_select (select Host.hard_limits)) in
+  Alcotest.(check int)
+    "selected frame limit" Host.hard_limits.max_frame_bytes accepted.max_frame_bytes;
+  let reordered =
+    `Assoc
+      [
+        ("protocol", `String Host.protocol);
+        ("limits", Host.limits_to_yojson Host.hard_limits);
+        ("kind", `String "host_select");
+      ]
+  in
+  let reordered = expect_ok "reordered selection" (Host.parse_host_select reordered) in
+  Alcotest.(check bool) "key order is insignificant" true (reordered = accepted)
+
+let test_select_unknown_version () =
+  let unknown =
+    `Assoc
+      [
+        ("kind", `String "host_select");
+        ("limits", Host.limits_to_yojson Host.hard_limits);
+        ("protocol", `String "jacquard-host-v9");
+      ]
+  in
+  expect_code "unknown version" "E1600" (Host.parse_host_select unknown)
+
+let test_select_shape_failures () =
+  let missing = `Assoc [ ("kind", `String "host_select"); ("protocol", `String Host.protocol) ] in
+  let extra =
+    match select Host.hard_limits with
+    | `Assoc fields -> `Assoc (("extra", `Null) :: fields)
+    | _ -> assert false
+  in
+  let wrong_scalar =
+    `Assoc
+      [
+        ("kind", `String "host_select");
+        ("limits", `String "large");
+        ("protocol", `String Host.protocol);
+      ]
+  in
+  let missing_limit =
+    match Host.limits_to_yojson Host.hard_limits with
+    | `Assoc (_ :: fields) ->
+        `Assoc
+          [
+            ("kind", `String "host_select");
+            ("limits", `Assoc fields);
+            ("protocol", `String Host.protocol);
+          ]
+    | _ -> assert false
+  in
+  let extra_limit =
+    match Host.limits_to_yojson Host.hard_limits with
+    | `Assoc fields ->
+        `Assoc
+          [
+            ("kind", `String "host_select");
+            ("limits", `Assoc (("extra", `Int 1) :: fields));
+            ("protocol", `String Host.protocol);
+          ]
+    | _ -> assert false
+  in
+  let noninteger_limit =
+    match Host.limits_to_yojson Host.hard_limits with
+    | `Assoc fields ->
+        let fields =
+          List.map
+            (fun (name, value) ->
+              if name = "max_arguments" then (name, `String "64") else (name, value))
+            fields
+        in
+        `Assoc
+          [
+            ("kind", `String "host_select");
+            ("limits", `Assoc fields);
+            ("protocol", `String Host.protocol);
+          ]
+    | _ -> assert false
+  in
+  List.iter
+    (fun (label, value) -> expect_code label "E1601" (Host.parse_host_select value))
+    [
+      ("missing limits", missing);
+      ("extra selection field", extra);
+      ("wrong limits scalar", wrong_scalar);
+      ("missing limit field", missing_limit);
+      ("extra limit field", extra_limit);
+      ("noninteger limit field", noninteger_limit);
+    ]
+
+let test_select_limit_bounds () =
+  let nonpositive = { Host.hard_limits with max_arguments = 0 } in
+  let excessive =
+    { Host.hard_limits with max_effect_requests = Host.hard_limits.max_effect_requests + 1 }
+  in
+  expect_code "nonpositive limit" "E1602" (Host.parse_host_select (select nonpositive));
+  expect_code "excessive limit" "E1602" (Host.parse_host_select (select excessive))
+
+let test_select_mandatory_terminal_capacity () =
+  let too_shallow = { Host.hard_limits with max_json_depth = 2 } in
+  let no_fatal_frame = { Host.hard_limits with max_frame_bytes = 1 } in
+  let no_diagnostic = { Host.hard_limits with max_diagnostic_bytes = 1 } in
+  expect_code "fatal depth capacity" "E1602" (Host.parse_host_select (select too_shallow));
+  expect_code "fatal frame capacity" "E1602" (Host.parse_host_select (select no_fatal_frame));
+  expect_code "fatal diagnostic capacity" "E1602" (Host.parse_host_select (select no_diagnostic))
+
+let test_shutdown_exact () =
+  let shutdown = `Assoc [ ("kind", `String "shutdown"); ("protocol", `String Host.protocol) ] in
+  expect_ok "shutdown" (Host.parse_shutdown ~limits:Host.hard_limits shutdown);
+  Alcotest.(check bool)
+    "deterministic ack" true
+    (Yojson.Safe.equal
+       (`Assoc [ ("kind", `String "shutdown_ack"); ("protocol", `String Host.protocol) ])
+       (Host.shutdown_ack ()))
+
+let test_shutdown_shape_failure () =
+  let extra =
+    `Assoc [ ("extra", `Null); ("kind", `String "shutdown"); ("protocol", `String Host.protocol) ]
+  in
+  expect_code "extra shutdown field" "E1601" (Host.parse_shutdown ~limits:Host.hard_limits extra)
+
+let test_shutdown_version_and_state_failures () =
+  let unknown = `Assoc [ ("kind", `String "shutdown"); ("protocol", `String "jacquard-host-v9") ] in
+  let wrong_kind = `Assoc [ ("kind", `String "invoke"); ("protocol", `String Host.protocol) ] in
+  expect_code "shutdown unknown version" "E1600"
+    (Host.parse_shutdown ~limits:Host.hard_limits unknown);
+  expect_code "shutdown wrong state" "E1608"
+    (Host.parse_shutdown ~limits:Host.hard_limits wrong_kind)
+
+let suite =
+  [
+    Alcotest.test_case "hard-limit hello is exact" `Quick test_hello_exact;
+    Alcotest.test_case "u32 frame bytes are deterministic" `Quick test_u32_frame_is_deterministic;
+    QCheck_alcotest.to_alcotest prop_frame_round_trip;
+    Alcotest.test_case "stream frame round-trip" `Quick test_stream_round_trip;
+    Alcotest.test_case "zero and oversized prefixes fail closed" `Quick
+      test_zero_and_oversized_prefixes;
+    Alcotest.test_case "truncated frame parts are carrier loss" `Quick test_truncated_frame_parts;
+    Alcotest.test_case "extra carrier and JSON bytes fail closed" `Quick
+      test_extra_bytes_and_trailing_json;
+    Alcotest.test_case "invalid UTF-8 and surrogates fail closed" `Quick
+      test_utf8_and_surrogate_rejection;
+    Alcotest.test_case "duplicate keys fail recursively" `Quick
+      test_duplicate_keys_rejected_recursively;
+    Alcotest.test_case "object, depth, and collection limits" `Quick
+      test_object_depth_and_collection_limits;
+    Alcotest.test_case "exact selection ignores key order" `Quick
+      test_select_accepts_exact_limits_and_key_reordering;
+    Alcotest.test_case "unknown selection version" `Quick test_select_unknown_version;
+    Alcotest.test_case "selection shape failures" `Quick test_select_shape_failures;
+    Alcotest.test_case "selection limit bounds" `Quick test_select_limit_bounds;
+    Alcotest.test_case "mandatory terminal capacity" `Quick test_select_mandatory_terminal_capacity;
+    Alcotest.test_case "shutdown and ack are exact" `Quick test_shutdown_exact;
+    Alcotest.test_case "shutdown shape failure" `Quick test_shutdown_shape_failure;
+    Alcotest.test_case "shutdown version and state failures" `Quick
+      test_shutdown_version_and_state_failures;
+  ]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -24,6 +24,7 @@ let () =
       ("prelude", Test_prelude.suite);
       ("effect-taxonomy", Test_effect_taxonomy.suite);
       ("host-protocol-v0", Test_host_protocol_vectors.suite);
+      ("host-protocol-codec", Test_host_protocol_codec.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Outcome

Adds the strict, bounded library codec for the first Jacquard host carrier. It
implements the frozen `stdio-u32-json-v0` framing and handshake contract while
leaving all existing language, evaluator, scheduler, CLI, and native-runtime
behavior unchanged.

This is the transport/selection slice of HB.2. It deliberately does **not**
make a runnable worker or claim that Jacquard can execute hosted effects yet.
Typed descriptors and boundary values come next; the affine effect lifecycle
and opt-in worker CLI follow after that.

## Included

- unsigned 32-bit big-endian frame encoding and bounded stream I/O
- strict UTF-8 JSON-object validation, including recursive duplicate-key,
  depth, collection-size, numeric-form, and trailing-data rejection
- deterministic `core_hello` and exact `host_select` parsing
- positive component-wise limit negotiation and mandatory terminal capacity
- exact shutdown and shutdown-ack envelopes
- stable E1600/E1601/E1602/E1608/E1611 failure classification without
  reflecting refused payload bytes
- 18 focused unit/property cases, including 300 generated frame round trips
- current documentation and successor evidence inventory updated from 882 to
  900 repository tests

## Explicit exclusions

No store lookup, checker/evaluator integration, target or interface preflight,
boundary-value codec, operation exchange, adapter, socket, server, or CLI is
added here. The public carrier remains unavailable until the later HB.2 slices
complete.

## Evidence

- independent Claude Fable 5 review at xhigh: **PASS**, no required code change
- reviewed and final head: `009f152cbcd65758b7ee6dececb72dbcc4890393`
- `dune runtest`: **900/900**, 424.475s, QCheck seed `762720898`
- focused host-protocol codec suite: **18/18**
- `dune build @all`: pass
- `dune build @doc`: pass
- `dune fmt`: clean
- meaningful whitespace check: clean

The review recorded two forward-looking worker concerns: dispatch decoded
message kind before body parsing to preserve state diagnostics, and specify a
fallback for diagnostics larger than a selected frame. Both are intentionally
owned by the later worker-state-machine slice and do not change this frozen
codec contract.
