### PR TITLE
HB.2b2: preflight checked v0 invokes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,12 +118,12 @@ When adding valid corpus files, regenerate the golden hashes with
 - Handlers and evaluation: `src/eval.ml`, `test/test_handlers.ml`,
   `test/test_gauntlet_handlers.ml`.
 - Host integration contracts: `docs/host-boundary.md` and
-  `spec/host-protocol-v0.md`; strict framing, selection, and first-order
-  type/value codecs: `src/host_protocol_v0.ml`,
-  `test/test_host_protocol_codec.ml`, `test/test_host_boundary_codec.ml`. No
-  runnable worker ships yet. Existing evaluator capture and host-readiness
-  modules are internal seams, not a public ABI; adapters and application
-  servers belong outside this repository.
+  `spec/host-protocol-v0.md`; strict framing, selection, first-order type/value
+  codecs, and checked invoke preflight: `src/host_protocol_v0.ml`,
+  `test/test_host_protocol_codec.ml`, `test/test_host_boundary_codec.ml`,
+  `test/test_host_invoke_preflight.ml`. No runnable worker ships yet. Existing
+  evaluator capture and host-readiness modules are internal seams, not a public
+  ABI; adapters and application servers belong outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,
   `src/infer_dist.ml`, `test/test_infer.ml`.
 - Warp: `prelude/15-warp.jqd`, `prelude/16-gen.jqd`, `src/warp.ml`,

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 900
+semantic boundary remains historical; the current successor is pinned by 925
 Alcotest/QCheck cases, 59 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
@@ -624,7 +624,10 @@ Deeper design references:
 - `spec/serialization.md`: canonical byte format.
 - `docs/host-boundary.md`: host/Core ownership and trust boundary.
 - `spec/host-protocol-v0.md`: frozen experimental host envelopes, process
-  framing, limits, failures, and conformance-vector contract.
+  framing, limits, failures, and conformance-vector contract. The library now
+  validates one exact checked invocation—including its store closure, pinned
+  interface, typed arguments, grants, and closed once-operation registry—but
+  does not yet run it or expose a process worker.
 - `docs/stdlib.md`: prelude and ringed standard library.
 - `docs/warp-testing.md`: Warp testing model.
 - `docs/errors.md`: diagnostic catalog.
@@ -718,7 +721,8 @@ proofs also do not ship. World grants remain coarse. See
 `docs/release/structured-concurrency/LIMITS.md` for the successor C0-C3 boundary.
 `docs/host-boundary.md` freezes the ownership and trust model, and
 `spec/host-protocol-v0.md` freezes the experimental language-neutral envelopes,
-process framing, limits, and schema/state vectors. No executable host carrier,
+process framing, limits, and schema/state vectors. Core can preflight one exact
+invoke envelope against a prepared checker, but no executable host carrier,
 stable ABI, adapter, or HTTP server ships in this repository today.
 The deterministic Workspace v0 governance boundary is separately advertised
 as an evidence-backed research reference implementation, not as a sandbox or

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,9 @@ project shape from file names alone.
 - `../spec/host-protocol-v0.md`: frozen HB.1 transport-neutral envelopes,
   provisional stdio framing, boundary values, limits, stable failures, and
   positive/hostile vectors. HB.2a implements strict framing/selection and
-  HB.2b1 implements bounded first-order type/value codecs, but no runnable
-  carrier ships yet.
+  HB.2b1 implements bounded first-order type/value codecs. HB.2b2 additionally
+  preflights exact stored targets, interfaces, typed arguments, effect grants,
+  and closed once-operation registries, but no runnable carrier ships yet.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -900,12 +900,14 @@ Do not invent new kernel forms for surface sugar.
   limits, stable failures, and schema/state vectors. `Host_protocol_v0`
   implements the strict framing/selection/shutdown codec for HB.2a and the
   shared-budget first-order type/value codecs for HB.2b1; reuse it instead of
-  recreating framing or value semantics. Store target, interface, capability,
-  and field-type preflight are not implemented yet. No runnable worker, stable
-  foreign-host ABI, adapter, or HTTP server ships yet. Internal
-  evaluator-capture and host-readiness OCaml APIs are not supported embedding
-  contracts; future adapters must consume the versioned protocol and its
-  executable conformance fixtures, not those OCaml seams.
+  recreating framing or value semantics. HB.2b2 also preflights one exact
+  public stored term closure, closed monomorphic interface, typed positional
+  arguments, exact effect grants, and sorted unique public `once` operation
+  registry. This returns a validated invocation but does not evaluate it. No
+  runnable worker, stable foreign-host ABI, adapter, or HTTP server ships yet.
+  Internal evaluator-capture and host-readiness OCaml APIs are not supported
+  embedding contracts; future adapters must consume the versioned protocol and
+  its executable conformance fixtures, not those OCaml seams.
 - The frozen Workspace v0 governed membrane ships as an evidence-backed
   research reference. It is not a general isolation mechanism, production
   authorization system, or operating-system sandbox; trusted host code still

--- a/docs/host-boundary.md
+++ b/docs/host-boundary.md
@@ -244,10 +244,10 @@ matrix.
 ## 9. Repository and product boundary
 
 `jacquard-lang` owns this contract, the HB.1 schema/state vectors, the
-`Host_protocol_v0` strict framing/selection and first-order type/value codecs,
-its later runnable carrier inside Core, executable fixtures, and
-language/runtime evidence. It may contain a tiny fake host used only to prove
-conformance.
+`Host_protocol_v0` strict framing/selection, first-order type/value codecs, and
+checked invoke preflight, its later runnable carrier inside Core, executable
+fixtures, and language/runtime evidence. It may contain a tiny fake host used
+only to prove conformance.
 
 The private `jacquard-host` repository owns real adapters, sockets,
 persistence, the minimal serial HTTP integration, and the requirements report
@@ -270,7 +270,7 @@ headers are not smuggled into HB.0.
 |---|---|---|
 | First-party programs | safety for hostile uploaded Jacquard code | separate-process or equivalent isolation design, hostile resource tests, and reviewed threat model |
 | Trusted adapter and OS | protection from a lying host or broader OS credentials | independently enforced isolation/authentication plus external security review |
-| No runnable carrier yet | interoperability or embedding support | completion of HB.2 descriptor/evaluator/lifecycle slices followed by HB.3 executable cross-language fixtures and evidence |
+| No runnable carrier yet | interoperability or embedding support | completion of the remaining HB.2 evaluator/lifecycle slices followed by HB.3 executable cross-language fixtures and evidence |
 | Experimental process carrier first | permanent ABI stability or low-overhead embedding | two independent adapters and one real integration pass the frozen fixtures before v1 |
 | One serial invocation | concurrent requests, streaming, or throughput | demonstrated need followed by the C4 scheduler contract and resource evidence |
 | No automatic side-effect retry | transparent recovery from ambiguous completion | per-operation idempotency, receipt, and crash/recovery contract |

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `914`
+Test count: `925`
 
 Cram count: `59`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `914`
+- Alcotest/QCheck cases: `925`
 - Cram transcript files: `59`
 - Documentation examples: `28` named examples across `8` documents
 

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `914`
+- Alcotest/QCheck cases: `925`
 - Cram transcript files: `59`
 - Doctest examples: `28` across 8 documents
 
@@ -65,8 +65,9 @@ producing `877 / 59 / 28`. HB.1 adds five host-protocol schema/vector contract
 cases, producing `882 / 59 / 28`. HB.2a adds eighteen bounded framing and
 selection codec cases, producing the then-current `900 / 59 / 28` successor
 inventory. HB.2b1 adds fourteen bounded first-order type/value codec cases,
-producing the current `914 / 59 / 28` successor inventory without changing the
-historical DX.2 publication.
+producing the then-current `914 / 59 / 28` successor inventory. HB.2b2 adds
+eleven checked invoke-preflight cases, producing the current `925 / 59 / 28`
+successor inventory without changing the historical DX.2 publication.
 
 ## Proved behavior
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 914 compiled Alcotest/QCheck cases, 59 recursive
+The current successor inventory is exactly 925 compiled Alcotest/QCheck cases, 59 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `914`
+- Alcotest/QCheck cases: `925`
 - Cram transcript files: `59`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -819,7 +819,8 @@ two D76 decision-mutation cases, and one transcript, producing
 producing `882 / 59 / 28`. HB.2a adds eighteen bounded framing and selection
 codec cases, producing the then-current `900 / 59 / 28` inventory.
 HB.2b1 adds fourteen bounded first-order type/value codec cases, producing the
-current `914 / 59 / 28` inventory.
+then-current `914 / 59 / 28` inventory. HB.2b2 adds eleven checked
+invoke-preflight cases, producing the current `925 / 59 / 28` inventory.
 
 Native scheduling remains outside the current backend. Differential coverage is
 therefore limited to the supported case: an Async operation discharged by an

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -596,8 +596,11 @@ scalar UTF-8, recursive duplicate-key checks, exact hard/selected limits, and
 the shutdown envelope. HB.2b1 adds exact nominal/tuple and lossless
 Int/Real/Text/Hash/tuple/saturated-constructor codecs, shared per-frame node
 accounting, selected descriptor limits, and constructor identity/arity
-resolution. It does not expose a runnable worker; target/interface/capability
-preflight, evaluation, and effect exchange remain later HB.2 slices.
+resolution. HB.2b2 adds exact invoke-envelope and fixed-ID checks, complete
+stored-target closure validation, structural checked-interface equality, typed
+arguments including constructor fields, exact grants, and the sorted unique
+public `once` operation registry. It does not expose a runnable worker;
+evaluation and effect exchange remain later HB.2 slices.
 
 A conforming implementation must:
 

--- a/src/check.ml
+++ b/src/check.ml
@@ -74,6 +74,17 @@ and match_site = { scrutinee_ty : Types.ty; arms : Kernel.clause list; site_meta
 (** [store ctx] returns the declaration store used by the checker. *)
 let store ctx = ctx.store
 
+type primitive_types = {
+  int_type : Hash.t;
+  real_type : Hash.t;
+  text_type : Hash.t;
+  hash_type : Hash.t;
+}
+
+(** [primitive_types ctx] returns immutable identities rather than repeating mutable name lookup. *)
+let primitive_types ctx =
+  { int_type = ctx.p_int; real_type = ctx.p_real; text_type = ctx.p_text; hash_type = ctx.p_hash }
+
 (** [register_builtin_signatures ctx signatures] installs trusted native-term schemes. Existing
     entries at the same hashes are replaced. *)
 let register_builtin_signatures ctx signatures =
@@ -2107,6 +2118,38 @@ let check_recovery_top ~identity (Recovery_session ctx) top = Recovery.check_top
     sweep the tier statistics need (PF.2 phase 1). *)
 let force_term ctx (h : Hash.t) : (scheme, Diag.t list) result =
   match term_scheme ctx h with s -> Ok s | exception Err d -> Error [ d ]
+
+(** [force_constructor ctx h] is the result-returning public form of {!con_scheme}. *)
+let force_constructor ctx (h : Hash.t) : (scheme, Diag.t list) result =
+  match con_scheme ctx h with s -> Ok s | exception Err d -> Error [ d ]
+
+type operation_contract = { effect_identity : Hash.t; mode : Kernel.op_mode; scheme : scheme }
+
+(** [force_operation ctx h] keeps operation identity, owner, mode, and scheme in one checked lookup
+    so host adapters cannot reconstruct part of the contract from display names. *)
+let force_operation ctx (h : Hash.t) : (operation_contract, Diag.t list) result =
+  let checked thunk =
+    match thunk () with value -> Ok value | exception Err diagnostic -> Error [ diagnostic ]
+  in
+  match Store.locate ctx.store h with
+  | Ok
+      {
+        Store.decl = { Kernel.it = Kernel.DefEffect { ops; _ }; _ };
+        decl_hash;
+        role = Store.Operation index;
+      } -> (
+      match List.nth_opt ops index with
+      | Some operation ->
+          checked (fun () ->
+              let scheme = op_scheme ctx h in
+              { effect_identity = decl_hash; mode = operation.Kernel.op_mode; scheme })
+      | None ->
+          checked (fun () ->
+              err ~code:"E0805" "operation hash %s has invalid store metadata" (Hash.to_hex h)))
+  | Ok _ -> checked (fun () -> err ~code:"E0805" "hash %s is not an operation" (Hash.to_hex h))
+  | Error diagnostics ->
+      checked (fun () ->
+          err ~code:"E0805" "%s" (String.concat "; " (List.map Diag.to_cause_string diagnostics)))
 
 (** Render an effect row for manifests and signatures. *)
 let show_row ctx (r : row) : string =

--- a/src/check.mli
+++ b/src/check.mli
@@ -14,6 +14,18 @@ val make_ctx : Store.t -> (ctx, Diag.t list) result
 val store : ctx -> Store.t
 (** [store ctx] returns the backing declaration store. *)
 
+type primitive_types = {
+  int_type : Hash.t;
+  real_type : Hash.t;
+  text_type : Hash.t;
+  hash_type : Hash.t;
+}
+(** Exact store identities for the scalar values that can cross a first-order host boundary. *)
+
+val primitive_types : ctx -> primitive_types
+(** [primitive_types ctx] returns the primitive identities captured when [ctx] was created. The
+    result is immutable and does not consult the mutable store name index. *)
+
 val register_builtin_signatures : ctx -> (Hash.t * Types.scheme) list -> unit
 (** [register_builtin_signatures ctx signatures] installs trusted native-term schemes, replacing
     entries at duplicate hashes. *)
@@ -73,6 +85,18 @@ val check_recovery_top :
 val force_term : ctx -> Hash.t -> (Types.scheme, Diag.t list) result
 (** [force_term ctx hash] computes a cached term scheme on demand, returning lookup/type failures.
 *)
+
+val force_constructor : ctx -> Hash.t -> (Types.scheme, Diag.t list) result
+(** [force_constructor ctx hash] returns the constructor scheme or a checker diagnostic when the
+    public hash is absent, has another role, or its declaration is malformed. *)
+
+type operation_contract = { effect_identity : Hash.t; mode : Kernel.op_mode; scheme : Types.scheme }
+(** Checked store metadata for one exact public operation identity. *)
+
+val force_operation : ctx -> Hash.t -> (operation_contract, Diag.t list) result
+(** [force_operation ctx hash] resolves the operation's owning effect, declared continuation mode,
+    and checked callable scheme. Missing, hidden, wrong-role, or malformed declarations return
+    checker diagnostics. *)
 
 val show_row : ctx -> Types.row -> string
 (** [show_row ctx row] renders every resolved identity in deterministic name/hash order. Distinct

--- a/src/host_protocol_v0.ml
+++ b/src/host_protocol_v0.ml
@@ -48,9 +48,16 @@ let diagnostic_spec = function
   | "E1602" ->
       ( "The host protocol limit was exceeded or cannot represent a mandatory result.",
         "Choose positive advertised limits and keep the frame within the selected ceilings." )
+  | "E1603" ->
+      ( "The selected Jacquard target or pinned interface is invalid.",
+        "Select one complete checked store-term closure and use its exact first-order interface." )
   | "E1604" ->
       ( "A Jacquard type or value is unsupported at the v0 host boundary.",
         "Use only the frozen closed first-order type and lossless value descriptor subset." )
+  | "E1605" ->
+      ( "The selected host capability or operation registry is invalid.",
+        "Use the exact checked effect set and a sorted unique registry of its public once \
+         operations." )
   | "E1608" ->
       ( "The host protocol message is invalid in the current state.",
         "Send only the next message permitted by the serial jacquard-host-v0 state machine." )
@@ -705,3 +712,391 @@ let encode_boundary_value ~budget value =
   let* json = encode value in
   let* () = validate_json ~limits:budget.limits json in
   Ok json
+
+type operation_binding = {
+  effect_identity : Hash.t;
+  operation : Hash.t;
+  parameters : Types.ty list;
+  result : Types.ty;
+}
+
+type invocation = {
+  invocation_id : string;
+  callable : Hash.t;
+  parameters : Types.ty list;
+  effects : Hash.t list;
+  result : Types.ty;
+  arguments : Value.t list;
+  operations : operation_binding list;
+}
+
+let equal_hashes left right =
+  List.length left = List.length right && List.for_all2 Hash.equal left right
+
+let rec equal_boundary_types left right =
+  match (Types.repr left, Types.repr right) with
+  | Types.TCon (left_identity, left_arguments), Types.TCon (right_identity, right_arguments) ->
+      Hash.equal left_identity right_identity
+      && List.length left_arguments = List.length right_arguments
+      && List.for_all2 equal_boundary_types left_arguments right_arguments
+  | Types.TTuple left_items, Types.TTuple right_items ->
+      List.length left_items = List.length right_items
+      && List.for_all2 equal_boundary_types left_items right_items
+  | _ -> false
+
+let boundary_type_supported ty =
+  let rec check = function
+    | Types.TCon (_, arguments) -> check_all arguments
+    | Types.TTuple items -> check_all items
+    | Types.TArrow _ | Types.TResume _ | Types.TVariadicArrow _ | Types.TExactThunk _ | Types.TVar _
+    | Types.TSkolem _ ->
+        error ~code:"E1604"
+          "A checked boundary contract contains a nested callable or unresolved type."
+  and check_all = function
+    | [] -> Ok ()
+    | ty :: rest ->
+        let* () = check (Types.repr ty) in
+        check_all rest
+  in
+  check (Types.repr ty)
+
+let map_error ~code cause = function Ok value -> Ok value | Error _ -> error ~code cause
+
+let validate_complete_closure store root =
+  let rec visit seen = function
+    | [] -> Ok ()
+    | hash :: rest when List.exists (Hash.equal hash) seen -> visit seen rest
+    | hash :: rest -> (
+        match Store.locate_internal store hash with
+        | Error _ ->
+            error ~code:"E1603"
+              "The selected target's reachable immutable store closure is incomplete or corrupt."
+        | Ok { Store.decl; _ } -> visit (hash :: seen) (Store.decl_refs decl @ rest))
+  in
+  visit [] [ root ]
+
+let validate_target checker callable =
+  let store = Check.store checker in
+  let* () =
+    match Store.locate store callable with
+    | Ok { Store.decl = { Kernel.it = Kernel.DefTerm _; _ }; role = Store.Member _; _ } -> Ok ()
+    | Ok _ | Error _ ->
+        error ~code:"E1603" "The invoke target is not one exact public stored term-member identity."
+  in
+  let* () = validate_complete_closure store callable in
+  let* scheme =
+    map_error ~code:"E1603" "The selected target closure does not pass strict checking."
+      (Check.force_term checker callable)
+  in
+  let quantified_types, quantified_rows = Types.quantified scheme in
+  if quantified_types <> [] || quantified_rows <> [] then
+    error ~code:"E1603" "The selected target is polymorphic rather than one closed invocation."
+  else
+    match Types.repr scheme.Types.ty with
+    | Types.TArrow (parameters, row, result) ->
+        let row = Types.repr_row row in
+        let* () =
+          match row.Types.tail with
+          | Types.RClosed -> Ok ()
+          | Types.RVar _ | Types.RSkolem _ ->
+              error ~code:"E1603" "The selected target has an open effect row."
+        in
+        let* () = map_result boundary_type_supported parameters |> Result.map (fun _ -> ()) in
+        let* () = boundary_type_supported result in
+        Ok (parameters, row.Types.effects, result)
+    | Types.TCon _ | Types.TTuple _ | Types.TResume _ | Types.TVariadicArrow _ | Types.TExactThunk _
+    | Types.TVar _ | Types.TSkolem _ ->
+        error ~code:"E1603" "The selected stored term is not one callable arrow."
+
+let parse_hash_list ~budget ~context ~maximum json =
+  let* items = boundary_list ~budget ~context ~arguments:false json in
+  if maximum <= 0 || List.length items > maximum then
+    error ~code:"E1602" (Printf.sprintf "The %s exceeds its selected protocol limit." context)
+  else map_result (boundary_hash context) items
+
+let parse_interface ~budget = function
+  | `Assoc fields ->
+      let* () = exact_fields [ "effects"; "parameters"; "result" ] fields in
+      let* parameters_json =
+        match field "parameters" fields with
+        | Some value -> boundary_list ~budget ~context:"interface parameters" ~arguments:true value
+        | None -> error ~code:"E1601" "The interface parameters are missing."
+      in
+      let* parameters = map_result (decode_boundary_type ~budget) parameters_json in
+      let* effects =
+        match field "effects" fields with
+        | Some value ->
+            parse_hash_list ~budget ~context:"interface effects" ~maximum:budget.limits.max_effects
+              value
+        | None -> error ~code:"E1601" "The interface effects are missing."
+      in
+      let* result =
+        match field "result" fields with
+        | Some value -> decode_boundary_type ~budget value
+        | None -> error ~code:"E1601" "The interface result is missing."
+      in
+      Ok (parameters, effects, result)
+  | _ -> error ~code:"E1601" "The interface must be one exact JSON object."
+
+let constructor_info checker identity =
+  let store = Check.store checker in
+  match Store.locate store identity with
+  | Ok
+      {
+        Store.decl = { Kernel.it = Kernel.DefType { cons; _ }; _ };
+        role = Store.Constructor index;
+        _;
+      } -> (
+      match List.nth_opt cons index with
+      | None -> error ~code:"E1603" "The constructor identity has invalid store metadata."
+      | Some constructor ->
+          let* _ =
+            map_error ~code:"E1603" "The constructor declaration does not pass strict checking."
+              (Check.force_constructor checker identity)
+          in
+          Ok (constructor.Kernel.con_name, List.length constructor.Kernel.fields))
+  | Ok _ | Error _ ->
+      error ~code:"E1603" "A boundary value names an absent or non-constructor store identity."
+
+let validate_argument_value checker ~expected value =
+  let primitives = Check.primitive_types checker in
+  let mismatch cause = error ~code:"E1603" cause in
+  let scalar identity expected cause =
+    if equal_boundary_types (Types.TCon (identity, [])) expected then Ok () else mismatch cause
+  in
+  let rec validate expected = function
+    | Value.VInt _ ->
+        scalar primitives.Check.int_type expected "An Int argument disagrees with its parameter."
+    | Value.VReal _ ->
+        scalar primitives.Check.real_type expected "A Real argument disagrees with its parameter."
+    | Value.VText _ ->
+        scalar primitives.Check.text_type expected "A Text argument disagrees with its parameter."
+    | Value.VHash _ ->
+        scalar primitives.Check.hash_type expected "A Hash argument disagrees with its parameter."
+    | Value.VTuple items -> (
+        match Types.repr expected with
+        | Types.TTuple item_types when List.length items = List.length item_types ->
+            validate_all item_types items
+        | Types.TTuple _ -> mismatch "A tuple argument has the wrong number of items."
+        | _ -> mismatch "A tuple argument disagrees with its parameter type.")
+    | Value.VCon { con; args; _ } ->
+        let* scheme =
+          map_error ~code:"E1603" "A constructor argument cannot be checked in this store."
+            (Check.force_constructor checker con)
+        in
+        let constructor_type = Types.instantiate ~level:0 scheme in
+        let fields, result =
+          match Types.repr constructor_type with
+          | Types.TArrow (fields, row, result)
+            when (Types.repr_row row).Types.effects = []
+                 && match (Types.repr_row row).Types.tail with Types.RClosed -> true | _ -> false ->
+              (fields, result)
+          | ty -> ([], ty)
+        in
+        if List.length fields <> List.length args then
+          error ~code:"E1604" "A constructor value is not saturated at the boundary."
+        else
+          let* () =
+            match Types.unify result expected with
+            | () -> Ok ()
+            | exception Types.Unify_error _ ->
+                mismatch "A constructor argument disagrees with its nominal parameter type."
+          in
+          let* () = map_result boundary_type_supported fields |> Result.map (fun _ -> ()) in
+          validate_all fields args
+    | Value.VSecret _ | Value.VConstructor _ | Value.VOp _ | Value.VClosure _ | Value.VBuiltin _
+    | Value.VTrustedBuiltin _ | Value.VCode _ | Value.VTask _ | Value.VChannel _ | Value.VResume _
+    | Value.VOnceResume _ ->
+        error ~code:"E1604" "A run-owned or callable value cannot be an invoke argument."
+  and validate_all expected values =
+    match (expected, values) with
+    | [], [] -> Ok ()
+    | expected :: expected_rest, value :: value_rest ->
+        let* () = validate expected value in
+        validate_all expected_rest value_rest
+    | _ -> mismatch "An aggregate argument has the wrong number of fields."
+  in
+  validate expected value
+
+type parsed_operation = { claimed_effect : Hash.t; claimed_operation : Hash.t }
+
+let parse_operation_entry = function
+  | `Assoc fields ->
+      let* () = exact_fields [ "effect"; "mode"; "operation" ] fields in
+      let* claimed_effect =
+        match field "effect" fields with
+        | Some value -> boundary_hash "operation registry effect" value
+        | None -> error ~code:"E1601" "The operation registry effect is missing."
+      in
+      let* claimed_operation =
+        match field "operation" fields with
+        | Some value -> boundary_hash "operation registry identity" value
+        | None -> error ~code:"E1601" "The operation registry identity is missing."
+      in
+      let* () =
+        match field "mode" fields with
+        | Some (`String "once") -> Ok ()
+        | Some (`String _) -> error ~code:"E1605" "A registry entry does not select mode once."
+        | Some _ | None -> error ~code:"E1601" "The operation registry mode must be one string."
+      in
+      Ok { claimed_effect; claimed_operation }
+  | _ -> error ~code:"E1601" "Each operation registry entry must be one exact JSON object."
+
+let operation_compare left right =
+  match Hash.compare left.claimed_effect right.claimed_effect with
+  | 0 -> Hash.compare left.claimed_operation right.claimed_operation
+  | order -> order
+
+let strictly_sorted ~compare ~code cause items =
+  let rec check = function
+    | left :: (right :: _ as rest) ->
+        if compare left right < 0 then check rest else error ~code cause
+    | [ _ ] | [] -> Ok ()
+  in
+  check items
+
+let validate_operation checker ~effects entry =
+  if not (List.exists (Hash.equal entry.claimed_effect) effects) then
+    error ~code:"E1605" "An operation registry entry introduces an ungranted effect."
+  else
+    let* contract =
+      map_error ~code:"E1605" "An operation registry identity is absent or is not an operation."
+        (Check.force_operation checker entry.claimed_operation)
+    in
+    if not (Hash.equal entry.claimed_effect contract.Check.effect_identity) then
+      error ~code:"E1605" "An operation registry entry names the wrong owning effect."
+    else if contract.Check.mode <> Kernel.Once then
+      error ~code:"E1605" "An operation registry entry names a non-once operation."
+    else
+      let quantified_types, quantified_rows = Types.quantified contract.Check.scheme in
+      if quantified_types <> [] || quantified_rows <> [] then
+        error ~code:"E1604" "A configured operation has a polymorphic boundary signature."
+      else
+        match Types.repr contract.Check.scheme.Types.ty with
+        | Types.TArrow (parameters, _, result) ->
+            let* () = map_result boundary_type_supported parameters |> Result.map (fun _ -> ()) in
+            let* () = boundary_type_supported result in
+            Ok
+              {
+                effect_identity = contract.Check.effect_identity;
+                operation = entry.claimed_operation;
+                parameters;
+                result;
+              }
+        | Types.TCon _ | Types.TTuple _ | Types.TResume _ | Types.TVariadicArrow _
+        | Types.TExactThunk _ | Types.TVar _ | Types.TSkolem _ ->
+            error ~code:"E1604" "A configured operation does not have one first-order arrow."
+
+let parse_capabilities ~budget checker ~interface_effects = function
+  | `Assoc fields ->
+      let* () = exact_fields [ "effects"; "operations" ] fields in
+      let* effects =
+        match field "effects" fields with
+        | Some value ->
+            parse_hash_list ~budget ~context:"capability effects" ~maximum:budget.limits.max_effects
+              value
+        | None -> error ~code:"E1601" "The capability effects are missing."
+      in
+      let* () =
+        strictly_sorted ~compare:Hash.compare ~code:"E1605"
+          "Capability effects must be strictly sorted and unique." effects
+      in
+      if not (equal_hashes effects interface_effects) then
+        error ~code:"E1605" "Capability effects do not exactly equal the pinned interface row."
+      else
+        let* operation_json =
+          match field "operations" fields with
+          | Some value ->
+              boundary_list ~budget ~context:"capability operations" ~arguments:false value
+          | None -> error ~code:"E1601" "The capability operations are missing."
+        in
+        if
+          budget.limits.max_operations <= 0
+          || List.length operation_json > budget.limits.max_operations
+        then error ~code:"E1602" "The operation registry exceeds max_operations."
+        else
+          let* parsed = map_result parse_operation_entry operation_json in
+          let* () =
+            strictly_sorted ~compare:operation_compare ~code:"E1605"
+              "Operation registry entries must be strictly sorted and unique." parsed
+          in
+          map_result (validate_operation checker ~effects) parsed
+  | _ -> error ~code:"E1601" "The capabilities field must be one exact JSON object."
+
+let parse_invoke ~limits ~checker json =
+  let* () = validate_json ~limits json in
+  match json with
+  | `Assoc fields ->
+      let* () =
+        exact_fields
+          [
+            "arguments"; "capabilities"; "interface"; "invocation_id"; "kind"; "protocol"; "target";
+          ]
+          fields
+      in
+      let* () = parse_protocol fields in
+      let* () = parse_kind "invoke" fields in
+      let* invocation_id =
+        match field "invocation_id" fields with
+        | Some (`String "0000000000000000") -> Ok "0000000000000000"
+        | Some (`String _) -> error ~code:"E1608" "The invoke ID is not the fixed v0 invocation ID."
+        | Some _ | None -> error ~code:"E1601" "The invocation ID must be one string."
+      in
+      let* callable =
+        match field "target" fields with
+        | Some (`Assoc target_fields) -> (
+            let* () = exact_fields [ "callable"; "kind" ] target_fields in
+            let* () =
+              match field "kind" target_fields with
+              | Some (`String "store-term-v0") -> Ok ()
+              | Some (`String _) -> error ~code:"E1603" "The target is not a store-term-v0 target."
+              | Some _ | None -> error ~code:"E1601" "The target kind must be one string."
+            in
+            match field "callable" target_fields with
+            | Some value -> boundary_hash "target callable identity" value
+            | None -> error ~code:"E1601" "The target callable identity is missing.")
+        | Some _ | None -> error ~code:"E1601" "The target must be one exact JSON object."
+      in
+      let* parameters, effects, result = validate_target checker callable in
+      let budget = create_boundary_budget limits in
+      let* interface_parameters, interface_effects, interface_result =
+        match field "interface" fields with
+        | Some value -> parse_interface ~budget value
+        | None -> error ~code:"E1601" "The interface is missing."
+      in
+      if
+        List.length parameters <> List.length interface_parameters
+        || (not (List.for_all2 equal_boundary_types parameters interface_parameters))
+        || (not (equal_hashes effects interface_effects))
+        || not (equal_boundary_types result interface_result)
+      then error ~code:"E1603" "The pinned interface disagrees with the checked target arrow."
+      else
+        let* argument_json =
+          match field "arguments" fields with
+          | Some value -> boundary_list ~budget ~context:"invoke arguments" ~arguments:true value
+          | None -> error ~code:"E1601" "The invoke arguments are missing."
+        in
+        if List.length argument_json <> List.length parameters then
+          error ~code:"E1603" "The invoke argument count disagrees with the checked target arrow."
+        else
+          let* arguments =
+            map_result
+              (decode_boundary_value ~budget ~constructor_info:(constructor_info checker))
+              argument_json
+          in
+          let rec validate_arguments expected values =
+            match (expected, values) with
+            | [], [] -> Ok ()
+            | expected :: expected_rest, value :: value_rest ->
+                let* () = validate_argument_value checker ~expected value in
+                validate_arguments expected_rest value_rest
+            | _ -> error ~code:"E1603" "The invoke argument count changed during preflight."
+          in
+          let* () = validate_arguments parameters arguments in
+          let* operations =
+            match field "capabilities" fields with
+            | Some value -> parse_capabilities ~budget checker ~interface_effects value
+            | None -> error ~code:"E1601" "The capabilities field is missing."
+          in
+          Ok { invocation_id; callable; parameters; effects; result; arguments; operations }
+  | _ -> error ~code:"E1601" "The invoke message must be one JSON object."

--- a/src/host_protocol_v0.mli
+++ b/src/host_protocol_v0.mli
@@ -1,9 +1,9 @@
 (** Strict bounded codecs for the provisional [jacquard-host-v0] process carrier.
 
     This module implements transport framing, structural JSON checks, limit negotiation, the
-    selected shutdown envelope, and the frozen first-order type/value descriptors. It does not
-    select a store target, validate a callable interface, evaluate code, dispatch host operations,
-    or expose a runnable worker. *)
+    selected shutdown envelope, the frozen first-order type/value descriptors, and preflight for one
+    exact checked invocation. It does not evaluate code, dispatch host operations, or expose a
+    runnable worker. *)
 
 val protocol : string
 (** The one protocol version accepted by this codec. *)
@@ -67,6 +67,35 @@ val encode_boundary_value : budget:boundary_budget -> Value.t -> (Yojson.Safe.t,
 (** [encode_boundary_value ~budget value] emits the deterministic lossless descriptor for a
     boundary-safe Core value. Constructor display names never cross the wire. Opaque, callable, or
     run-owned values return E1604; malformed UTF-8 and exceeded limits retain E1601/E1602. *)
+
+type operation_binding = {
+  effect_identity : Hash.t;
+  operation : Hash.t;
+  parameters : Types.ty list;
+  result : Types.ty;
+}
+(** One exact, checked, once-mode operation admitted by an invocation's closed host registry. *)
+
+type invocation = {
+  invocation_id : string;
+  callable : Hash.t;
+  parameters : Types.ty list;
+  effects : Hash.t list;
+  result : Types.ty;
+  arguments : Value.t list;
+  operations : operation_binding list;
+}
+(** Immutable preflight output for the later serial worker. Types, effects, values, and operation
+    contracts come from the checked store rather than mutable display names. *)
+
+val parse_invoke :
+  limits:limits -> checker:Check.ctx -> Yojson.Safe.t -> (invocation, Diag.t list) result
+(** [parse_invoke ~limits ~checker json] validates the exact v0 invoke envelope, fixed invocation
+    ID, public stored term target and complete reachable closure, closed monomorphic first-order
+    arrow, structurally identical interface, typed positional values, exact effect grants, and
+    sorted unique once-operation registry. It returns E1600-E1605 according to the frozen fail-fast
+    order and never evaluates the target or calls an adapter. A registry may be partial or empty;
+    reaching an omitted operation is a later worker concern. *)
 
 val limits_to_yojson : limits -> Yojson.Safe.t
 (** [limits_to_yojson limits] emits every limit field once in deterministic lexical order. *)

--- a/src/host_protocol_v0.mli
+++ b/src/host_protocol_v0.mli
@@ -93,9 +93,9 @@ val parse_invoke :
 (** [parse_invoke ~limits ~checker json] validates the exact v0 invoke envelope, fixed invocation
     ID, public stored term target and complete reachable closure, closed monomorphic first-order
     arrow, structurally identical interface, typed positional values, exact effect grants, and
-    sorted unique once-operation registry. It returns E1600-E1605 according to the frozen fail-fast
-    order and never evaluates the target or calls an adapter. A registry may be partial or empty;
-    reaching an omitted operation is a later worker concern. *)
+    sorted unique once-operation registry. It returns E1600-E1605 or E1608 according to the frozen
+    fail-fast order and never evaluates the target or calls an adapter. A registry may be partial or
+    empty; reaching an omitted operation is a later worker concern. *)
 
 val limits_to_yojson : limits -> Yojson.Safe.t
 (** [limits_to_yojson limits] emits every limit field once in deterministic lexical order. *)

--- a/test/dune
+++ b/test/dune
@@ -133,11 +133,22 @@
  (modules host_boundary_codec_focused)
  (libraries host_boundary_codec_test_support alcotest))
 
+(library
+ (name host_invoke_preflight_test_support)
+ (wrapped false)
+ (modules test_host_invoke_preflight)
+ (libraries jacquard alcotest unix yojson))
+
+(executable
+ (name host_invoke_preflight_focused)
+ (modules host_invoke_preflight_focused)
+ (libraries host_invoke_preflight_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused))
- (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)

--- a/test/host_invoke_preflight_focused.ml
+++ b/test/host_invoke_preflight_focused.ml
@@ -1,0 +1,3 @@
+let () =
+  Alcotest.run "jacquard-host-invoke-preflight"
+    [ ("host-invoke-preflight", Test_host_invoke_preflight.suite) ]

--- a/test/test_host_invoke_preflight.ml
+++ b/test/test_host_invoke_preflight.ml
@@ -323,6 +323,26 @@ let missing_closure_case () =
   Sys.remove (Store.object_path store dependency.Canon.decl_hash);
   (checker, named "boundary.dependent" target, required_hash store "text" Resolve.KType)
 
+let hidden_closure_case () =
+  let store = expect_ok "open hidden-closure store" (Store.open_store (fresh_dir "hidden")) in
+  seed_primitives store;
+  let dependency =
+    put_src store
+      "(defterm ((binding boundary.hidden-dependency ((tarrow () (row) (tref text))) (lam () (lit \
+       \"dependency\")))))"
+  in
+  let target =
+    put_src store
+      "(defterm ((binding boundary.hidden-dependent ((tarrow () (row) (tref text))) (lam () (app \
+       (var boundary.hidden-dependency))))))"
+  in
+  Store.hide_derived store (named "boundary.hidden-dependency" dependency);
+  let checker = expect_ok "create hidden-closure checker" (Check.make_ctx store) in
+  ( store,
+    checker,
+    named "boundary.hidden-dependent" target,
+    required_hash store "text" Resolve.KType )
+
 let test_complete_reachable_store_closure_is_required () =
   let checker, target, text = missing_closure_case () in
   let json =
@@ -330,6 +350,17 @@ let test_complete_reachable_store_closure_is_required () =
       ~operations:[]
   in
   expect_code "missing reachable object" "E1603"
+    (Host.parse_invoke ~limits:Host.hard_limits ~checker json);
+  let store, checker, target, text = hidden_closure_case () in
+  let json =
+    invoke_json ~target ~parameters:[] ~effects:[] ~result:(nominal text []) ~arguments:[]
+      ~operations:[]
+  in
+  ignore
+    (expect_ok "hidden resolved dependency remains reachable"
+       (Host.parse_invoke ~limits:Host.hard_limits ~checker json));
+  Store.hide_derived store target;
+  expect_code "hidden root is not public" "E1603"
     (Host.parse_invoke ~limits:Host.hard_limits ~checker json)
 
 let test_interface_and_argument_count_must_equal_checked_arrow () =
@@ -418,8 +449,8 @@ let test_selected_argument_effect_operation_and_node_limits_are_aggregate () =
        ~limits:{ Host.hard_limits with max_operations = 1 }
        fixture
        (effectful_invoke ~operations:[ entry; entry ] fixture));
-  expect_code "shared type/value node budget" "E1602"
-    (parse ~limits:{ Host.hard_limits with max_value_nodes = 4 } fixture (pure_invoke fixture))
+  expect_code "type/value node budget is shared across interface and arguments" "E1602"
+    (parse ~limits:{ Host.hard_limits with max_value_nodes = 8 } fixture (pure_invoke fixture))
 
 let test_capabilities_and_registry_are_exact_closed_and_once () =
   let fixture = Lazy.force fixture in

--- a/test/test_host_invoke_preflight.ml
+++ b/test/test_host_invoke_preflight.ml
@@ -1,0 +1,558 @@
+open Jacquard
+module Host = Host_protocol_v0
+
+let fail_diagnostics diagnostics = String.concat "\n" (List.map Diag.to_string diagnostics)
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error diagnostics -> Alcotest.failf "%s failed:\n%s" label (fail_diagnostics diagnostics)
+
+let expect_code label expected = function
+  | Error (diagnostic :: _) ->
+      Alcotest.(check string) label expected (Diag.code_or_uncoded diagnostic)
+  | Error [] -> Alcotest.failf "%s returned an empty diagnostic list" label
+  | Ok _ -> Alcotest.failf "%s unexpectedly succeeded" label
+
+let fresh_dir =
+  let serial = ref 0 in
+  fun label ->
+    incr serial;
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "jacquard-host-preflight-%s-%d-%d" label (Unix.getpid ()) !serial)
+
+let put_src store source =
+  let form =
+    expect_ok "parse fixture declaration" (Reader.parse_one ~file:"host-preflight.jqd" source)
+  in
+  let declaration = expect_ok "validate fixture declaration" (Kernel.decl_of_form form) in
+  let declaration =
+    expect_ok "resolve fixture declaration"
+      (Resolve.resolve_decl (Store.names_view store) declaration)
+  in
+  expect_ok "store fixture declaration" (Store.put_decl store declaration)
+
+let named name hashes = List.assoc name hashes.Canon.named
+
+let seed_primitives store =
+  List.iter
+    (fun name ->
+      ignore (put_src store (Printf.sprintf "(deftype %s () (con host-%s-value))" name name)))
+    [ "int"; "real"; "text"; "code"; "hash"; "secret" ]
+
+let required_hash store name kind =
+  match Store.lookup_kind store name kind with
+  | Some { Resolve.hash; _ } -> hash
+  | None -> Alcotest.failf "fixture prelude is missing %s" name
+
+type fixture = {
+  store : Store.t;
+  checker : Check.ctx;
+  int_type : Hash.t;
+  text_type : Hash.t;
+  hash_type : Hash.t;
+  packet_type : Hash.t;
+  packet_constructor : Hash.t;
+  world_effect : Hash.t;
+  send_operation : Hash.t;
+  log_operation : Hash.t;
+  callback_operation : Hash.t;
+  peek_operation : Hash.t;
+  generic_effect : Hash.t;
+  generic_operation : Hash.t;
+  pure_target : Hash.t;
+  effectful_target : Hash.t;
+  generic_target : Hash.t;
+  constant_target : Hash.t;
+  polymorphic_target : Hash.t;
+  open_row_target : Hash.t;
+  higher_order_target : Hash.t;
+}
+
+let make_fixture () =
+  let store = expect_ok "open fixture store" (Store.open_store (fresh_dir "main")) in
+  seed_primitives store;
+  let packet =
+    put_src store
+      "(deftype boundary-packet ((tvar a)) (con make-boundary-packet (field (tvar a)) (field (tref \
+       text))))"
+  in
+  let world =
+    put_src store
+      "(defeffect boundary-world () (op boundary.send once ((tref int) (tref text)) (tref text)) \
+       (op boundary.log once ((tref text)) (ttuple)) (op boundary.callback once ((tarrow ((tref \
+       int)) (row) (tref int))) (tref int)) (op boundary.peek () (tref int)))"
+  in
+  let generic =
+    put_src store
+      "(defeffect boundary-generic ((tvar a)) (op boundary.generic once ((tvar a)) (tvar a)))"
+  in
+  let pure =
+    put_src store
+      "(defterm ((binding boundary.pure ((tarrow ((tapp (tref boundary-packet) (tref int)) (ttuple \
+       (tref text) (tref hash))) (row) (tref text))) (lam ((pvar packet) (pvar metadata)) (lit \
+       \"accepted\")))))"
+  in
+  let effectful =
+    put_src store
+      "(defterm ((binding boundary.effectful ((tarrow ((tref int) (tref text)) (row (eref \
+       boundary-world)) (tref text))) (lam ((pvar count) (pvar body)) (app (var boundary.send) \
+       (var count) (var body))))))"
+  in
+  let generic_target =
+    put_src store
+      "(defterm ((binding boundary.generic-target ((tarrow ((tref int)) (row (eref \
+       boundary-generic)) (tref int))) (lam ((pvar value)) (app (var boundary.generic) (var \
+       value))))))"
+  in
+  let constant = put_src store "(defterm ((binding boundary.constant () (lit 1))))" in
+  let polymorphic =
+    put_src store
+      "(defterm ((binding boundary.identity ((tarrow ((tvar a)) (row) (tvar a))) (lam ((pvar \
+       value)) (var value)))))"
+  in
+  let open_row =
+    put_src store
+      "(defterm ((binding boundary.forward () (lam ((pvar computation)) (app (var computation))))))"
+  in
+  let higher_order =
+    put_src store
+      "(defterm ((binding boundary.higher ((tarrow ((tarrow ((tref int)) (row) (tref int))) (row) \
+       (tref int))) (lam ((pvar function)) (app (var function) (lit 1))))))"
+  in
+  let checker = expect_ok "create fixture checker" (Check.make_ctx store) in
+  {
+    store;
+    checker;
+    int_type = required_hash store "int" Resolve.KType;
+    text_type = required_hash store "text" Resolve.KType;
+    hash_type = required_hash store "hash" Resolve.KType;
+    packet_type = named "boundary-packet" packet;
+    packet_constructor = named "make-boundary-packet" packet;
+    world_effect = named "boundary-world" world;
+    send_operation = named "boundary.send" world;
+    log_operation = named "boundary.log" world;
+    callback_operation = named "boundary.callback" world;
+    peek_operation = named "boundary.peek" world;
+    generic_effect = named "boundary-generic" generic;
+    generic_operation = named "boundary.generic" generic;
+    pure_target = named "boundary.pure" pure;
+    effectful_target = named "boundary.effectful" effectful;
+    generic_target = named "boundary.generic-target" generic_target;
+    constant_target = named "boundary.constant" constant;
+    polymorphic_target = named "boundary.identity" polymorphic;
+    open_row_target = named "boundary.forward" open_row;
+    higher_order_target = named "boundary.higher" higher_order;
+  }
+
+let fixture = lazy (make_fixture ())
+let nominal identity arguments = Types.TCon (identity, arguments)
+let int_type fixture = nominal fixture.int_type []
+let text_type fixture = nominal fixture.text_type []
+let hash_type fixture = nominal fixture.hash_type []
+let packet_int fixture = nominal fixture.packet_type [ int_type fixture ]
+let metadata_type fixture = Types.TTuple [ text_type fixture; hash_type fixture ]
+
+let encode_type value =
+  expect_ok "encode fixture boundary type"
+    (Host.encode_boundary_type ~budget:(Host.create_boundary_budget Host.hard_limits) value)
+
+let encode_value value =
+  expect_ok "encode fixture boundary value"
+    (Host.encode_boundary_value ~budget:(Host.create_boundary_budget Host.hard_limits) value)
+
+let hash_json hash = `String (Hash.to_hex hash)
+
+let operation_json ~effect_identity ~mode ~operation =
+  `Assoc
+    [
+      ("effect", hash_json effect_identity);
+      ("mode", `String mode);
+      ("operation", hash_json operation);
+    ]
+
+let invoke_json ~target ~parameters ~effects ~result ~arguments ~operations =
+  `Assoc
+    [
+      ("arguments", `List (List.map encode_value arguments));
+      ( "capabilities",
+        `Assoc [ ("effects", `List (List.map hash_json effects)); ("operations", `List operations) ]
+      );
+      ( "interface",
+        `Assoc
+          [
+            ("effects", `List (List.map hash_json effects));
+            ("parameters", `List (List.map encode_type parameters));
+            ("result", encode_type result);
+          ] );
+      ("invocation_id", `String "0000000000000000");
+      ("kind", `String "invoke");
+      ("protocol", `String Host.protocol);
+      ("target", `Assoc [ ("callable", hash_json target); ("kind", `String "store-term-v0") ]);
+    ]
+
+let pure_arguments fixture =
+  [
+    Value.VCon
+      {
+        con = fixture.packet_constructor;
+        name = "display-name-does-not-cross";
+        args = [ Value.VInt 7; Value.VText "payload" ];
+      };
+    Value.VTuple [ Value.VText "metadata"; Value.VHash (Hash.of_string "metadata") ];
+  ]
+
+let pure_invoke fixture =
+  invoke_json ~target:fixture.pure_target
+    ~parameters:[ packet_int fixture; metadata_type fixture ]
+    ~effects:[] ~result:(text_type fixture) ~arguments:(pure_arguments fixture) ~operations:[]
+
+let effectful_invoke ?(operations = []) fixture =
+  invoke_json ~target:fixture.effectful_target
+    ~parameters:[ int_type fixture; text_type fixture ]
+    ~effects:[ fixture.world_effect ] ~result:(text_type fixture)
+    ~arguments:[ Value.VInt 2; Value.VText "body" ]
+    ~operations
+
+let replace_field name replacement = function
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (candidate, value) ->
+             if String.equal candidate name then (candidate, replacement) else (candidate, value))
+           fields)
+  | _ -> Alcotest.failf "cannot replace %s on a non-object test fixture" name
+
+let update_field name update = function
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (candidate, value) ->
+             if String.equal candidate name then (candidate, update value) else (candidate, value))
+           fields)
+  | _ -> Alcotest.failf "cannot update %s on a non-object test fixture" name
+
+let append_field name value = function
+  | `Assoc fields -> `Assoc ((name, value) :: fields)
+  | _ -> Alcotest.failf "cannot append %s to a non-object test fixture" name
+
+let parse ?(limits = Host.hard_limits) fixture json =
+  Host.parse_invoke ~limits ~checker:fixture.checker json
+
+let test_pure_target_and_typed_composites_succeed () =
+  let fixture = Lazy.force fixture in
+  let invocation = expect_ok "pure invoke preflight" (parse fixture (pure_invoke fixture)) in
+  Alcotest.(check string)
+    "exact target" (Hash.to_hex fixture.pure_target)
+    (Hash.to_hex invocation.Host.callable);
+  Alcotest.(check int) "two decoded arguments" 2 (List.length invocation.Host.arguments);
+  Alcotest.(check int) "pure effect set" 0 (List.length invocation.Host.effects);
+  Alcotest.(check int) "empty operation registry" 0 (List.length invocation.Host.operations)
+
+let test_effectful_target_accepts_partial_or_exact_registry_without_running () =
+  let fixture = Lazy.force fixture in
+  let partial = expect_ok "partial registry" (parse fixture (effectful_invoke fixture)) in
+  Alcotest.(check int) "partial registry remains empty" 0 (List.length partial.Host.operations);
+  let entry =
+    operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+      ~operation:fixture.send_operation
+  in
+  let exact =
+    expect_ok "exact operation registry"
+      (parse fixture (effectful_invoke ~operations:[ entry ] fixture))
+  in
+  match exact.Host.operations with
+  | [ operation ] ->
+      Alcotest.(check string)
+        "operation identity"
+        (Hash.to_hex fixture.send_operation)
+        (Hash.to_hex operation.Host.operation);
+      Alcotest.(check int) "operation parameter count" 2 (List.length operation.Host.parameters)
+  | operations -> Alcotest.failf "expected one operation, got %d" (List.length operations)
+
+let test_envelope_version_state_and_id_fail_closed () =
+  let fixture = Lazy.force fixture in
+  let valid = pure_invoke fixture in
+  let target_with callable = update_field "target" (replace_field "callable" callable) valid in
+  let cases =
+    [
+      ("unknown outer field", append_field "extra" `Null valid, "E1601");
+      ("unsupported protocol", replace_field "protocol" (`String "future") valid, "E1600");
+      ("wrong state kind", replace_field "kind" (`String "shutdown") valid, "E1608");
+      ( "wrong invocation id",
+        replace_field "invocation_id" (`String "0000000000000001") valid,
+        "E1608" );
+      ( "malformed target identity",
+        target_with (`String (String.uppercase_ascii (Hash.to_hex fixture.pure_target))),
+        "E1601" );
+    ]
+  in
+  List.iter (fun (label, json, code) -> expect_code label code (parse fixture json)) cases
+
+let test_target_role_callable_and_boundary_shape_fail_closed () =
+  let fixture = Lazy.force fixture in
+  let valid = pure_invoke fixture in
+  let with_target target =
+    update_field "target" (replace_field "callable" (hash_json target)) valid
+  in
+  let cases =
+    [
+      ("missing target", with_target (Hash.of_string "missing-target"), "E1603");
+      ("constructor target", with_target fixture.packet_constructor, "E1603");
+      ("non-callable term", with_target fixture.constant_target, "E1603");
+      ("polymorphic term", with_target fixture.polymorphic_target, "E1603");
+      ("open-row term", with_target fixture.open_row_target, "E1603");
+      ("nested-arrow boundary", with_target fixture.higher_order_target, "E1604");
+    ]
+  in
+  List.iter (fun (label, json, code) -> expect_code label code (parse fixture json)) cases
+
+let missing_closure_case () =
+  let store = expect_ok "open incomplete store" (Store.open_store (fresh_dir "closure")) in
+  seed_primitives store;
+  let dependency =
+    put_src store
+      "(defterm ((binding boundary.dependency ((tarrow () (row) (tref text))) (lam () (lit \
+       \"dependency\")))))"
+  in
+  let target =
+    put_src store
+      "(defterm ((binding boundary.dependent ((tarrow () (row) (tref text))) (lam () (app (var \
+       boundary.dependency))))))"
+  in
+  let checker = expect_ok "create incomplete-store checker" (Check.make_ctx store) in
+  Sys.remove (Store.object_path store dependency.Canon.decl_hash);
+  (checker, named "boundary.dependent" target, required_hash store "text" Resolve.KType)
+
+let test_complete_reachable_store_closure_is_required () =
+  let checker, target, text = missing_closure_case () in
+  let json =
+    invoke_json ~target ~parameters:[] ~effects:[] ~result:(nominal text []) ~arguments:[]
+      ~operations:[]
+  in
+  expect_code "missing reachable object" "E1603"
+    (Host.parse_invoke ~limits:Host.hard_limits ~checker json)
+
+let test_interface_and_argument_count_must_equal_checked_arrow () =
+  let fixture = Lazy.force fixture in
+  let valid = pure_invoke fixture in
+  let cases =
+    [
+      ( "parameter order",
+        update_field "interface"
+          (replace_field "parameters"
+             (`List [ encode_type (metadata_type fixture); encode_type (packet_int fixture) ]))
+          valid );
+      ( "result type",
+        update_field "interface" (replace_field "result" (encode_type (int_type fixture))) valid );
+      ( "interface effects",
+        update_field "interface"
+          (replace_field "effects" (`List [ hash_json fixture.world_effect ]))
+          valid );
+      ( "argument count",
+        replace_field "arguments" (`List [ encode_value (List.hd (pure_arguments fixture)) ]) valid
+      );
+    ]
+  in
+  List.iter (fun (label, json) -> expect_code label "E1603" (parse fixture json)) cases
+
+let test_scalar_tuple_and_generic_constructor_fields_are_typed () =
+  let fixture = Lazy.force fixture in
+  let valid = pure_invoke fixture in
+  let wrong_packet =
+    Value.VCon
+      {
+        con = fixture.packet_constructor;
+        name = "ignored";
+        args = [ Value.VText "not-an-int"; Value.VText "payload" ];
+      }
+  in
+  let wrong_tuple = Value.VTuple [ Value.VInt 1; Value.VHash (Hash.of_string "metadata") ] in
+  let replace_arguments arguments = replace_field "arguments" (`List arguments) valid in
+  expect_code "generic constructor field" "E1603"
+    (parse fixture
+       (replace_arguments
+          [ encode_value wrong_packet; encode_value (List.nth (pure_arguments fixture) 1) ]));
+  expect_code "tuple item" "E1603"
+    (parse fixture
+       (replace_arguments
+          [ encode_value (List.hd (pure_arguments fixture)); encode_value wrong_tuple ]));
+  expect_code "unsupported value descriptor" "E1604"
+    (parse fixture
+       (replace_arguments
+          [
+            `Assoc [ ("kind", `String "secret"); ("value", `String "opaque") ];
+            encode_value (List.nth (pure_arguments fixture) 1);
+          ]));
+  let wrong_constructor =
+    `Assoc
+      [
+        ("arguments", `List []);
+        ("identity", hash_json fixture.text_type);
+        ("kind", `String "constructor");
+      ]
+  in
+  expect_code "non-constructor identity" "E1603"
+    (parse fixture
+       (replace_arguments [ wrong_constructor; encode_value (List.nth (pure_arguments fixture) 1) ]))
+
+let test_selected_argument_effect_operation_and_node_limits_are_aggregate () =
+  let fixture = Lazy.force fixture in
+  expect_code "parameter count limit" "E1602"
+    (parse ~limits:{ Host.hard_limits with max_arguments = 1 } fixture (pure_invoke fixture));
+  let duplicate_effects =
+    `List [ hash_json fixture.world_effect; hash_json fixture.world_effect ]
+  in
+  let too_many_effects =
+    effectful_invoke fixture
+    |> update_field "interface" (replace_field "effects" duplicate_effects)
+    |> update_field "capabilities" (replace_field "effects" duplicate_effects)
+  in
+  expect_code "effect count limit" "E1602"
+    (parse ~limits:{ Host.hard_limits with max_effects = 1 } fixture too_many_effects);
+  let entry =
+    operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+      ~operation:fixture.send_operation
+  in
+  expect_code "operation count limit" "E1602"
+    (parse
+       ~limits:{ Host.hard_limits with max_operations = 1 }
+       fixture
+       (effectful_invoke ~operations:[ entry; entry ] fixture));
+  expect_code "shared type/value node budget" "E1602"
+    (parse ~limits:{ Host.hard_limits with max_value_nodes = 4 } fixture (pure_invoke fixture))
+
+let test_capabilities_and_registry_are_exact_closed_and_once () =
+  let fixture = Lazy.force fixture in
+  let valid = effectful_invoke fixture in
+  let capability_effects effects =
+    update_field "capabilities" (replace_field "effects" (`List (List.map hash_json effects))) valid
+  in
+  expect_code "missing capability effect" "E1605" (parse fixture (capability_effects []));
+  expect_code "duplicate capability effect" "E1605"
+    (parse fixture (capability_effects [ fixture.world_effect; fixture.world_effect ]));
+  let with_operations operations =
+    update_field "capabilities" (replace_field "operations" (`List operations)) valid
+  in
+  let send =
+    operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+      ~operation:fixture.send_operation
+  in
+  let log =
+    operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+      ~operation:fixture.log_operation
+  in
+  let unsorted =
+    if Hash.compare fixture.send_operation fixture.log_operation < 0 then [ log; send ]
+    else [ send; log ]
+  in
+  let cases =
+    [
+      ("duplicate operation", [ send; send ]);
+      ("unsorted operation", unsorted);
+      ( "wrong operation owner",
+        [
+          operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+            ~operation:fixture.generic_operation;
+        ] );
+      ( "multi declaration",
+        [
+          operation_json ~effect_identity:fixture.world_effect ~mode:"multi"
+            ~operation:fixture.peek_operation;
+        ] );
+      ( "declared mode disagreement",
+        [
+          operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+            ~operation:fixture.peek_operation;
+        ] );
+      ( "payload mode disagreement",
+        [
+          operation_json ~effect_identity:fixture.world_effect ~mode:"multi"
+            ~operation:fixture.send_operation;
+        ] );
+      ( "unresolved operation",
+        [
+          operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+            ~operation:(Hash.of_string "missing-operation");
+        ] );
+    ]
+  in
+  List.iter
+    (fun (label, operations) ->
+      expect_code label "E1605" (parse fixture (with_operations operations)))
+    cases;
+  let callback =
+    operation_json ~effect_identity:fixture.world_effect ~mode:"once"
+      ~operation:fixture.callback_operation
+  in
+  expect_code "nested callable operation signature" "E1604"
+    (parse fixture (with_operations [ callback ]));
+  let pure_with_ungranted_operation =
+    pure_invoke fixture |> update_field "capabilities" (replace_field "operations" (`List [ send ]))
+  in
+  expect_code "operation cannot introduce an ungranted effect" "E1605"
+    (parse fixture pure_with_ungranted_operation)
+
+let test_generic_operation_signature_is_not_a_boundary_contract () =
+  let fixture = Lazy.force fixture in
+  let entry =
+    operation_json ~effect_identity:fixture.generic_effect ~mode:"once"
+      ~operation:fixture.generic_operation
+  in
+  let json =
+    invoke_json ~target:fixture.generic_target
+      ~parameters:[ int_type fixture ]
+      ~effects:[ fixture.generic_effect ] ~result:(int_type fixture) ~arguments:[ Value.VInt 1 ]
+      ~operations:[ entry ]
+  in
+  expect_code "generic operation signature" "E1604" (parse fixture json)
+
+let test_fail_fast_precedence_does_not_trust_later_material () =
+  let fixture = Lazy.force fixture in
+  let invalid_target =
+    pure_invoke fixture
+    |> update_field "target"
+         (replace_field "callable" (hash_json (Hash.of_string "missing-target")))
+    |> update_field "capabilities"
+         (replace_field "effects" (`List [ hash_json fixture.world_effect ]))
+  in
+  expect_code "protocol precedes target" "E1600"
+    (parse fixture (replace_field "protocol" (`String "future") invalid_target));
+  expect_code "target precedes capabilities" "E1603" (parse fixture invalid_target);
+  let wrong_argument_and_capability =
+    effectful_invoke fixture
+    |> replace_field "arguments"
+         (`List [ encode_value (Value.VText "wrong"); encode_value (Value.VText "body") ])
+    |> update_field "capabilities" (replace_field "effects" (`List []))
+  in
+  expect_code "argument typing precedes capabilities" "E1603"
+    (parse fixture wrong_argument_and_capability);
+  let malformed_and_future =
+    pure_invoke fixture |> replace_field "protocol" (`String "future") |> append_field "extra" `Null
+  in
+  expect_code "shape precedes protocol" "E1601" (parse fixture malformed_and_future)
+
+let suite =
+  [
+    Alcotest.test_case "pure target and typed composites succeed" `Quick
+      test_pure_target_and_typed_composites_succeed;
+    Alcotest.test_case "effectful preflight accepts partial registry without running" `Quick
+      test_effectful_target_accepts_partial_or_exact_registry_without_running;
+    Alcotest.test_case "invoke envelope, version, state, and ID fail closed" `Quick
+      test_envelope_version_state_and_id_fail_closed;
+    Alcotest.test_case "target role, callable, and boundary shape fail closed" `Quick
+      test_target_role_callable_and_boundary_shape_fail_closed;
+    Alcotest.test_case "complete reachable store closure is required" `Quick
+      test_complete_reachable_store_closure_is_required;
+    Alcotest.test_case "interface and argument count equal the checked arrow" `Quick
+      test_interface_and_argument_count_must_equal_checked_arrow;
+    Alcotest.test_case "scalar, tuple, and generic constructor fields are typed" `Quick
+      test_scalar_tuple_and_generic_constructor_fields_are_typed;
+    Alcotest.test_case "selected invoke limits are aggregate" `Quick
+      test_selected_argument_effect_operation_and_node_limits_are_aggregate;
+    Alcotest.test_case "capabilities and registry are exact, closed, and once" `Quick
+      test_capabilities_and_registry_are_exact_closed_and_once;
+    Alcotest.test_case "generic operation signatures stay outside v0" `Quick
+      test_generic_operation_signature_is_not_a_boundary_contract;
+    Alcotest.test_case "fail-fast precedence rejects untrusted later material" `Quick
+      test_fail_fast_precedence_does_not_trust_later_material;
+  ]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -26,6 +26,7 @@ let () =
       ("host-protocol-v0", Test_host_protocol_vectors.suite);
       ("host-protocol-codec", Test_host_protocol_codec.suite);
       ("host-boundary-codec", Test_host_boundary_codec.suite);
+      ("host-invoke-preflight", Test_host_invoke_preflight.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Summary

- add library-only `jacquard-host-v0` invoke preflight for one exact public
  stored callable and its complete reachable closure
- derive and pin a closed monomorphic first-order interface, recursively type
  positional boundary values, and validate exact effect grants plus a sorted
  unique public `once` operation registry
- expose result-valued checker lookups for immutable primitive identities,
  constructors, and operation contracts without changing checker inference or
  evaluator behavior
- update human/agent protocol maps and the live successor inventory from 914
  to 925 while preserving historical milestones

## Boundary

This is Core Task 205 / HB.2b2 only. It returns an immutable validated
invocation. It does not evaluate the target, exchange effects, enforce dynamic
E1606, emit outcomes, add a worker/CLI, or introduce adapter, HTTP, socket,
SQLite, concurrency, attenuation, general-RPC, or sandbox behavior.

## Evidence

- focused invoke-preflight suite: 11/11
- cold exact-head `dune runtest`: 925/925 plus native runtime/memory/leak
  checks, crams, and 28 doctests in 611.641s (QCheck seed `416736164`)
- `dune build @all @doc`, `dune fmt`, meaningful whitespace check, tracked
  cleanliness, and version smoke (`0.2.0`): pass
- independent Claude Fable 5 xhigh review: PASS; no blocker, disputed test,
  scope leak, or architecture conflict
- exact reviewed head: `2f0a12f3b1a1421f1e037a9b811f1008c6821d6f`
- exact reviewed tree: `c1b071344703e7b84a5dd826260554ed84372390`

## Review follow-up

The first PASS review identified an incomplete API diagnostic sentence and two
test-strength gaps. The correction documents E1608, makes the node-budget test
cross interface/argument phases, and directly proves hidden dependencies are
usable while hidden roots are rejected. A permitted exact-head correction
review returned PASS. Fixed external diagnostic causes and bounded linear
closure traversal remain classified as nonblocking implementation debt.
