### PR TITLE
HB.2b1: add bounded host boundary codecs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,11 +118,12 @@ When adding valid corpus files, regenerate the golden hashes with
 - Handlers and evaluation: `src/eval.ml`, `test/test_handlers.ml`,
   `test/test_gauntlet_handlers.ml`.
 - Host integration contracts: `docs/host-boundary.md` and
-  `spec/host-protocol-v0.md`; strict framing and selection codec:
-  `src/host_protocol_v0.ml`, `test/test_host_protocol_codec.ml`. No runnable
-  worker ships yet. Existing evaluator capture and host-readiness modules are
-  internal seams, not a public ABI; adapters and application servers belong
-  outside this repository.
+  `spec/host-protocol-v0.md`; strict framing, selection, and first-order
+  type/value codecs: `src/host_protocol_v0.ml`,
+  `test/test_host_protocol_codec.ml`, `test/test_host_boundary_codec.ml`. No
+  runnable worker ships yet. Existing evaluator capture and host-readiness
+  modules are internal seams, not a public ABI; adapters and application
+  servers belong outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,
   `src/infer_dist.ml`, `test/test_infer.ml`.
 - Warp: `prelude/15-warp.jqd`, `prelude/16-gen.jqd`, `src/warp.ml`,

--- a/README.md
+++ b/README.md
@@ -601,7 +601,8 @@ Key release docs:
 - `src/diff.ml`: canonical-structure diff over stores.
 - `src/warp.ml`: Warp test discovery, running, cache, and properties.
 - `src/host_protocol_v0.ml`: strict library-only framing, JSON, limit-selection,
-  and shutdown codec for the experimental host protocol; no worker entry point.
+  shutdown, and bounded first-order type/value codecs for the experimental host
+  protocol; no worker entry point.
 
 ## Documentation Map
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,9 @@ project shape from file names alone.
 - `../spec/serialization.md`: canonical byte serialization and hashing.
 - `../spec/host-protocol-v0.md`: frozen HB.1 transport-neutral envelopes,
   provisional stdio framing, boundary values, limits, stable failures, and
-  positive/hostile vectors. HB.2a implements its strict library codec, but no
-  runnable carrier ships yet.
+  positive/hostile vectors. HB.2a implements strict framing/selection and
+  HB.2b1 implements bounded first-order type/value codecs, but no runnable
+  carrier ships yet.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -898,8 +898,10 @@ Do not invent new kernel forms for surface sugar.
 - HB.0 documents the language-neutral host ownership and trust boundary, and
   HB.1 freezes `jacquard-host-v0` envelopes, provisional process framing,
   limits, stable failures, and schema/state vectors. `Host_protocol_v0`
-  implements the strict framing/selection/shutdown codec for HB.2a; reuse it
-  instead of recreating JSON or u32 framing. No runnable worker, stable
+  implements the strict framing/selection/shutdown codec for HB.2a and the
+  shared-budget first-order type/value codecs for HB.2b1; reuse it instead of
+  recreating framing or value semantics. Store target, interface, capability,
+  and field-type preflight are not implemented yet. No runnable worker, stable
   foreign-host ABI, adapter, or HTTP server ships yet. Internal
   evaluator-capture and host-readiness OCaml APIs are not supported embedding
   contracts; future adapters must consume the versioned protocol and its

--- a/docs/host-boundary.md
+++ b/docs/host-boundary.md
@@ -244,9 +244,10 @@ matrix.
 ## 9. Repository and product boundary
 
 `jacquard-lang` owns this contract, the HB.1 schema/state vectors, the
-`Host_protocol_v0` strict framing/selection codec, its later runnable carrier
-inside Core, executable fixtures, and language/runtime evidence. It may
-contain a tiny fake host used only to prove conformance.
+`Host_protocol_v0` strict framing/selection and first-order type/value codecs,
+its later runnable carrier inside Core, executable fixtures, and
+language/runtime evidence. It may contain a tiny fake host used only to prove
+conformance.
 
 The private `jacquard-host` repository owns real adapters, sockets,
 persistence, the minimal serial HTTP integration, and the requirements report

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `900`
+Test count: `914`
 
 Cram count: `59`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `900`
+- Alcotest/QCheck cases: `914`
 - Cram transcript files: `59`
 - Documentation examples: `28` named examples across `8` documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `900`
+- Alcotest/QCheck cases: `914`
 - Cram transcript files: `59`
 - Doctest examples: `28` across 8 documents
 
@@ -63,8 +63,10 @@ Task 171 adds one labeled-pattern contract case. SX.23 then adds six compiled
 named-call cases, two D76 decision-mutation cases, and one CLI transcript,
 producing `877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract
 cases, producing `882 / 59 / 28`. HB.2a adds eighteen bounded framing and
-selection codec cases, producing the current `900 / 59 / 28` successor
-inventory without changing the historical DX.2 publication.
+selection codec cases, producing the then-current `900 / 59 / 28` successor
+inventory. HB.2b1 adds fourteen bounded first-order type/value codec cases,
+producing the current `914 / 59 / 28` successor inventory without changing the
+historical DX.2 publication.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 900 compiled Alcotest/QCheck cases, 59 recursive
+The current successor inventory is exactly 914 compiled Alcotest/QCheck cases, 59 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `900`
+- Alcotest/QCheck cases: `914`
 - Cram transcript files: `59`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -817,7 +817,9 @@ contract case, producing `869 / 58 / 28`. SX.23 then adds six named-call cases,
 two D76 decision-mutation cases, and one transcript, producing
 `877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract cases,
 producing `882 / 59 / 28`. HB.2a adds eighteen bounded framing and selection
-codec cases, producing the current `900 / 59 / 28` inventory.
+codec cases, producing the then-current `900 / 59 / 28` inventory.
+HB.2b1 adds fourteen bounded first-order type/value codec cases, producing the
+current `914 / 59 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -590,10 +590,13 @@ separation; they do not claim that a Core store contains those objects. HB.2
 adds the executable Core carrier fixtures. HB.3 packages the final executable
 fixtures for independent adapters and replaces no HB.1 expectation.
 
-Implementation status: HB.2a now provides the library-only strict framing and
+Implementation status: HB.2a provides the library-only strict framing and
 selection codec in `Host_protocol_v0`, including bounded u32 framing, Unicode
 scalar UTF-8, recursive duplicate-key checks, exact hard/selected limits, and
-the shutdown envelope. It does not expose a runnable worker; descriptor
+the shutdown envelope. HB.2b1 adds exact nominal/tuple and lossless
+Int/Real/Text/Hash/tuple/saturated-constructor codecs, shared per-frame node
+accounting, selected descriptor limits, and constructor identity/arity
+resolution. It does not expose a runnable worker; target/interface/capability
 preflight, evaluation, and effect exchange remain later HB.2 slices.
 
 A conforming implementation must:

--- a/src/host_protocol_v0.ml
+++ b/src/host_protocol_v0.ml
@@ -17,6 +17,8 @@ type limits = {
   max_stderr_bytes : int;
 }
 
+type boundary_budget = { limits : limits; mutable nodes : int }
+
 let hard_limits =
   {
     max_frame_bytes = 1_048_576;
@@ -34,6 +36,8 @@ let hard_limits =
     max_stderr_bytes = 65_536;
   }
 
+let create_boundary_budget limits = { limits; nodes = 0 }
+
 let diagnostic_spec = function
   | "E1600" ->
       ( "The host selected an unsupported protocol version.",
@@ -44,6 +48,9 @@ let diagnostic_spec = function
   | "E1602" ->
       ( "The host protocol limit was exceeded or cannot represent a mandatory result.",
         "Choose positive advertised limits and keep the frame within the selected ceilings." )
+  | "E1604" ->
+      ( "A Jacquard type or value is unsupported at the v0 host boundary.",
+        "Use only the frozen closed first-order type and lossless value descriptor subset." )
   | "E1608" ->
       ( "The host protocol message is invalid in the current state.",
         "Send only the next message permitted by the serial jacquard-host-v0 state machine." )
@@ -431,3 +438,270 @@ let parse_shutdown ~limits json =
             (exact_fields [ "kind"; "protocol" ] fields)
             (fun () -> Result.bind (parse_protocol fields) (fun () -> parse_kind "shutdown" fields))
       | _ -> error ~code:"E1601" "The shutdown message must be one JSON object.")
+
+let consume_boundary_node budget =
+  if budget.limits.max_value_nodes <= 0 || budget.nodes >= budget.limits.max_value_nodes then
+    error ~code:"E1602" "The frame exceeds max_value_nodes across its type and value descriptors."
+  else (
+    budget.nodes <- budget.nodes + 1;
+    Ok ())
+
+let boundary_kind fields =
+  match field "kind" fields with
+  | Some (`String kind) -> Ok kind
+  | Some _ | None -> error ~code:"E1601" "A boundary descriptor kind must be one string."
+
+let boundary_hash context = function
+  | `String spelling -> (
+      match Hash.of_canonical_hex spelling with
+      | Some hash -> Ok hash
+      | None ->
+          error ~code:"E1601"
+            (Printf.sprintf "The %s must be exactly 64 lowercase hexadecimal digits." context))
+  | _ -> error ~code:"E1601" (Printf.sprintf "The %s must be one HASH_V0 string." context)
+
+let validate_boundary_count ~budget ~context ~arguments count =
+  if budget.limits.max_collection_items <= 0 || count > budget.limits.max_collection_items then
+    error ~code:"E1602" (Printf.sprintf "The %s exceeds max_collection_items." context)
+  else if arguments && (budget.limits.max_arguments <= 0 || count > budget.limits.max_arguments)
+  then error ~code:"E1602" (Printf.sprintf "The %s exceeds max_arguments." context)
+  else Ok ()
+
+let boundary_list ~budget ~context ~arguments = function
+  | `List items ->
+      let* () = validate_boundary_count ~budget ~context ~arguments (List.length items) in
+      Ok items
+  | _ -> error ~code:"E1601" (Printf.sprintf "The %s must be one JSON array." context)
+
+let rec map_result f = function
+  | [] -> Ok []
+  | item :: rest ->
+      let* item = f item in
+      let* rest = map_result f rest in
+      Ok (item :: rest)
+
+let decode_boundary_type ~budget json =
+  let rec decode = function
+    | `Assoc fields ->
+        let* kind = boundary_kind fields in
+        let* () =
+          match kind with
+          | "nominal" -> exact_fields [ "arguments"; "identity"; "kind" ] fields
+          | "tuple" -> exact_fields [ "items"; "kind" ] fields
+          | _ ->
+              error ~code:"E1604"
+                (Printf.sprintf "Boundary type kind %S is not supported in jacquard-host-v0." kind)
+        in
+        let* () = consume_boundary_node budget in
+        if String.equal kind "nominal" then
+          let* identity =
+            match field "identity" fields with
+            | Some value -> boundary_hash "nominal type identity" value
+            | None -> error ~code:"E1601" "The nominal type identity is missing."
+          in
+          let* arguments =
+            match field "arguments" fields with
+            | Some value ->
+                boundary_list ~budget ~context:"nominal type arguments" ~arguments:false value
+            | None -> error ~code:"E1601" "The nominal type arguments are missing."
+          in
+          let* arguments = map_result decode arguments in
+          Ok (Types.TCon (identity, arguments))
+        else
+          let* items =
+            match field "items" fields with
+            | Some value -> boundary_list ~budget ~context:"tuple type items" ~arguments:false value
+            | None -> error ~code:"E1601" "The tuple type items are missing."
+          in
+          let* items = map_result decode items in
+          Ok (Types.TTuple items)
+    | _ -> error ~code:"E1601" "A boundary type must be one exact JSON object."
+  in
+  let* () = validate_json ~limits:budget.limits json in
+  decode json
+
+let encode_boundary_type ~budget ty =
+  let rec encode ty =
+    match Types.repr ty with
+    | Types.TCon (identity, arguments) ->
+        let* () = consume_boundary_node budget in
+        let* () =
+          validate_boundary_count ~budget ~context:"nominal type arguments" ~arguments:false
+            (List.length arguments)
+        in
+        let* arguments = map_result encode arguments in
+        Ok
+          (`Assoc
+             [
+               ("arguments", `List arguments);
+               ("identity", `String (Hash.to_hex identity));
+               ("kind", `String "nominal");
+             ])
+    | Types.TTuple items ->
+        let* () = consume_boundary_node budget in
+        let* () =
+          validate_boundary_count ~budget ~context:"tuple type items" ~arguments:false
+            (List.length items)
+        in
+        let* items = map_result encode items in
+        Ok (`Assoc [ ("items", `List items); ("kind", `String "tuple") ])
+    | Types.TArrow _ | Types.TResume _ | Types.TVariadicArrow _ | Types.TExactThunk _ | Types.TVar _
+    | Types.TSkolem _ ->
+        error ~code:"E1604"
+          "The Core type contains an arrow, resumption, exact thunk, or unresolved variable."
+  in
+  let* json = encode ty in
+  let* () = validate_json ~limits:budget.limits json in
+  Ok json
+
+let canonical_int = function
+  | `String spelling -> (
+      match int_of_string_opt spelling with
+      | Some value when String.equal spelling (string_of_int value) -> Ok value
+      | Some _ | None ->
+          error ~code:"E1601"
+            "A boundary Int must use canonical decimal text in the released OCaml 63-bit range.")
+  | _ -> error ~code:"E1601" "A boundary Int value must be one canonical decimal string."
+
+let lowercase_hex_16 spelling =
+  String.length spelling = 16
+  && String.for_all (function '0' .. '9' | 'a' .. 'f' -> true | _ -> false) spelling
+
+let real_of_bits = function
+  | `String spelling when lowercase_hex_16 spelling -> (
+      match Int64.of_string_opt ("0x" ^ spelling) with
+      | Some bits -> Ok (Int64.float_of_bits bits)
+      | None -> error ~code:"E1601" "A boundary Real bit string is not valid binary64 data.")
+  | `String _ ->
+      error ~code:"E1601" "A boundary Real must use exactly 16 lowercase hexadecimal digits."
+  | _ -> error ~code:"E1601" "A boundary Real bits field must be one string."
+
+let validate_boundary_text limits text =
+  if not (valid_utf8 text) then
+    error ~code:"E1601" "A boundary Text value is not Unicode scalar UTF-8."
+  else if limits.max_text_bytes <= 0 || String.length text > limits.max_text_bytes then
+    error ~code:"E1602" "A boundary Text value exceeds max_text_bytes."
+  else Ok text
+
+let decode_boundary_value ~budget ~constructor_info json =
+  let rec decode = function
+    | `Assoc fields -> (
+        let* kind = boundary_kind fields in
+        let* () =
+          match kind with
+          | "int" | "text" | "hash" -> exact_fields [ "kind"; "value" ] fields
+          | "real" -> exact_fields [ "bits"; "kind" ] fields
+          | "tuple" -> exact_fields [ "items"; "kind" ] fields
+          | "constructor" -> exact_fields [ "arguments"; "identity"; "kind" ] fields
+          | _ ->
+              error ~code:"E1604"
+                (Printf.sprintf "Boundary value kind %S is not supported in jacquard-host-v0." kind)
+        in
+        let* () = consume_boundary_node budget in
+        let field_or_missing name cause =
+          match field name fields with Some value -> Ok value | None -> error ~code:"E1601" cause
+        in
+        match kind with
+        | "int" ->
+            let* value = field_or_missing "value" "The boundary Int value is missing." in
+            let* value = canonical_int value in
+            Ok (Value.VInt value)
+        | "real" ->
+            let* bits = field_or_missing "bits" "The boundary Real bits are missing." in
+            let* value = real_of_bits bits in
+            Ok (Value.VReal value)
+        | "text" ->
+            let* value = field_or_missing "value" "The boundary Text value is missing." in
+            let* value =
+              match value with
+              | `String text -> validate_boundary_text budget.limits text
+              | _ -> error ~code:"E1601" "A boundary Text value must be one string."
+            in
+            Ok (Value.VText value)
+        | "hash" ->
+            let* value = field_or_missing "value" "The boundary Hash value is missing." in
+            let* value = boundary_hash "boundary Hash value" value in
+            Ok (Value.VHash value)
+        | "tuple" ->
+            let* items = field_or_missing "items" "The boundary tuple items are missing." in
+            let* items =
+              boundary_list ~budget ~context:"tuple value items" ~arguments:false items
+            in
+            let* items = map_result decode items in
+            Ok (Value.VTuple items)
+        | "constructor" ->
+            let* identity =
+              field_or_missing "identity" "The boundary constructor identity is missing."
+            in
+            let* identity = boundary_hash "constructor identity" identity in
+            let* arguments =
+              field_or_missing "arguments" "The boundary constructor arguments are missing."
+            in
+            let* arguments =
+              boundary_list ~budget ~context:"constructor arguments" ~arguments:true arguments
+            in
+            let* arguments = map_result decode arguments in
+            let* name, arity = constructor_info identity in
+            if arity <> List.length arguments then
+              error ~code:"E1604"
+                (Printf.sprintf
+                   "The constructor value has %d argument(s), but the resolved constructor \
+                    requires %d."
+                   (List.length arguments) arity)
+            else Ok (Value.VCon { con = identity; name; args = arguments })
+        | _ ->
+            error ~code:"E1604"
+              (Printf.sprintf "Boundary value kind %S is not supported in jacquard-host-v0." kind))
+    | _ -> error ~code:"E1601" "A boundary value must be one exact JSON object."
+  in
+  let* () = validate_json ~limits:budget.limits json in
+  decode json
+
+let encode_boundary_value ~budget value =
+  let rec encode value =
+    match value with
+    | Value.VInt value ->
+        let* () = consume_boundary_node budget in
+        Ok (`Assoc [ ("kind", `String "int"); ("value", `String (string_of_int value)) ])
+    | Value.VReal value ->
+        let* () = consume_boundary_node budget in
+        let bits = Printf.sprintf "%016Lx" (Int64.bits_of_float value) in
+        Ok (`Assoc [ ("bits", `String bits); ("kind", `String "real") ])
+    | Value.VText value ->
+        let* () = consume_boundary_node budget in
+        let* value = validate_boundary_text budget.limits value in
+        Ok (`Assoc [ ("kind", `String "text"); ("value", `String value) ])
+    | Value.VHash value ->
+        let* () = consume_boundary_node budget in
+        Ok (`Assoc [ ("kind", `String "hash"); ("value", `String (Hash.to_hex value)) ])
+    | Value.VTuple items ->
+        let* () = consume_boundary_node budget in
+        let* () =
+          validate_boundary_count ~budget ~context:"tuple value items" ~arguments:false
+            (List.length items)
+        in
+        let* items = map_result encode items in
+        Ok (`Assoc [ ("items", `List items); ("kind", `String "tuple") ])
+    | Value.VCon { con; args; _ } ->
+        let* () = consume_boundary_node budget in
+        let* () =
+          validate_boundary_count ~budget ~context:"constructor arguments" ~arguments:true
+            (List.length args)
+        in
+        let* arguments = map_result encode args in
+        Ok
+          (`Assoc
+             [
+               ("arguments", `List arguments);
+               ("identity", `String (Hash.to_hex con));
+               ("kind", `String "constructor");
+             ])
+    | Value.VSecret _ | Value.VConstructor _ | Value.VOp _ | Value.VClosure _ | Value.VBuiltin _
+    | Value.VTrustedBuiltin _ | Value.VCode _ | Value.VTask _ | Value.VChannel _ | Value.VResume _
+    | Value.VOnceResume _ ->
+        error ~code:"E1604"
+          "The Core value is opaque, callable, or owned by one evaluator run and cannot cross v0."
+  in
+  let* json = encode value in
+  let* () = validate_json ~limits:budget.limits json in
+  Ok json

--- a/src/host_protocol_v0.mli
+++ b/src/host_protocol_v0.mli
@@ -1,8 +1,9 @@
 (** Strict bounded codecs for the provisional [jacquard-host-v0] process carrier.
 
-    This module implements only transport framing, structural JSON checks, limit negotiation, and
-    the selected shutdown envelope. It does not select a store target, decode Jacquard values,
-    evaluate code, dispatch host operations, or expose a runnable worker. *)
+    This module implements transport framing, structural JSON checks, limit negotiation, the
+    selected shutdown envelope, and the frozen first-order type/value descriptors. It does not
+    select a store target, validate a callable interface, evaluate code, dispatch host operations,
+    or expose a runnable worker. *)
 
 val protocol : string
 (** The one protocol version accepted by this codec. *)
@@ -30,6 +31,42 @@ type limits = {
 
 val hard_limits : limits
 (** The fixed maxima advertised before selection. *)
+
+type boundary_budget
+(** Mutable aggregate node accounting for all boundary types and values in one frame. A caller
+    creates one budget after limit selection, shares it across every descriptor in that frame, and
+    discards it after either success or the first diagnostic. *)
+
+val create_boundary_budget : limits -> boundary_budget
+(** [create_boundary_budget limits] starts a zero-node budget using [limits]. Invalid nonpositive
+    selected ceilings fail as E1602 when a codec first observes them. *)
+
+val decode_boundary_type : budget:boundary_budget -> Yojson.Safe.t -> (Types.ty, Diag.t list) result
+(** [decode_boundary_type ~budget json] accepts exactly the recursive nominal/tuple type subset,
+    canonical HASH_V0 identities, and the selected structural/node/collection ceilings. Malformed
+    shapes return E1601, exceeded limits E1602, and unsupported type variants E1604. *)
+
+val encode_boundary_type : budget:boundary_budget -> Types.ty -> (Yojson.Safe.t, Diag.t list) result
+(** [encode_boundary_type ~budget ty] emits the deterministic descriptor for a normalized
+    boundary-safe Core type. Unresolved variables, arrows, resumptions, variadic arrows, and exact
+    thunks return E1604; malformed internal text or exceeded limits retain E1601/E1602. *)
+
+val decode_boundary_value :
+  budget:boundary_budget ->
+  constructor_info:(Hash.t -> (string * int, Diag.t list) result) ->
+  Yojson.Safe.t ->
+  (Value.t, Diag.t list) result
+(** [decode_boundary_value ~budget ~constructor_info json] accepts exactly the frozen
+    Int/Real/Text/Hash/tuple/saturated-constructor subset. [constructor_info] resolves each exact
+    constructor identity to its store-owned display name and declared arity; its diagnostic is
+    propagated, and an arity mismatch returns E1604. Field-type validation deliberately remains in
+    invoke preflight. Malformed shapes return E1601, exceeded limits E1602, and unsupported value
+    variants E1604. *)
+
+val encode_boundary_value : budget:boundary_budget -> Value.t -> (Yojson.Safe.t, Diag.t list) result
+(** [encode_boundary_value ~budget value] emits the deterministic lossless descriptor for a
+    boundary-safe Core value. Constructor display names never cross the wire. Opaque, callable, or
+    run-owned values return E1604; malformed UTF-8 and exceeded limits retain E1601/E1602. *)
 
 val limits_to_yojson : limits -> Yojson.Safe.t
 (** [limits_to_yojson limits] emits every limit field once in deterministic lexical order. *)

--- a/test/dune
+++ b/test/dune
@@ -122,11 +122,22 @@
  (modules host_protocol_codec_focused)
  (libraries host_protocol_codec_test_support alcotest))
 
+(library
+ (name host_boundary_codec_test_support)
+ (wrapped false)
+ (modules test_host_boundary_codec)
+ (libraries jacquard alcotest fmt qcheck-core qcheck-alcotest yojson))
+
+(executable
+ (name host_boundary_codec_focused)
+ (modules host_boundary_codec_focused)
+ (libraries host_boundary_codec_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused))
- (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)

--- a/test/host_boundary_codec_focused.ml
+++ b/test/host_boundary_codec_focused.ml
@@ -1,0 +1,3 @@
+let () =
+  Alcotest.run "jacquard-host-boundary-codec"
+    [ ("host-boundary-codec", Test_host_boundary_codec.suite) ]

--- a/test/test_host_boundary_codec.ml
+++ b/test/test_host_boundary_codec.ml
@@ -1,0 +1,454 @@
+open Jacquard
+module Host = Host_protocol_v0
+
+let fail_diagnostics diagnostics = String.concat "\n" (List.map Diag.to_string diagnostics)
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error diagnostics -> Alcotest.failf "%s failed:\n%s" label (fail_diagnostics diagnostics)
+
+let expect_code label expected = function
+  | Error (diagnostic :: _) ->
+      Alcotest.(check string) label expected (Diag.code_or_uncoded diagnostic)
+  | Error [] -> Alcotest.failf "%s returned an empty diagnostic list" label
+  | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
+
+let json = Alcotest.testable Yojson.Safe.pretty_print Yojson.Safe.equal
+let hash seed = Hash.of_string seed
+let canonical seed = hash seed |> Hash.to_hex
+let budget ?(limits = Host.hard_limits) () = Host.create_boundary_budget limits
+let constructor_info _ = Ok ("decoded-constructor", 0)
+
+let decode_type ?limits value =
+  expect_ok "decode type" (Host.decode_boundary_type ~budget:(budget ?limits ()) value)
+
+let encode_type ?limits value =
+  expect_ok "encode type" (Host.encode_boundary_type ~budget:(budget ?limits ()) value)
+
+let decode_value ?limits ?(resolve = constructor_info) value =
+  expect_ok "decode value"
+    (Host.decode_boundary_value ~budget:(budget ?limits ()) ~constructor_info:resolve value)
+
+let encode_value ?limits value =
+  expect_ok "encode value" (Host.encode_boundary_value ~budget:(budget ?limits ()) value)
+
+let test_type_variants_are_exact () =
+  let identity = canonical "boundary-nominal" in
+  let descriptor =
+    `Assoc
+      [
+        ("arguments", `List [ `Assoc [ ("items", `List []); ("kind", `String "tuple") ] ]);
+        ("identity", `String identity);
+        ("kind", `String "nominal");
+      ]
+  in
+  let decoded = decode_type descriptor in
+  (match Types.repr decoded with
+  | Types.TCon (actual, [ Types.TTuple [] ]) ->
+      Alcotest.(check string) "nominal identity" identity (Hash.to_hex actual)
+  | _ -> Alcotest.fail "nominal descriptor decoded to the wrong Core type");
+  Alcotest.check json "deterministic type encoding" descriptor (encode_type decoded);
+  let tuple = Types.TTuple [ Types.TCon (hash "left", []); Types.TTuple [] ] in
+  let encoded = encode_type tuple in
+  let reencoded = encoded |> decode_type |> encode_type in
+  Alcotest.check json "nested tuple round-trip" encoded reencoded
+
+let test_type_shape_and_identity_fail_closed () =
+  let identity = canonical "type-shape" in
+  let cases =
+    [
+      ("type is not an object", `List [], "E1601");
+      ("kind is missing", `Assoc [ ("items", `List []) ], "E1601");
+      ("kind is not text", `Assoc [ ("items", `List []); ("kind", `Int 1) ], "E1601");
+      ("unknown type kind", `Assoc [ ("kind", `String "arrow") ], "E1604");
+      ( "missing nominal arguments",
+        `Assoc [ ("identity", `String identity); ("kind", `String "nominal") ],
+        "E1601" );
+      ( "extra tuple field",
+        `Assoc [ ("extra", `Null); ("items", `List []); ("kind", `String "tuple") ],
+        "E1601" );
+      ( "uppercase type identity",
+        `Assoc
+          [
+            ("arguments", `List []);
+            ("identity", `String (String.uppercase_ascii identity));
+            ("kind", `String "nominal");
+          ],
+        "E1601" );
+      ( "type arguments are not an array",
+        `Assoc [ ("arguments", `Null); ("identity", `String identity); ("kind", `String "nominal") ],
+        "E1601" );
+    ]
+  in
+  List.iter
+    (fun (label, descriptor, code) ->
+      expect_code label code (Host.decode_boundary_type ~budget:(budget ()) descriptor))
+    cases
+
+let test_non_boundary_core_types_fail_e1604 () =
+  let unit = Types.TTuple [] in
+  let unsupported =
+    [
+      ("arrow", Types.TArrow ([], Types.empty_row, unit));
+      ("resume", Types.TResume (unit, Types.empty_row, unit));
+      ("variadic arrow", Types.TVariadicArrow (unit, Types.empty_row, unit));
+      ("exact thunk", Types.TExactThunk unit);
+      ("unresolved variable", Types.new_tvar 0);
+      ("skolem", Types.TSkolem (42, "a"));
+    ]
+  in
+  List.iter
+    (fun (label, ty) ->
+      expect_code label "E1604" (Host.encode_boundary_type ~budget:(budget ()) ty))
+    unsupported
+
+let type_json_gen =
+  let open QCheck.Gen in
+  let identity = canonical "property-type" in
+  let rec go depth =
+    let nominal arguments =
+      `Assoc
+        [
+          ("arguments", `List arguments); ("identity", `String identity); ("kind", `String "nominal");
+        ]
+    in
+    let tuple items = `Assoc [ ("items", `List items); ("kind", `String "tuple") ] in
+    if depth = 0 then oneof [ return (nominal []); return (tuple []) ]
+    else
+      oneof_weighted
+        [
+          (2, return (nominal []));
+          (2, return (tuple []));
+          (1, map nominal (list_size (int_bound 3) (go (depth - 1))));
+          (1, map tuple (list_size (int_bound 3) (go (depth - 1))));
+        ]
+  in
+  go 4
+
+let prop_type_codec_round_trip =
+  QCheck.Test.make ~count:300 ~name:"boundary type codec round-trips canonical descriptors"
+    QCheck.(make type_json_gen)
+    (fun descriptor ->
+      match Host.decode_boundary_type ~budget:(budget ()) descriptor with
+      | Error _ -> false
+      | Ok ty -> (
+          match Host.encode_boundary_type ~budget:(budget ()) ty with
+          | Ok encoded -> Yojson.Safe.equal descriptor encoded
+          | Error _ -> false))
+
+let test_scalar_value_variants_are_lossless () =
+  let value_hash = hash "opaque-boundary-hash" in
+  let cases =
+    [
+      (Value.VInt (-12), `Assoc [ ("kind", `String "int"); ("value", `String "-12") ]);
+      ( Value.VReal (Int64.float_of_bits 0x8000_0000_0000_0000L),
+        `Assoc [ ("bits", `String "8000000000000000"); ("kind", `String "real") ] );
+      (Value.VText "hello 😀", `Assoc [ ("kind", `String "text"); ("value", `String "hello 😀") ]);
+      ( Value.VHash value_hash,
+        `Assoc [ ("kind", `String "hash"); ("value", `String (Hash.to_hex value_hash)) ] );
+    ]
+  in
+  List.iter
+    (fun (value, expected) ->
+      let encoded = encode_value value in
+      Alcotest.check json "exact scalar encoding" expected encoded;
+      Alcotest.check json "scalar decode/encode" expected (encoded |> decode_value |> encode_value))
+    cases
+
+let test_int_canonical_range () =
+  let min_text = "-4611686018427387904" and max_text = "4611686018427387903" in
+  List.iter
+    (fun spelling ->
+      let value = `Assoc [ ("kind", `String "int"); ("value", `String spelling) ] in
+      let decoded = decode_value value in
+      Alcotest.check json ("canonical " ^ spelling) value (encode_value decoded))
+    [ min_text; "-1"; "0"; "1"; max_text ];
+  List.iter
+    (fun spelling ->
+      expect_code ("noncanonical " ^ spelling) "E1601"
+        (Host.decode_boundary_value ~budget:(budget ()) ~constructor_info
+           (`Assoc [ ("kind", `String "int"); ("value", `String spelling) ])))
+    [ "+1"; "00"; "01"; "-0"; " 1"; "4611686018427387904"; "-4611686018427387905" ]
+
+let test_real_bits_preserve_special_values () =
+  let bit_patterns =
+    [
+      "0000000000000000";
+      "8000000000000000";
+      "7ff0000000000000";
+      "fff0000000000000";
+      "7ff8000000000042";
+      "ffffffffffffffff";
+    ]
+  in
+  List.iter
+    (fun bits ->
+      let descriptor = `Assoc [ ("bits", `String bits); ("kind", `String "real") ] in
+      Alcotest.check json bits descriptor (descriptor |> decode_value |> encode_value))
+    bit_patterns;
+  List.iter
+    (fun bits ->
+      expect_code ("invalid real bits " ^ bits) "E1601"
+        (Host.decode_boundary_value ~budget:(budget ()) ~constructor_info
+           (`Assoc [ ("bits", `String bits); ("kind", `String "real") ])))
+    [ "0"; "7FF8000000000042"; "gggggggggggggggg"; "00000000000000000" ]
+
+let test_tuple_and_constructor_values_are_exact () =
+  let con = hash "boundary-constructor" in
+  let descriptor =
+    `Assoc
+      [
+        ( "arguments",
+          `List
+            [
+              `Assoc [ ("kind", `String "int"); ("value", `String "7") ];
+              `Assoc [ ("items", `List []); ("kind", `String "tuple") ];
+            ] );
+        ("identity", `String (Hash.to_hex con));
+        ("kind", `String "constructor");
+      ]
+  in
+  let resolved = ref None in
+  let constructor_info identity =
+    resolved := Some identity;
+    Ok ("pair", 2)
+  in
+  let decoded = decode_value ~resolve:constructor_info descriptor in
+  (match decoded with
+  | Value.VCon { con = actual; name; args = [ Value.VInt 7; Value.VTuple [] ] } ->
+      Alcotest.(check bool) "constructor identity" true (Hash.equal con actual);
+      Alcotest.(check string) "resolved display name" "pair" name
+  | _ -> Alcotest.fail "constructor descriptor decoded to the wrong Core value");
+  Alcotest.(check bool)
+    "resolver saw exact identity" true
+    (Option.fold ~none:false ~some:(Hash.equal con) !resolved);
+  Alcotest.check json "display name stays off the wire" descriptor (encode_value decoded);
+  expect_code "constructor must be saturated" "E1604"
+    (Host.decode_boundary_value ~budget:(budget ())
+       ~constructor_info:(fun _ -> Ok ("triple", 3))
+       descriptor);
+  let unresolved =
+    Diag.error ~domain:Process ~code:"E1603" ~summary:"The constructor is unresolved."
+      ~cause:"The exact constructor identity is absent from the selected store."
+      ~next_step:"Install the complete checked store closure." ~contrast:None ()
+  in
+  expect_code "constructor resolver diagnostic is preserved" "E1603"
+    (Host.decode_boundary_value ~budget:(budget ())
+       ~constructor_info:(fun _ -> Error [ unresolved ])
+       descriptor);
+  let tuple = Value.VTuple [ Value.VInt 1; decoded ] in
+  let encoded = encode_value tuple in
+  Alcotest.check json "nested value round-trip" encoded
+    (encoded |> decode_value ~resolve:constructor_info |> encode_value)
+
+let test_value_shape_and_unknown_kinds_fail_closed () =
+  let identity = canonical "value-shape" in
+  let cases =
+    [
+      ("value is not an object", `String "1", "E1601");
+      ("kind is missing", `Assoc [ ("value", `String "1") ], "E1601");
+      ("kind is not text", `Assoc [ ("kind", `Int 1); ("value", `String "1") ], "E1601");
+      ( "unsupported secret kind",
+        `Assoc [ ("kind", `String "secret"); ("value", `String "must-not-cross") ],
+        "E1604" );
+      ( "extra int field",
+        `Assoc [ ("extra", `Null); ("kind", `String "int"); ("value", `String "1") ],
+        "E1601" );
+      ("int scalar is not text", `Assoc [ ("kind", `String "int"); ("value", `Int 1) ], "E1601");
+      ( "uppercase hash value",
+        `Assoc [ ("kind", `String "hash"); ("value", `String (String.uppercase_ascii identity)) ],
+        "E1601" );
+      ( "missing constructor arguments",
+        `Assoc [ ("identity", `String identity); ("kind", `String "constructor") ],
+        "E1601" );
+    ]
+  in
+  List.iter
+    (fun (label, descriptor, code) ->
+      expect_code label code
+        (Host.decode_boundary_value ~budget:(budget ()) ~constructor_info descriptor))
+    cases
+
+let test_non_boundary_runtime_values_fail_e1604 () =
+  let unsupported =
+    [
+      ("secret", Value.VSecret (Secret.of_string "private"));
+      ( "unapplied constructor",
+        Value.VConstructor { con = hash "constructor"; name = "constructor"; arity = 1 } );
+      ("operation", Value.VOp { op = hash "operation"; name = "operation"; effect_ = "effect" });
+      ("untrusted builtin", Value.VBuiltin ("callback", fun _ -> Ok Value.unit_v));
+      ("code", Value.VCode (Form.form "lit" [ Form.Int 1 ]));
+      ("resumption", Value.VResume []);
+    ]
+  in
+  List.iter
+    (fun (label, value) ->
+      expect_code label "E1604" (Host.encode_boundary_value ~budget:(budget ()) value))
+    unsupported
+
+let test_text_utf8_normalization_and_limit () =
+  let composed = "é" and decomposed = "e\204\129" in
+  let composed_json = encode_value (Value.VText composed) in
+  let decomposed_json = encode_value (Value.VText decomposed) in
+  Alcotest.(check bool)
+    "normalization is not performed" false
+    (Yojson.Safe.equal composed_json decomposed_json);
+  Alcotest.(check string)
+    "decomposed bytes survive" decomposed
+    (match decode_value decomposed_json with Value.VText text -> text | _ -> "");
+  let two_bytes = { Host.hard_limits with max_text_bytes = 2 } in
+  ignore
+    (decode_value ~limits:two_bytes (`Assoc [ ("kind", `String "text"); ("value", `String "é") ]));
+  expect_code "text bytes exceed selected limit" "E1602"
+    (Host.decode_boundary_value
+       ~budget:(budget ~limits:{ Host.hard_limits with max_text_bytes = 1 } ())
+       ~constructor_info
+       (`Assoc [ ("kind", `String "text"); ("value", `String "é") ]));
+  expect_code "encoded text bytes exceed selected limit" "E1602"
+    (Host.encode_boundary_value
+       ~budget:(budget ~limits:{ Host.hard_limits with max_text_bytes = 1 } ())
+       (Value.VText "é"));
+  let invalid = String.make 1 (Char.chr 0x80) in
+  expect_code "decoded text is invalid UTF-8" "E1601"
+    (Host.decode_boundary_value ~budget:(budget ()) ~constructor_info
+       (`Assoc [ ("kind", `String "text"); ("value", `String invalid) ]));
+  expect_code "encoded text is invalid UTF-8" "E1601"
+    (Host.encode_boundary_value ~budget:(budget ()) (Value.VText invalid))
+
+let test_shared_node_budget_is_aggregate () =
+  let limits = { Host.hard_limits with max_value_nodes = 2 } in
+  let shared = budget ~limits () in
+  ignore
+    (expect_ok "first shared node"
+       (Host.decode_boundary_type ~budget:shared
+          (`Assoc [ ("items", `List []); ("kind", `String "tuple") ])));
+  ignore
+    (expect_ok "second shared node"
+       (Host.decode_boundary_value ~budget:shared ~constructor_info
+          (`Assoc [ ("kind", `String "int"); ("value", `String "1") ])));
+  expect_code "third shared node" "E1602" (Host.encode_boundary_value ~budget:shared (Value.VInt 2));
+  let shape_first = budget ~limits:{ limits with max_value_nodes = 1 } () in
+  ignore
+    (expect_ok "shape-order first node"
+       (Host.encode_boundary_value ~budget:shape_first (Value.VInt 1)));
+  expect_code "exact shape precedes exhausted node budget" "E1601"
+    (Host.decode_boundary_value ~budget:shape_first ~constructor_info
+       (`Assoc [ ("extra", `Null); ("kind", `String "int"); ("value", `String "2") ]));
+  let nested = budget ~limits () in
+  expect_code "nested value exhausts one frame budget" "E1602"
+    (Host.encode_boundary_value ~budget:nested (Value.VTuple [ Value.VTuple [ Value.VInt 1 ] ]))
+
+let test_collection_argument_and_depth_limits () =
+  let one_collection = { Host.hard_limits with max_collection_items = 1 } in
+  ignore (encode_value ~limits:one_collection (Value.VTuple [ Value.VInt 1 ]));
+  expect_code "tuple collection limit" "E1602"
+    (Host.encode_boundary_value
+       ~budget:(budget ~limits:one_collection ())
+       (Value.VTuple [ Value.VInt 1; Value.VInt 2 ]));
+  expect_code "decoded tuple collection limit" "E1602"
+    (Host.decode_boundary_value
+       ~budget:(budget ~limits:one_collection ())
+       ~constructor_info
+       (`Assoc
+          [
+            ( "items",
+              `List
+                [
+                  `Assoc [ ("kind", `String "int"); ("value", `String "1") ];
+                  `Assoc [ ("kind", `String "int"); ("value", `String "2") ];
+                ] );
+            ("kind", `String "tuple");
+          ]));
+  expect_code "type collection limit" "E1602"
+    (Host.encode_boundary_type
+       ~budget:(budget ~limits:one_collection ())
+       (Types.TTuple [ Types.TTuple []; Types.TTuple [] ]));
+  let one_argument = { Host.hard_limits with max_arguments = 1 } in
+  let constructor =
+    Value.VCon
+      { con = hash "arity-two"; name = "display-only"; args = [ Value.VInt 1; Value.VInt 2 ] }
+  in
+  expect_code "constructor argument limit" "E1602"
+    (Host.encode_boundary_value ~budget:(budget ~limits:one_argument ()) constructor);
+  expect_code "decoded constructor argument limit" "E1602"
+    (Host.decode_boundary_value ~budget:(budget ~limits:one_argument ())
+       ~constructor_info:(fun _ -> Ok ("arity-two", 2))
+       (encode_value constructor));
+  let nested = Value.VTuple [ Value.VTuple [] ] in
+  ignore (encode_value ~limits:{ Host.hard_limits with max_json_depth = 4 } nested);
+  expect_code "boundary JSON depth" "E1602"
+    (Host.encode_boundary_value
+       ~budget:(budget ~limits:{ Host.hard_limits with max_json_depth = 3 } ())
+       nested);
+  expect_code "decoded boundary JSON depth" "E1602"
+    (Host.decode_boundary_value
+       ~budget:(budget ~limits:{ Host.hard_limits with max_json_depth = 3 } ())
+       ~constructor_info (encode_value nested))
+
+let value_json_gen =
+  let open QCheck.Gen in
+  let value_hash = canonical "property-value" in
+  let rec go depth =
+    let leaf =
+      oneof
+        [
+          map
+            (fun value ->
+              `Assoc [ ("kind", `String "int"); ("value", `String (string_of_int value)) ])
+            (int_range (-1_000_000) 1_000_000);
+          map
+            (fun value -> `Assoc [ ("kind", `String "text"); ("value", `String value) ])
+            (string_size ~gen:printable (int_bound 24));
+          return (`Assoc [ ("kind", `String "hash"); ("value", `String value_hash) ]);
+        ]
+    in
+    if depth = 0 then leaf
+    else
+      oneof_weighted
+        [
+          (5, leaf);
+          ( 1,
+            map
+              (fun items -> `Assoc [ ("items", `List items); ("kind", `String "tuple") ])
+              (list_size (int_bound 3) (go (depth - 1))) );
+        ]
+  in
+  go 4
+
+let prop_value_codec_round_trip =
+  QCheck.Test.make ~count:300 ~name:"boundary value codec round-trips canonical descriptors"
+    QCheck.(make value_json_gen)
+    (fun descriptor ->
+      match Host.decode_boundary_value ~budget:(budget ()) ~constructor_info descriptor with
+      | Error _ -> false
+      | Ok value -> (
+          match Host.encode_boundary_value ~budget:(budget ()) value with
+          | Ok encoded -> Yojson.Safe.equal descriptor encoded
+          | Error _ -> false))
+
+let suite =
+  [
+    Alcotest.test_case "nominal and tuple types are exact" `Quick test_type_variants_are_exact;
+    Alcotest.test_case "type shape and identity fail closed" `Quick
+      test_type_shape_and_identity_fail_closed;
+    Alcotest.test_case "non-boundary Core types fail E1604" `Quick
+      test_non_boundary_core_types_fail_e1604;
+    QCheck_alcotest.to_alcotest prop_type_codec_round_trip;
+    Alcotest.test_case "scalar values are lossless" `Quick test_scalar_value_variants_are_lossless;
+    Alcotest.test_case "integer text is canonical and bounded" `Quick test_int_canonical_range;
+    Alcotest.test_case "real bits preserve special values" `Quick
+      test_real_bits_preserve_special_values;
+    Alcotest.test_case "tuple and constructor values are exact" `Quick
+      test_tuple_and_constructor_values_are_exact;
+    Alcotest.test_case "value shapes and unknown kinds fail closed" `Quick
+      test_value_shape_and_unknown_kinds_fail_closed;
+    Alcotest.test_case "opaque and callable values fail E1604" `Quick
+      test_non_boundary_runtime_values_fail_e1604;
+    Alcotest.test_case "Text preserves UTF-8 bytes within limits" `Quick
+      test_text_utf8_normalization_and_limit;
+    Alcotest.test_case "node budget is aggregate across one frame" `Quick
+      test_shared_node_budget_is_aggregate;
+    Alcotest.test_case "collection, argument, and depth limits" `Quick
+      test_collection_argument_and_depth_limits;
+    QCheck_alcotest.to_alcotest prop_value_codec_round_trip;
+  ]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -25,6 +25,7 @@ let () =
       ("effect-taxonomy", Test_effect_taxonomy.suite);
       ("host-protocol-v0", Test_host_protocol_vectors.suite);
       ("host-protocol-codec", Test_host_protocol_codec.suite);
+      ("host-boundary-codec", Test_host_boundary_codec.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Summary

Implement HB.2b1, the bounded first-order type/value codec layer for the
provisional `jacquard-host-v0` boundary.

- add exact nominal/tuple type descriptors;
- add lossless Int/Real/Text/Hash/tuple/saturated-constructor value
  descriptors;
- share selected node/collection/argument/text/depth limits across all
  descriptors in one frame;
- resolve constructor identity and arity without sending display names;
- fail malformed, over-limit, and unsupported data as E1601/E1602/E1604;
- document the actual shipped boundary status without claiming a worker or
  runnable host.

This is deliberately a library-only slice. Invoke/store/interface/type/
capability preflight remains HB.2b2, and evaluation, effect exchange, process
state, cancellation, and the worker CLI remain HB.2c.

## Compatibility

The change is additive to `Host_protocol_v0`. It does not change ordinary
`jacquard run`, HB.2a framing/selection, the evaluator or checker, the
deterministic scheduler, the 27 kernel forms, HASH_V0, canonical
serialization, store identity, or diagnostic-v1.

## Evidence

- [x] focused HB.2b1 codec suite: 14/14, including 600 randomized round trips
- [x] cold `dune build @all @doc`
- [x] cold full `dune runtest`: 914/914 in 593.373s, seed 151481881
- [x] native runtime/memory/leak checks, crams, and 28 doctests
- [x] forced GM12B: exhaustive 50,000-case proof, 0 failures/skips/refusals
- [x] governance viewer: lint, typecheck, 28/28 unit/accessibility tests,
  production build, and 12/12 Chromium/Firefox/WebKit browser tests
- [x] `dune fmt`, meaningful whitespace check, clean tracked diff, and
  version smoke (`0.2.0`)
- [x] independent Claude Code 2.1.236 / Fable 5 / xhigh review: PASS on exact
  head `db6f0e0af5ef4b76c77efee3e445236927bf5b40`

## Review notes

The independent review found no blocker, disputed test, scope leak, evidence
defect, or architecture conflict. Nonblocking follow-ups are confined to test
strength and API sharp edges: byte-golden object field order, broader random
variant generation, harmless defensive missing-field branches, and the
documented requirement that budgets use already-selected hard-capped limits.

Task 205 remains in progress after this PR because HB.2b2 and HB.2c are
separate dependent slices.

