### PR TITLE
Add serial host-session response and terminal accounting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,9 @@ When adding valid corpus files, regenerate the golden hashes with
   `spec/host-protocol-v0.md`; strict framing, selection, first-order type/value
   codecs, and checked invoke preflight: `src/host_protocol_v0.ml`,
   `test/test_host_protocol_codec.ml`, `test/test_host_boundary_codec.ml`,
-  `test/test_host_invoke_preflight.ml`. No runnable worker ships yet. Existing
+  `test/test_host_invoke_preflight.ml`. Serial session actions and terminal
+  accounting: `Host_protocol_v0.Session`, `test/test_host_session.ml`, and
+  `docs/host-session-v0.md`. No runnable worker ships yet. Existing
   evaluator capture and host-readiness modules are internal seams, not a public
   ABI; adapters and application servers belong outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ studied during planning; `docs/ast.md` records each debt in detail:
 The prototype is complete against its original core plan and has since added
 the public surface syntax, ringed standard library, Warp properties and cache,
 native compilation, packaged binaries, and product-scale case studies. The RC1
-semantic boundary remains historical; the current successor is pinned by 925
-Alcotest/QCheck cases, 59 cram transcripts, 28 documentation examples, native
+semantic boundary remains historical; the current successor is pinned by 984
+Alcotest/QCheck cases, 60 cram transcripts, 28 documentation examples, native
 sanitizer/leak/fuzz lanes, and fresh-clone evidence workflows. RC2 repaired
 binary-demo packaging; RC3 adds an explicit
 runtime/output license exception and packages the native runtime. The current

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,8 @@ project shape from file names alone.
   positive/hostile vectors. HB.2a implements strict framing/selection and
   HB.2b1 implements bounded first-order type/value codecs. HB.2b2 additionally
   preflights exact stored targets, interfaces, typed arguments, effect grants,
-  and closed once-operation registries, but no runnable carrier ships yet.
+  and closed once-operation registries. The [session layer](host-session-v0.md)
+  accounts for serial responses and terminal evidence; no runnable carrier ships yet.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -905,6 +905,9 @@ Do not invent new kernel forms for surface sugar.
   arguments, exact effect grants, and sorted unique public `once` operation
   registry. This returns a validated invocation but does not evaluate it. No
   runnable worker, stable foreign-host ABI, adapter, or HTTP server ships yet.
+  `Host_protocol_v0.Session` now validates serial responses, accounts for
+  bounded evidence, and returns request/resume/terminal actions. See
+  `host-session-v0.md` for the caller-owned continuation and I/O obligations.
   Internal evaluator-capture and host-readiness OCaml APIs are not supported
   embedding contracts; future adapters must consume the versioned protocol and
   its executable conformance fixtures, not those OCaml seams.

--- a/docs/host-session-v0.md
+++ b/docs/host-session-v0.md
@@ -1,0 +1,67 @@
+# Serial host session accounting
+
+`Host_protocol_v0.Session` implements the invocation state machine in the
+[frozen v0 protocol](../spec/host-protocol-v0.md). It builds on checked invoke
+preflight and the bounded type/value codecs. It is an OCaml library layer;
+the opt-in process worker and evaluator loop remain to be implemented.
+
+A session starts only after the exact stored callable, complete reachable
+closure, pinned interface, arguments, grants, and operation registry pass
+preflight. It also reserves room for an error outcome with that invocation's
+evidence. The checker and store must remain stable for the session's lifetime.
+
+## State and ownership
+
+| State | Event | Returned action and next state |
+|---|---|---|
+| Running | Configured operation with valid arguments | One request; wait for its response |
+| Running | Missing operation, invalid value, or exhausted capacity | Error outcome; closed |
+| Waiting | Matching, correctly typed `effect_ok` | One value to resume with; running |
+| Waiting | Valid failure or cancellation | Error outcome with the frozen classification; closed |
+| Waiting | Invalid response | E1608 outcome, or E1602 for a selected limit; closed |
+| Running | Computation returns | Validate actual result and return success or diagnostic; closed |
+| Running or waiting | Runtime abort | Bounded diagnostic outcome; closed |
+| Closed | Any further state-changing call | Result-valued E1608; no additional frame |
+
+A second request while waiting, an unsolicited response, or a result while
+waiting is E1608. Request IDs are deterministic, one-based 16-digit hex
+ordinals. A response must match the selected protocol, invocation, and current
+request. Stale replies cannot consume a newer response slot.
+
+The session owns no evaluator continuation, channel, or operating-system
+resource. The worker must retain one captured continuation while waiting,
+resume it only on `Resume`, and drop it on `Finished`. An action is committed
+when returned: the worker writes and flushes it once. A write failure ends the
+worker; retrying a request or claiming that an unwritten terminal was delivered
+would violate the protocol. Only the later worker integration can establish
+these resource-lifetime and delivery guarantees.
+
+## Capacity and evidence
+
+Before returning a request, the session reserves terminal capacity for the
+new request, the largest permitted next observation, and the longest terminal
+label. If that evidence cannot fit, the operation is refused before a request
+is returned. Accepted observations survive subsequent failure.
+
+Each envelope passes the selected byte, depth, and collection checks.
+Repeated interface descriptors and a successful result share the outcome's
+node budget. Diagnostic accounting includes every rendered UTF-8 string value,
+including contrasts and span paths, and excludes fixed JSON keys.
+
+Diagnostics that cannot fit are replaced with a fixed E1602 diagnostic. This
+retains the terminal classification and accepted observations: an accepted
+unknown-completion response stays `completion_unknown` even when its detailed
+host diagnostic exceeds the budget. Host message bytes appear as an exact
+cause suffix when they fit; they are never truncated into a different claim.
+The trusted host remains responsible for redacting those messages.
+
+Core evidence contains the validated identity/interface/grants and request
+order. Host observations contain only accepted category/completion/ordinal
+claims. Arguments, results, and host message text stay out of both evidence
+sections. Rejected responses are never recorded as accepted observations.
+
+`test/test_host_session.ml` covers both directions of typed nominal values,
+all four host-failure and nine cancellation mappings, state violations,
+strict response validation, growing evidence, and exact capacity boundaries.
+The worker's pipe, EOF, cancellation cleanup, descriptor, and ordinary-command
+compatibility evidence belongs to the remaining integration work.

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `969`
+Test count: `984`
 
 Cram count: `60`
 
@@ -48,3 +48,8 @@ unifier isolation case, plus one CLI transcript, bringing the live inventory to
 `969 / 60 / 28`. See [the containment contract](../../effect-payload-containment.md).
 The historical publication manifests and their recorded source evidence remain
 unchanged; these inventory numbers describe the current source checkout.
+
+The serial host-session library adds 15 cases, bringing the current source
+inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
+finish-once accounting, and bounded evidence; the process worker remains
+unimplemented. See [the session contract](../../host-session-v0.md).

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `969`
+- Alcotest/QCheck cases: `984`
 - Cram transcript files: `60`
 - Documentation examples: `28` named examples across `8` documents
 
@@ -93,3 +93,8 @@ unifier isolation case, plus one CLI transcript, bringing the live inventory to
 `969 / 60 / 28`. See [the containment contract](../../effect-payload-containment.md).
 The historical publication manifests and their recorded source evidence remain
 unchanged; these inventory numbers describe the current source checkout.
+
+The serial host-session library adds 15 cases, bringing the current source
+inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
+finish-once accounting, and bounded evidence; the process worker remains
+unimplemented. See [the session contract](../../host-session-v0.md).

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `969`
+- Alcotest/QCheck cases: `984`
 - Cram transcript files: `60`
 - Doctest examples: `28` across 8 documents
 
@@ -107,3 +107,8 @@ unifier isolation case, plus one CLI transcript, bringing the live inventory to
 `969 / 60 / 28`. See [the containment contract](../../effect-payload-containment.md).
 The historical publication manifests and their recorded source evidence remain
 unchanged; these inventory numbers describe the current source checkout.
+
+The serial host-session library adds 15 cases, bringing the current source
+inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
+finish-once accounting, and bounded evidence; the process worker remains
+unimplemented. See [the session contract](../../host-session-v0.md).

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -34,7 +34,7 @@ native Channel, actor, or supervision claim.
 | C3 | Scoped typed channels run through deterministic FIFO, seeded, replay, exhaustive, and cached interpreter scheduling with exact run/scope ownership, rendezvous and buffering, close, cancellation, and deadlock behavior. | `channel-contract`, `round-robin`, and `exhaustive-schedule` suites; `test/cli/task-values.t`; `test/cli/schedule-replay.t`; and the frozen traces below |
 | C4 | Not claimed: host asynchronous I/O, actors, and supervision are absent. | [LIMITS.md](LIMITS.md) |
 
-The current successor inventory is exactly 969 compiled Alcotest/QCheck cases, 60 recursive
+The current successor inventory is exactly 984 compiled Alcotest/QCheck cases, 60 recursive
 cram transcript files, and 28 named doctest examples across 8 documents. The
 repository release-law checks recompute those counts instead of trusting this
 paragraph.
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `969`
+- Alcotest/QCheck cases: `984`
 - Cram transcript files: `60`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
@@ -923,3 +923,8 @@ unifier isolation case, plus one CLI transcript, bringing the live inventory to
 `969 / 60 / 28`. See [the containment contract](../../effect-payload-containment.md).
 The historical publication manifests and their recorded source evidence remain
 unchanged; these inventory numbers describe the current source checkout.
+
+The serial host-session library adds 15 cases, bringing the current source
+inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
+finish-once accounting, and bounded evidence; the process worker remains
+unimplemented. See [the session contract](../../host-session-v0.md).

--- a/src/host_protocol_v0.ml
+++ b/src/host_protocol_v0.ml
@@ -58,12 +58,33 @@ let diagnostic_spec = function
       ( "The selected host capability or operation registry is invalid.",
         "Use the exact checked effect set and a sorted unique registry of its public once \
          operations." )
+  | "E1606" ->
+      ( "The root operation has no configured host implementation.",
+        "Configure the exact operation before starting a new invocation." )
+  | "E1607" ->
+      ( "The host refused authority before starting the outside action.",
+        "Review the host's authority policy before starting a new invocation." )
   | "E1608" ->
       ( "The host protocol message is invalid in the current state.",
         "Send only the next message permitted by the serial jacquard-host-v0 state machine." )
+  | "E1609" ->
+      ( "The host reported a timeout with known completion.",
+        "Inspect the host's completion evidence before deciding on any later invocation." )
+  | "E1610" ->
+      ( "The host requested shutdown with known completion.",
+        "Release invocation resources and close the worker." )
   | "E1611" ->
       ( "The host carrier was lost before a trustworthy frame completed.",
         "Treat the missing terminal exchange as host-owned carrier-failure evidence." )
+  | "E1612" ->
+      ( "The outside action's completion is unknown.",
+        "Reconcile host-owned evidence; do not automatically retry the action or invocation." )
+  | "E1613" ->
+      ( "The host reported that the outside action failed.",
+        "Inspect the host's failure evidence before deciding on any later invocation." )
+  | "E1614" ->
+      ( "The host cancelled the invocation with known completion.",
+        "Release invocation resources without resuming the cancelled continuation." )
   | code -> raise (Diag.Bug_invalid_diagnostic ("unknown host protocol diagnostic code " ^ code))
 
 let diagnostic ~code cause =
@@ -1100,3 +1121,374 @@ let parse_invoke ~limits ~checker json =
           in
           Ok { invocation_id; callable; parameters; effects; result; arguments; operations }
   | _ -> error ~code:"E1601" "The invoke message must be one JSON object."
+
+module Session = struct
+  type phase = Running | Waiting of operation_binding * int | Closed
+
+  type t = {
+    limits : limits;
+    checker : Check.ctx;
+    invocation : invocation;
+    mutable phase : phase;
+    mutable requests : Yojson.Safe.t list;
+    mutable observations : Yojson.Safe.t list;
+  }
+
+  type action = Request of Yojson.Safe.t | Resume of Value.t | Finished of Yojson.Safe.t
+
+  let hash_json hash = `String (Hash.to_hex hash)
+  let request_id ordinal = Printf.sprintf "%016x" ordinal
+
+  let observation ordinal category completion =
+    `Assoc
+      [
+        ("category", `String category); ("completion", `String completion); ("ordinal", `Int ordinal);
+      ]
+
+  let checked_frame limits json =
+    let* _ = encode_frame_bytes ~limits json in
+    Ok json
+
+  let diagnostic_json limits diagnostics =
+    let json = List.map Diag.to_yojson diagnostics in
+    if
+      diagnostics = []
+      || List.length diagnostics > limits.max_diagnostics
+      || json_string_bytes (`List json) > limits.max_diagnostic_bytes
+    then error ~code:"E1602" "The terminal diagnostics exceed the selected count or byte limit."
+    else Ok (`List json)
+
+  let fatal ~limits diagnostics =
+    let encode diagnostics =
+      let* diagnostics = diagnostic_json limits diagnostics in
+      checked_frame limits
+        (`Assoc
+           [
+             ("diagnostics", diagnostics); ("kind", `String "fatal"); ("protocol", `String protocol);
+           ])
+    in
+    match encode diagnostics with Ok json -> Ok json | Error _ -> encode [ capacity_diagnostic ]
+
+  let evidence session budget ~requests ~observations ~terminal =
+    let invocation = session.invocation in
+    let* parameters = map_result (encode_boundary_type ~budget) invocation.parameters in
+    let* result = encode_boundary_type ~budget invocation.result in
+    let effects = `List (List.map hash_json invocation.effects) in
+    let operations =
+      List.map
+        (fun (binding : operation_binding) ->
+          `Assoc
+            [
+              ("effect", hash_json binding.effect_identity);
+              ("mode", `String "once");
+              ("operation", hash_json binding.operation);
+            ])
+        invocation.operations
+    in
+    Ok
+      (`Assoc
+         [
+           ( "core",
+             `Assoc
+               [
+                 ("capabilities", `Assoc [ ("effects", effects); ("operations", `List operations) ]);
+                 ("effect_requests", `List (List.rev requests));
+                 ( "interface",
+                   `Assoc
+                     [ ("effects", effects); ("parameters", `List parameters); ("result", result) ]
+                 );
+                 ("invocation_id", `String invocation.invocation_id);
+                 ("schema", `String "jacquard-host-core-evidence-v0");
+                 ( "target",
+                   `Assoc
+                     [
+                       ("callable", hash_json invocation.callable); ("kind", `String "store-term-v0");
+                     ] );
+                 ("terminal", `String terminal);
+               ] );
+           ( "host_observations",
+             `Assoc
+               [
+                 ("responses", `List (List.rev observations));
+                 ("schema", `String "jacquard-host-observations-v0");
+               ] );
+         ])
+
+  let outcome session ~requests ~observations ~terminal result =
+    let budget = create_boundary_budget session.limits in
+    let* evidence = evidence session budget ~requests ~observations ~terminal in
+    let* result =
+      match result with
+      | Ok value ->
+          let* value = encode_boundary_value ~budget value in
+          Ok (`Assoc [ ("kind", `String "ok"); ("value", value) ])
+      | Error diagnostics ->
+          let* diagnostics = diagnostic_json session.limits diagnostics in
+          Ok (`Assoc [ ("diagnostics", diagnostics); ("kind", `String "error") ])
+    in
+    checked_frame session.limits
+      (`Assoc
+         [
+           ("evidence", evidence);
+           ("invocation_id", `String session.invocation.invocation_id);
+           ("kind", `String "outcome");
+           ("protocol", `String protocol);
+           ("result", result);
+         ])
+
+  let reserve session ~requests ~observations =
+    outcome session ~requests ~observations ~terminal:"completion_unknown"
+      (Error [ capacity_diagnostic ])
+    |> Result.map (fun _ -> ())
+
+  let start ~limits ~checker json =
+    (* Revalidate the public record so callers cannot create uncapped sessions. *)
+    let* limits =
+      parse_host_select
+        (`Assoc
+           [
+             ("kind", `String "host_select");
+             ("limits", limits_to_yojson limits);
+             ("protocol", `String protocol);
+           ])
+    in
+    let* _ = checked_frame limits json in
+    let* invocation = parse_invoke ~limits ~checker json in
+    let session =
+      { limits; checker; invocation; phase = Running; requests = []; observations = [] }
+    in
+    let* () = reserve session ~requests:[] ~observations:[] in
+    Ok session
+
+  let call session = (session.invocation.callable, session.invocation.arguments)
+  let closed () = error ~code:"E1608" "The invocation already produced its terminal action."
+
+  let finish_error session ~terminal diagnostics =
+    match session.phase with
+    | Closed -> closed ()
+    | Running | Waiting _ ->
+        session.phase <- Closed;
+        let encode diagnostics =
+          outcome session ~requests:session.requests ~observations:session.observations ~terminal
+            (Error diagnostics)
+        in
+        let result =
+          match encode diagnostics with
+          | Ok json -> Ok json
+          | Error _ -> encode [ capacity_diagnostic ]
+        in
+        Result.map (fun json -> Finished json) result
+
+  let violation session =
+    finish_error session ~terminal:"diagnostic"
+      [ diagnostic ~code:"E1608" "The action is invalid in the current invocation state." ]
+
+  let abort session diagnostics = finish_error session ~terminal:"diagnostic" diagnostics
+
+  let finish session value =
+    match session.phase with
+    | Closed -> closed ()
+    | Waiting _ -> violation session
+    | Running -> (
+        let encoded =
+          let* json =
+            outcome session ~requests:session.requests ~observations:session.observations
+              ~terminal:"ok" (Ok value)
+          in
+          let* () =
+            validate_argument_value session.checker ~expected:session.invocation.result value
+          in
+          Ok json
+        in
+        match encoded with
+        | Error diagnostics -> abort session diagnostics
+        | Ok json ->
+            session.phase <- Closed;
+            Ok (Finished json))
+
+  let request session ~operation ~arguments =
+    match session.phase with
+    | Closed -> closed ()
+    | Waiting _ -> violation session
+    | Running -> (
+        let prepared =
+          let* binding =
+            match
+              List.find_opt
+                (fun (binding : operation_binding) -> Hash.equal binding.operation operation)
+                session.invocation.operations
+            with
+            | Some binding -> Ok binding
+            | None ->
+                error ~code:"E1606" "The root operation is absent from the configured registry."
+          in
+          let ordinal = List.length session.requests + 1 in
+          if ordinal > session.limits.max_effect_requests then
+            error ~code:"E1602" "The invocation exceeds max_effect_requests."
+          else if List.length arguments <> List.length binding.parameters then
+            error ~code:"E1603" "The root operation arguments disagree with its checked arity."
+          else
+            let budget = create_boundary_budget session.limits in
+            let* () =
+              validate_boundary_count ~budget ~context:"operation arguments" ~arguments:true
+                (List.length arguments)
+            in
+            let* arguments =
+              map_result
+                (fun (expected, value) ->
+                  let* json = encode_boundary_value ~budget value in
+                  let* () = validate_argument_value session.checker ~expected value in
+                  Ok json)
+                (List.combine binding.parameters arguments)
+            in
+            let* frame =
+              checked_frame session.limits
+                (`Assoc
+                   [
+                     ("arguments", `List arguments);
+                     ("effect", hash_json binding.effect_identity);
+                     ("invocation_id", `String session.invocation.invocation_id);
+                     ("kind", `String "effect_request");
+                     ("mode", `String "once");
+                     ("operation", hash_json operation);
+                     ("protocol", `String protocol);
+                     ("request_id", `String (request_id ordinal));
+                   ])
+            in
+            let requests =
+              `Assoc
+                [
+                  ("effect", hash_json binding.effect_identity);
+                  ("operation", hash_json operation);
+                  ("ordinal", `Int ordinal);
+                ]
+              :: session.requests
+            in
+            (* Longest permitted observation strings and terminal label reserve
+               every response's bounded fallback before an outside action. *)
+            let observations =
+              observation ordinal "unsupported_operation" "not_started" :: session.observations
+            in
+            let* () = reserve session ~requests ~observations in
+            Ok (binding, ordinal, requests, frame)
+        in
+        match prepared with
+        | Error diagnostics -> abort session diagnostics
+        | Ok (binding, ordinal, requests, frame) ->
+            session.requests <- requests;
+            session.phase <- Waiting (binding, ordinal);
+            Ok (Request frame))
+
+  type response = Success of Value.t | Stop of string * string * string * Diag.t
+
+  let parse_response session (binding : operation_binding) ordinal json =
+    let* _ = checked_frame session.limits json in
+    let* fields =
+      match json with
+      | `Assoc fields -> Ok fields
+      | _ -> error ~code:"E1608" "A response must be an object."
+    in
+    let string name =
+      match field name fields with
+      | Some (`String value) -> Ok value
+      | _ -> error ~code:"E1608" "A response string field is missing or malformed."
+    in
+    let* version = string "protocol" in
+    let* invocation_id = string "invocation_id" in
+    let* id = string "request_id" in
+    if
+      version <> protocol
+      || invocation_id <> session.invocation.invocation_id
+      || id <> request_id ordinal
+    then error ~code:"E1608" "The response protocol or invocation/request identity does not match."
+    else
+      let* kind = string "kind" in
+      let common = [ "invocation_id"; "kind"; "protocol"; "request_id" ] in
+      match kind with
+      | "effect_ok" ->
+          let* () = exact_fields ("value" :: common) fields in
+          let* value =
+            match field "value" fields with
+            | Some value -> Ok value
+            | None -> error ~code:"E1608" "The response value is missing."
+          in
+          let* value =
+            decode_boundary_value
+              ~budget:(create_boundary_budget session.limits)
+              ~constructor_info:(constructor_info session.checker)
+              value
+          in
+          let* () = validate_argument_value session.checker ~expected:binding.result value in
+          Ok (Success value)
+      | "effect_failure" ->
+          let* () = exact_fields ([ "category"; "completion"; "message" ] @ common) fields in
+          let* category = string "category" in
+          let* completion = string "completion" in
+          let* message = string "message" in
+          if String.length message > session.limits.max_host_message_bytes then
+            error ~code:"E1602" "The host message exceeds max_host_message_bytes."
+          else
+            let* code, terminal =
+              match (category, completion) with
+              | "unsupported_operation", "not_started" -> Ok ("E1606", "host_failure")
+              | "refused_authority", "not_started" -> Ok ("E1607", "host_failure")
+              | "outside_failure", "failed" -> Ok ("E1613", "host_failure")
+              | "completion_unknown", "unknown" -> Ok ("E1612", "completion_unknown")
+              | _ -> error ~code:"E1608" "The host failure category/completion pair is invalid."
+            in
+            Ok
+              (Stop
+                 ( category,
+                   completion,
+                   terminal,
+                   diagnostic ~code ("The host reported an outside failure. Host detail: " ^ message)
+                 ))
+      | "cancel" ->
+          let* () = exact_fields ([ "reason"; "completion" ] @ common) fields in
+          let* reason = string "reason" in
+          let* completion = string "completion" in
+          let* code =
+            match reason with
+            | "cancelled" -> Ok "E1614"
+            | "timeout" -> Ok "E1609"
+            | "host_shutdown" -> Ok "E1610"
+            | _ -> error ~code:"E1608" "The cancellation reason is invalid."
+          in
+          let* code, terminal =
+            match completion with
+            | "unknown" -> Ok ("E1612", "completion_unknown")
+            | "not_started" | "failed" -> Ok (code, "cancelled")
+            | _ -> error ~code:"E1608" "The cancellation completion is invalid."
+          in
+          Ok
+            (Stop
+               ( reason,
+                 completion,
+                 terminal,
+                 diagnostic ~code "The host ended the response slot without a successful value." ))
+      | _ -> error ~code:"E1608" "The message is not a response or cancellation."
+
+  let respond session json =
+    match session.phase with
+    | Closed -> closed ()
+    | Running -> violation session
+    | Waiting (binding, ordinal) -> (
+        match parse_response session binding ordinal json with
+        | Error diagnostics ->
+            let diagnostics =
+              if List.exists (fun d -> Diag.code d = Some "E1602") diagnostics then diagnostics
+              else
+                [
+                  diagnostic ~code:"E1608"
+                    "The host response is malformed or disagrees with its checked result type.";
+                ]
+            in
+            abort session diagnostics
+        | Ok (Success value) ->
+            session.observations <- observation ordinal "ok" "completed" :: session.observations;
+            session.phase <- Running;
+            Ok (Resume value)
+        | Ok (Stop (category, completion, terminal, diagnostic)) ->
+            session.observations <- observation ordinal category completion :: session.observations;
+            finish_error session ~terminal [ diagnostic ])
+end

--- a/src/host_protocol_v0.mli
+++ b/src/host_protocol_v0.mli
@@ -2,8 +2,8 @@
 
     This module implements transport framing, structural JSON checks, limit negotiation, the
     selected shutdown envelope, the frozen first-order type/value descriptors, and preflight for one
-    exact checked invocation. It does not evaluate code, dispatch host operations, or expose a
-    runnable worker. *)
+    exact checked invocation. Session implements serial request/response and terminal accounting.
+    The module does not evaluate code, dispatch host operations, or expose a runnable worker. *)
 
 val protocol : string
 (** The one protocol version accepted by this codec. *)
@@ -135,3 +135,52 @@ val read_frame : limits:limits -> in_channel -> (Yojson.Safe.t, Diag.t list) res
 val write_frame : limits:limits -> out_channel -> Yojson.Safe.t -> (unit, Diag.t list) result
 (** [write_frame ~limits output json] writes and flushes one complete frame. Encoding failures
     retain E1601/E1602; an output or flush failure returns E1611. *)
+
+(** Serial invocation accounting without evaluator continuations or carrier I/O. Keep the
+    checker/store stable for a session's lifetime. The caller owns writes, flushes, continuation
+    resume/drop, descriptor release, and carrier loss. Actions are committed when returned and must
+    never be retried. *)
+module Session : sig
+  type t
+  type action = Request of Yojson.Safe.t | Resume of Value.t | Finished of Yojson.Safe.t
+
+  val start : limits:limits -> checker:Check.ctx -> Yojson.Safe.t -> (t, Diag.t list) result
+  (** Validate selected limits and full invoke preflight, then reserve a bounded error outcome
+      before accepting the invocation. Returns the preflight diagnostics or E1602 if terminal
+      evidence cannot fit; never evaluates. *)
+
+  val call : t -> Hash.t * Value.t list
+  (** The checked target and positional arguments for the caller's isolated evaluator. *)
+
+  val request : t -> operation:Hash.t -> arguments:Value.t list -> (action, Diag.t list) result
+  (** In the running state, validate the configured operation and actual values, reserve terminal
+      capacity, and return one [Request]. Missing operations finish with E1606, mismatched values
+      with E1603/E1604, limits with E1602. A second request while waiting finishes with E1608. No
+      refused request enters evidence. The caller retains exactly one continuation. *)
+
+  val respond : t -> Yojson.Safe.t -> (action, Diag.t list) result
+  (** Consume one matching response slot. [Resume] carries a type-checked value exactly once; the
+      caller may then resume its captured continuation. Failure/cancellation returns [Finished] with
+      the frozen terminal mapping; the caller must drop the continuation. Rejected messages finish
+      with E1608 (E1602 for a selected limit) and are not accepted observations. *)
+
+  val finish : t -> Value.t -> (action, Diag.t list) result
+  (** Validate the actual invocation result and return one bounded [Finished]. Wrong
+      types/unsupported values yield E1603/E1604, capacity failures E1602, and attempting to finish
+      while waiting E1608. Result and evidence share the frame's boundary-node budget. *)
+
+  val abort : t -> Diag.t list -> (action, Diag.t list) result
+  (** End a live invocation with its structured runtime diagnostics. Empty or oversized diagnostics
+      become the fixed E1602 fallback. Carrier loss can prevent writing this action; do not
+      fabricate a delivered terminal. *)
+
+  val fatal : limits:limits -> Diag.t list -> (Yojson.Safe.t, Diag.t list) result
+  (** Encode a pre-invocation fatal with bounded diagnostics. Oversized or empty diagnostics become
+      E1602; returns Error if even the fallback cannot fit. Use negotiated limits after selection
+      and hard limits before selection. *)
+
+  (** All state-changing calls after [Finished] return Error E1608, never a second terminal. Every
+      returned frame obeys selected structural and byte limits. If full diagnostics cannot fit, a
+      fixed E1602 diagnostic replaces them while retaining accepted observations and terminal
+      classification. *)
+end

--- a/test/dune
+++ b/test/dune
@@ -149,11 +149,22 @@
  (modules host_invoke_preflight_focused)
  (libraries host_invoke_preflight_test_support alcotest))
 
+(library
+ (name host_session_test_support)
+ (wrapped false)
+ (modules test_host_session)
+ (libraries jacquard host_invoke_preflight_test_support alcotest unix yojson))
+
+(executable
+ (name host_session_focused)
+ (modules host_session_focused)
+ (libraries host_session_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused))
- (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused test_host_session host_session_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support host_session_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)

--- a/test/host_session_focused.ml
+++ b/test/host_session_focused.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "jacquard-host-session" [ ("host-session", Test_host_session.suite) ]

--- a/test/test_host_session.ml
+++ b/test/test_host_session.ml
@@ -1,0 +1,508 @@
+open Jacquard
+module Host = Host_protocol_v0
+module Session = Host.Session
+module P = Test_host_invoke_preflight
+open P
+
+let get name json = Yojson.Safe.Util.member name json
+let text json = Yojson.Safe.Util.to_string json
+let items json = Yojson.Safe.Util.to_list json
+
+let check_json label expected actual =
+  Alcotest.(check string) label (Yojson.Safe.to_string expected) (Yojson.Safe.to_string actual)
+
+let fixture () = Lazy.force P.fixture
+
+let entry f =
+  operation_json ~effect_identity:f.world_effect ~mode:"once" ~operation:f.send_operation
+
+let start ?(limits = Host.hard_limits) () =
+  let f = fixture () in
+  expect_ok "start"
+    (Session.start ~limits ~checker:f.checker (effectful_invoke ~operations:[ entry f ] f))
+
+let request session =
+  Session.request session ~operation:(fixture ()).send_operation
+    ~arguments:[ Value.VInt 2; Value.VText "private argument" ]
+
+let pending ?(limits = Host.hard_limits) () =
+  let session = start ~limits () in
+  (match expect_ok "request" (request session) with
+  | Session.Request _ -> ()
+  | _ -> Alcotest.fail "expected a request");
+  session
+
+let response ?(ordinal = 1) kind fields =
+  `Assoc
+    ([
+       ("invocation_id", `String "0000000000000000");
+       ("kind", `String kind);
+       ("protocol", `String Host.protocol);
+       ("request_id", `String (Printf.sprintf "%016x" ordinal));
+     ]
+    @ fields)
+
+let success ?ordinal value = response ?ordinal "effect_ok" [ ("value", encode_value value) ]
+
+let finished result =
+  match expect_ok "terminal action" result with
+  | Session.Finished json -> json
+  | _ -> Alcotest.fail "expected one terminal"
+
+let core json = get "core" (get "evidence" json)
+let observations json = get "responses" (get "host_observations" (get "evidence" json)) |> items
+let requests json = get "effect_requests" (core json) |> items
+let diagnostics json = get "diagnostics" (get "result" json) |> items
+
+let check_code code json =
+  Alcotest.(check string)
+    "terminal diagnostic" code
+    (text (get "code" (List.hd (diagnostics json))))
+
+let check_terminal expected json =
+  Alcotest.(check string) "terminal classification" expected (text (get "terminal" (core json)))
+
+let check_closed session =
+  expect_code "finish after terminal" "E1608" (Session.finish session (Value.VText "later"));
+  expect_code "request after terminal" "E1608" (request session);
+  expect_code "response after terminal" "E1608"
+    (Session.respond session (success (Value.VText "later")));
+  expect_code "abort after terminal" "E1608" (Session.abort session [])
+
+let test_pure () =
+  let f = fixture () in
+  let invoke = pure_invoke f in
+  let session =
+    expect_ok "pure start" (Session.start ~limits:Host.hard_limits ~checker:f.checker invoke)
+  in
+  let target, args = Session.call session in
+  Alcotest.(check bool) "checked target" true (Hash.equal target f.pure_target);
+  Alcotest.(check int) "arguments" 2 (List.length args);
+  let json = finished (Session.finish session (Value.VText "private result")) in
+  check_terminal "ok" json;
+  List.iter
+    (fun name -> check_json name (get name invoke) (get name (core json)))
+    [ "target"; "interface"; "capabilities" ];
+  check_json "result"
+    (encode_value (Value.VText "private result"))
+    (get "value" (get "result" json));
+  check_json "no requests" (`List []) (get "effect_requests" (core json));
+  Alcotest.(check int) "no observations" 0 (List.length (observations json));
+  let core_fields = match core json with `Assoc fields -> List.map fst fields | _ -> [] in
+  Alcotest.(check (list string))
+    "exact evidence fields"
+    [
+      "capabilities";
+      "effect_requests";
+      "interface";
+      "invocation_id";
+      "schema";
+      "target";
+      "terminal";
+    ]
+    core_fields;
+  check_closed session
+
+let test_exchange () =
+  let session = start () in
+  for ordinal = 1 to 3 do
+    let json =
+      match expect_ok "request" (request session) with
+      | Session.Request json -> json
+      | _ -> Alcotest.fail "no request"
+    in
+    check_json "request id" (`String (Printf.sprintf "%016x" ordinal)) (get "request_id" json);
+    check_json "request arguments"
+      (`List [ encode_value (Value.VInt 2); encode_value (Value.VText "private argument") ])
+      (get "arguments" json);
+    check_json "operation" (hash_json (fixture ()).send_operation) (get "operation" json);
+    match
+      expect_ok "accepted response"
+        (Session.respond session (success ~ordinal (Value.VText "private response")))
+    with
+    | Session.Resume (Value.VText value) ->
+        Alcotest.(check string) "typed resume" "private response" value
+    | _ -> Alcotest.fail "no typed resume"
+  done;
+  let json = finished (Session.finish session (Value.VText "done")) in
+  Alcotest.(check int) "three requests" 3 (List.length (requests json));
+  Alcotest.(check int) "three responses" 3 (List.length (observations json));
+  List.iteri
+    (fun i obs ->
+      check_json "observation"
+        (`Assoc
+           [
+             ("category", `String "ok");
+             ("completion", `String "completed");
+             ("ordinal", `Int (i + 1));
+           ])
+        obs)
+    (observations json);
+  check_closed session
+
+let test_failure_mappings () =
+  List.iter
+    (fun (category, completion, code, terminal) ->
+      let session = pending () in
+      let message = "redacted é\nsecond line" in
+      let json =
+        finished
+          (Session.respond session
+             (response "effect_failure"
+                [
+                  ("category", `String category);
+                  ("completion", `String completion);
+                  ("message", `String message);
+                ]))
+      in
+      check_code code json;
+      check_terminal terminal json;
+      let cause = text (get "cause" (List.hd (diagnostics json))) in
+      Alcotest.(check bool) "exact host message suffix" true (Filename.check_suffix cause message);
+      check_json "accepted observation"
+        (`Assoc
+           [
+             ("category", `String category); ("completion", `String completion); ("ordinal", `Int 1);
+           ])
+        (List.hd (observations json));
+      check_closed session)
+    [
+      ("unsupported_operation", "not_started", "E1606", "host_failure");
+      ("refused_authority", "not_started", "E1607", "host_failure");
+      ("outside_failure", "failed", "E1613", "host_failure");
+      ("completion_unknown", "unknown", "E1612", "completion_unknown");
+    ]
+
+let test_cancellation_mappings () =
+  List.iter
+    (fun (reason, known_code) ->
+      List.iter
+        (fun completion ->
+          let session = pending () in
+          let json =
+            finished
+              (Session.respond session
+                 (response "cancel"
+                    [ ("reason", `String reason); ("completion", `String completion) ]))
+          in
+          check_code (if completion = "unknown" then "E1612" else known_code) json;
+          check_terminal (if completion = "unknown" then "completion_unknown" else "cancelled") json;
+          check_json "cancel observation"
+            (`Assoc
+               [
+                 ("category", `String reason);
+                 ("completion", `String completion);
+                 ("ordinal", `Int 1);
+               ])
+            (List.hd (observations json));
+          check_closed session)
+        [ "not_started"; "failed"; "unknown" ])
+    [ ("cancelled", "E1614"); ("timeout", "E1609"); ("host_shutdown", "E1610") ]
+
+let test_rejected_responses () =
+  let valid = success (Value.VText "ok") in
+  let failure category completion =
+    response "effect_failure"
+      [
+        ("category", `String category);
+        ("completion", `String completion);
+        ("message", `String "detail");
+      ]
+  in
+  List.iter
+    (fun json ->
+      let session = pending () in
+      let terminal = finished (Session.respond session json) in
+      check_code "E1608" terminal;
+      Alcotest.(check int) "rejected response not observed" 0 (List.length (observations terminal));
+      Alcotest.(check int) "original request retained" 1 (List.length (requests terminal));
+      check_closed session)
+    [
+      replace_field "protocol" (`String "future") valid;
+      replace_field "request_id" (`String "0000000000000002") valid;
+      replace_field "request_id" (`String "1") valid;
+      replace_field "invocation_id" (`String "0000000000000001") valid;
+      append_field "extra" `Null valid;
+      append_field "kind" (`String "effect_ok") valid;
+      replace_field "value" (`Assoc [ ("kind", `String "unknown") ]) valid;
+      success (Value.VInt 1);
+      success (Value.VTuple []);
+      replace_field "value" (`Assoc [ ("kind", `String "text"); ("value", `String "\255") ]) valid;
+      replace_field "kind" (`String "shutdown") valid;
+      failure "outside_failure" "unknown";
+      failure "refused_authority" "failed";
+      response "cancel" [ ("reason", `String "bad"); ("completion", `String "unknown") ];
+      response "cancel" [ ("reason", `String "timeout"); ("completion", `String "completed") ];
+      `List [];
+      `Assoc [];
+    ]
+
+let test_state_violations () =
+  List.iter
+    (fun act ->
+      let session = pending () in
+      let json = finished (act session) in
+      check_code "E1608" json;
+      Alcotest.(check int) "only one request" 1 (List.length (requests json));
+      check_closed session)
+    [ request; (fun session -> Session.finish session (Value.VText "early")) ];
+  let session = start () in
+  check_code "E1608" (finished (Session.respond session (success (Value.VText "unsolicited"))));
+  let session = pending () in
+  ignore (expect_ok "first response" (Session.respond session (success (Value.VText "first"))));
+  check_code "E1608" (finished (Session.respond session (success (Value.VText "duplicate"))));
+  let session = pending () in
+  ignore (expect_ok "first response" (Session.respond session (success (Value.VText "first"))));
+  ignore (expect_ok "next request" (request session));
+  let json = finished (Session.respond session (success (Value.VText "stale"))) in
+  check_code "E1608" json;
+  Alcotest.(check int) "only prior response observed" 1 (List.length (observations json))
+
+let test_outgoing_types () =
+  let f = fixture () in
+  let session =
+    expect_ok "empty registry"
+      (Session.start ~limits:Host.hard_limits ~checker:f.checker (effectful_invoke f))
+  in
+  let json = finished (request session) in
+  check_code "E1606" json;
+  Alcotest.(check int) "no request emitted" 0 (List.length (requests json));
+  List.iter
+    (fun arguments ->
+      let session = start () in
+      let json = finished (Session.request session ~operation:f.send_operation ~arguments) in
+      check_code "E1603" json;
+      Alcotest.(check int) "bad arguments not emitted" 0 (List.length (requests json)))
+    [ []; [ Value.VText "wrong"; Value.VText "body" ] ];
+  check_code "E1603" (finished (Session.finish (start ()) (Value.VInt 7)));
+  let opaque =
+    Value.VCode (expect_ok "quoted fixture" (Reader.parse_one ~file:"fixture" "(lit 7)"))
+  in
+  check_code "E1604" (finished (Session.finish (start ()) opaque));
+  check_code "E1604"
+    (finished
+       (Session.request (start ()) ~operation:f.send_operation ~arguments:[ Value.VInt 2; opaque ]))
+
+let test_request_limit () =
+  let limits = { Host.hard_limits with max_effect_requests = 1 } in
+  let session = pending ~limits () in
+  ignore (expect_ok "first response" (Session.respond session (success (Value.VText "first"))));
+  let json = finished (request session) in
+  check_code "E1602" json;
+  Alcotest.(check int) "limit stops second request" 1 (List.length (requests json));
+  Alcotest.(check int) "accepted observation retained" 1 (List.length (observations json))
+
+let test_response_limits () =
+  List.iter
+    (fun (limits, message) ->
+      let session = pending ~limits () in
+      let json = finished (Session.respond session message) in
+      check_code "E1602" json;
+      Alcotest.(check int) "over-limit response not observed" 0 (List.length (observations json)))
+    [
+      ({ Host.hard_limits with max_text_bytes = 16 }, success (Value.VText (String.make 17 'x')));
+      ( { Host.hard_limits with max_host_message_bytes = 3 },
+        response "effect_failure"
+          [
+            ("category", `String "outside_failure");
+            ("completion", `String "failed");
+            ("message", `String "éé");
+          ] );
+    ]
+
+let test_terminal_reservation () =
+  let limits = { Host.hard_limits with max_frame_bytes = 1000 } in
+  let f = fixture () in
+  ignore
+    (expect_ok "selection fits fatal"
+       (Host.parse_host_select
+          (`Assoc
+             [
+               ("kind", `String "host_select");
+               ("protocol", `String Host.protocol);
+               ("limits", Host.limits_to_yojson limits);
+             ])));
+  expect_code "evidence cannot fit" "E1602"
+    (Session.start ~limits ~checker:f.checker (effectful_invoke ~operations:[ entry f ] f));
+  (* A growing transcript is stopped before its next request, retaining the
+     previous successful observations and enough room for the refusal. *)
+  let limits = { Host.hard_limits with max_frame_bytes = 3000 } in
+  let session = start ~limits () in
+  let rec loop ordinal =
+    if ordinal > 20 then Alcotest.fail "evidence limit never reached";
+    match expect_ok "bounded request" (request session) with
+    | Session.Request _ ->
+        ignore
+          (expect_ok "response" (Session.respond session (success ~ordinal (Value.VText "ok"))));
+        loop (ordinal + 1)
+    | Session.Finished json ->
+        check_code "E1602" json;
+        Alcotest.(check int) "refused ordinal absent" (ordinal - 1) (List.length (requests json));
+        Alcotest.(check int) "observations retained" (ordinal - 1) (List.length (observations json));
+        ignore (expect_ok "terminal fits" (Host.encode_frame_bytes ~limits json))
+    | _ -> Alcotest.fail "request returned Resume"
+  in
+  loop 1
+
+let test_diagnostic_budget () =
+  let limits = { Host.hard_limits with max_diagnostic_bytes = 500 } in
+  let session = pending ~limits () in
+  let json =
+    finished
+      (Session.respond session
+         (response "effect_failure"
+            [
+              ("category", `String "completion_unknown");
+              ("completion", `String "unknown");
+              ("message", `String (String.make 600 'x'));
+            ]))
+  in
+  check_code "E1602" json;
+  check_terminal "completion_unknown" json;
+  Alcotest.(check int) "accepted ambiguity retained" 1 (List.length (observations json));
+  let diagnostic =
+    Diag.error ~domain:Runtime ~code:"E0001" ~summary:"Runtime failure." ~cause:"detail"
+      ~next_step:"Inspect the computation." ~contrast:None ()
+  in
+  let json = finished (Session.abort (start ()) [ diagnostic ]) in
+  check_json "diagnostic preserved" (Diag.to_yojson diagnostic) (List.hd (diagnostics json));
+  let json = finished (Session.abort (start ()) []) in
+  check_code "E1602" json;
+  let fatal = expect_ok "bounded fatal" (Session.fatal ~limits []) in
+  Alcotest.(check string) "fatal kind" "fatal" (text (get "kind" fatal));
+  Alcotest.(check string)
+    "fatal fallback" "E1602"
+    (text (get "code" (List.hd (items (get "diagnostics" fatal)))));
+  expect_code "cannot fit even fatal" "E1602"
+    (Session.fatal ~limits:{ limits with max_frame_bytes = 1 } [ diagnostic ])
+
+let test_shared_node_budget () =
+  let f = fixture () in
+  let stored =
+    put_src f.store
+      "(defterm ((binding boundary.session-pure ((tarrow () (row) (tref text))) (lam () (lit \
+       \"ok\")))))"
+  in
+  let invoke =
+    invoke_json
+      ~target:(named "boundary.session-pure" stored)
+      ~parameters:[] ~effects:[] ~result:(text_type f) ~arguments:[] ~operations:[]
+  in
+  let start nodes =
+    expect_ok "minimal invocation"
+      (Session.start
+         ~limits:{ Host.hard_limits with max_value_nodes = nodes }
+         ~checker:f.checker invoke)
+  in
+  (* One interface descriptor fits preflight/failure; a success needs its own
+     value node in addition to the repeated interface descriptor. *)
+  check_code "E1602" (finished (Session.finish (start 1) (Value.VText "ok")));
+  check_terminal "ok" (finished (Session.finish (start 2) (Value.VText "ok")))
+
+let test_nominal_fields () =
+  let f = fixture () in
+  let effect_hashes =
+    put_src f.store
+      "(defeffect boundary.session-packet () (op boundary.exchange once ((tapp (tref \
+       boundary-packet) (tref int))) (tapp (tref boundary-packet) (tref int))))"
+  in
+  let target =
+    put_src f.store
+      "(defterm ((binding boundary.packet-call ((tarrow ((tapp (tref boundary-packet) (tref int))) \
+       (row (eref boundary.session-packet)) (tapp (tref boundary-packet) (tref int)))) (lam ((pvar \
+       value)) (app (var boundary.exchange) (var value))))))"
+  in
+  let effect_identity = named "boundary.session-packet" effect_hashes in
+  let operation = named "boundary.exchange" effect_hashes in
+  let packet value =
+    Value.VCon
+      { con = f.packet_constructor; name = "ignored"; args = [ value; Value.VText "body" ] }
+  in
+  let valid = packet (Value.VInt 4) in
+  let invoke =
+    invoke_json
+      ~target:(named "boundary.packet-call" target)
+      ~parameters:[ packet_int f ]
+      ~effects:[ effect_identity ] ~result:(packet_int f) ~arguments:[ valid ]
+      ~operations:[ operation_json ~effect_identity ~operation ~mode:"once" ]
+  in
+  let start () =
+    expect_ok "nominal session" (Session.start ~limits:Host.hard_limits ~checker:f.checker invoke)
+  in
+  let pending () =
+    let session = start () in
+    ignore (expect_ok "nominal request" (Session.request session ~operation ~arguments:[ valid ]));
+    session
+  in
+  let session = pending () in
+  (match expect_ok "nominal response" (Session.respond session (success valid)) with
+  | Session.Resume value -> check_json "lossless nominal" (encode_value valid) (encode_value value)
+  | _ -> Alcotest.fail "missing nominal resume");
+  check_terminal "ok" (finished (Session.finish session valid));
+  check_code "E1608"
+    (finished (Session.respond (pending ()) (success (packet (Value.VText "wrong field")))));
+  check_code "E1603"
+    (finished
+       (Session.request (start ()) ~operation ~arguments:[ packet (Value.VText "wrong field") ]));
+  check_code "E1603" (finished (Session.finish (start ()) (packet (Value.VText "wrong field"))))
+
+let rec string_bytes = function
+  | `String s -> String.length s
+  | `Assoc fields -> List.fold_left (fun n (_, v) -> n + string_bytes v) 0 fields
+  | `List values -> List.fold_left (fun n v -> n + string_bytes v) 0 values
+  | _ -> 0
+
+let test_exact_diagnostic_bytes () =
+  let cause = String.concat "" (List.init 300 (fun _ -> "é")) in
+  let contrast =
+    Diag.contrast ~mistaken:"Supposed a result was available." ~intended:"The computation failed."
+  in
+  let diagnostic =
+    Diag.error ~domain:Runtime ~code:"E0001" ~summary:"Runtime failure." ~cause
+      ~next_step:"Inspect the computation." ~contrast:(Some contrast) ()
+  in
+  let bytes = string_bytes (Diag.to_yojson diagnostic) in
+  let limits = { Host.hard_limits with max_diagnostic_bytes = bytes } in
+  let exact = finished (Session.abort (start ~limits ()) [ diagnostic ]) in
+  check_json "all UTF-8 diagnostic strings fit exactly" (Diag.to_yojson diagnostic)
+    (List.hd (diagnostics exact));
+  let smaller = { limits with max_diagnostic_bytes = bytes - 1 } in
+  check_code "E1602" (finished (Session.abort (start ~limits:smaller ()) [ diagnostic ]));
+  let count = { Host.hard_limits with max_diagnostics = 1 } in
+  check_code "E1602" (finished (Session.abort (start ~limits:count ()) [ diagnostic; diagnostic ]))
+
+let test_preflight_terminal_capacity () =
+  let f = fixture () in
+  let invoke = effectful_invoke ~operations:[ entry f ] f in
+  let minimal = finished (Session.abort (start ()) []) in
+  (* Reservation uses the longest terminal label (18 bytes), eight bytes
+     longer than this diagnostic terminal. Fail on precisely its final byte. *)
+  let bytes = String.length (Yojson.Safe.to_string minimal) + 8 in
+  let limits = { Host.hard_limits with max_frame_bytes = bytes - 1 } in
+  ignore (expect_ok "invoke itself fits" (Host.encode_frame_bytes ~limits invoke));
+  ignore (expect_ok "checked invoke fits" (Host.parse_invoke ~limits ~checker:f.checker invoke));
+  expect_code "terminal cannot fit" "E1602" (Session.start ~limits ~checker:f.checker invoke);
+  ignore
+    (expect_ok "terminal exact capacity"
+       (Session.start ~limits:{ limits with max_frame_bytes = bytes } ~checker:f.checker invoke))
+
+let suite =
+  List.map
+    (fun (label, test) -> Alcotest.test_case label `Quick test)
+    [
+      ("pure result and exact evidence", test_pure);
+      ("nominal fields in both directions", test_nominal_fields);
+      ("exact UTF-8 diagnostic accounting", test_exact_diagnostic_bytes);
+      ("invoke fits but terminal does not", test_preflight_terminal_capacity);
+      ("serial typed exchange", test_exchange);
+      ("four host failure mappings", test_failure_mappings);
+      ("nine cancellation mappings", test_cancellation_mappings);
+      ("rejected responses have no observation", test_rejected_responses);
+      ("state violations and stale replies", test_state_violations);
+      ("outgoing type and registry checks", test_outgoing_types);
+      ("cumulative request limit", test_request_limit);
+      ("decoded response byte limits", test_response_limits);
+      ("reserve growing terminal evidence", test_terminal_reservation);
+      ("bounded diagnostics preserve ambiguity", test_diagnostic_budget);
+      ("result shares evidence node budget", test_shared_node_budget);
+    ]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -27,6 +27,7 @@ let () =
       ("host-protocol-codec", Test_host_protocol_codec.suite);
       ("host-boundary-codec", Test_host_boundary_codec.suite);
       ("host-invoke-preflight", Test_host_invoke_preflight.suite);
+      ("host-session", Test_host_session.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Context

The host protocol already has strict framing, typed value codecs, and checked
invocation preflight. The serial worker also needs to decide which response
may resume a computation, when a failure ends it, and how much evidence it
can promise to return. Those decisions were specified but had no executable
session layer.

For example, a host reply must match the current request and its declared
result type. A stale reply must not resume a newer continuation. Similarly,
a request must be refused before it reaches the host if adding its evidence
would leave too little room for the required terminal outcome.

## What changed

`Host_protocol_v0.Session` now implements that accounting over an abstract
mutable session:

- validates the invocation and reserves an error outcome before accepting it;
- returns one configured, typed request and waits for its matching response;
- returns a validated value to resume with, or one terminal outcome for a
  failure, cancellation, invalid response, or completed computation;
- preserves all four host-failure and nine cancellation mappings, including
  unknown-completion precedence;
- reserves growing terminal evidence before each request and shares the
  outcome's node budget between the repeated interface and actual result;
- records only accepted host observations and returns E1608 after closure,
  without producing another terminal frame.

When a diagnostic cannot fit, a fixed E1602 fallback retains the accepted
observations and terminal classification. An unknown outside completion
therefore remains visible even when its detailed host message is too large.
Arguments, results, and host messages stay outside the evidence sections.

## Integration boundary

This is the library state machine needed by the opt-in process worker.
The worker and evaluator loop remain to be implemented. The caller owns
continuation resume/drop, writes and flushes, channel closure, and carrier-loss
reporting. Returned actions are committed and must not be retried.

The change is additive to the frozen v0 protocol. The checker, evaluator,
native runtime, scheduler, kernel forms, and canonical identities retain their
existing behavior. The ownership contract is in `docs/host-session-v0.md`.

## Validation and review

- Full `dune build @all @doc`, `dune runtest`, formatting, and version smoke:
  pass on the final head. The suite ran 984 unit/property cases in 468 seconds,
  with 60 cram transcripts and 28 documentation examples.
- All 15 focused session cases pass, including nested nominal fields in both
  directions, all terminal mappings, stale/duplicate replies, exact UTF-8
  diagnostic limits, growing evidence, and an invocation that fits while its
  terminal does not. The independent reviewer also ran these 15 cases.
- Documentation links and whitespace checks pass. Historical manifests are
  unchanged. Prior governance/browser and 50,000-case forwarding evidence
  remains applicable to unchanged semantic inputs; required CI will still
  rerun those protected contexts before merge.

A fresh independent Codex reviewer returned **PASS** on the exact head below,
with no blockers or material unresolved decisions. The remaining worker
integration obligations are documented above; this review does not claim
executable worker conformance.

Base: `7e10c53e5127af7e784136944a52180cbd761e30`  
Reviewed head: `a00655b68274208fb12e5db3fe6c272492e5f33a`
