### PR TITLE
HB.2c: add the opt-in serial host worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,11 @@ When adding valid corpus files, regenerate the golden hashes with
   `test/test_host_protocol_codec.ml`, `test/test_host_boundary_codec.ml`,
   `test/test_host_invoke_preflight.ml`. Serial session actions and terminal
   accounting: `Host_protocol_v0.Session`, `test/test_host_session.ml`, and
-  `docs/host-session-v0.md`. No runnable worker ships yet. Existing
-  evaluator capture and host-readiness modules are internal seams, not a public
-  ABI; adapters and application servers belong outside this repository.
+  `docs/host-session-v0.md`. The opt-in serial carrier `jac host worker`:
+  `src/host_worker.ml`, `test/test_host_worker.ml`, `test/cli/host-worker.t`,
+  and `docs/host-worker-v0.md`. Existing evaluator capture and host-readiness
+  modules are internal seams, not a public ABI; adapters and application
+  servers belong outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,
   `src/infer_dist.ml`, `test/test_infer.ml`.
 - Warp: `prelude/15-warp.jqd`, `prelude/16-gen.jqd`, `src/warp.ml`,

--- a/README.md
+++ b/README.md
@@ -408,7 +408,13 @@ jac governance verify-run RUN_BUNDLE.jqd
 jac governance reconcile RECONCILIATION_BUNDLE.jqd
 jac governance explain PROPOSAL_ID --bundle RECONCILIATION_BUNDLE.jqd [--output-format text|json-v1]
 jac why-effect EFFECT --source FILE.jac [--output-format text|json-v1]
+jac host worker --store DIR
 ```
+
+`jac host worker` is the opt-in serial carrier for the experimental
+`jacquard-host-v0` protocol: a trusted host process invokes one checked stored
+term and answers its typed root operations over length-prefixed JSON frames on
+stdin/stdout (`docs/host-worker-v0.md`). Ordinary commands never use it.
 
 `.jac` is the source format people and agents write. `.jqd` is the lower-level
 format that `.jac` files reduce to — a small fixed grammar of 27 forms, called
@@ -600,9 +606,11 @@ Key release docs:
 - `src/infer_dist.ml`: exact enumeration and likelihood weighting.
 - `src/diff.ml`: canonical-structure diff over stores.
 - `src/warp.ml`: Warp test discovery, running, cache, and properties.
-- `src/host_protocol_v0.ml`: strict library-only framing, JSON, limit-selection,
-  shutdown, and bounded first-order type/value codecs for the experimental host
-  protocol; no worker entry point.
+- `src/host_protocol_v0.ml`: strict framing, JSON, limit-selection, shutdown,
+  bounded first-order type/value codecs, invoke preflight, and serial session
+  accounting for the experimental host protocol.
+- `src/host_worker.ml`: the opt-in `jac host worker` process carrier that
+  evaluates one preflighted invocation over stdin/stdout frames.
 
 ## Documentation Map
 
@@ -721,9 +729,9 @@ proofs also do not ship. World grants remain coarse. See
 `docs/release/structured-concurrency/LIMITS.md` for the successor C0-C3 boundary.
 `docs/host-boundary.md` freezes the ownership and trust model, and
 `spec/host-protocol-v0.md` freezes the experimental language-neutral envelopes,
-process framing, limits, and schema/state vectors. Core can preflight one exact
-invoke envelope against a prepared checker, but no executable host carrier,
-stable ABI, adapter, or HTTP server ships in this repository today.
+process framing, limits, and schema/state vectors. `jac host worker` is the
+experimental serial carrier for that protocol; no stable ABI, adapter,
+cross-language conformance kit, or HTTP server ships in this repository today.
 The deterministic Workspace v0 governance boundary is separately advertised
 as an evidence-backed research reference implementation, not as a sandbox or
 production security system; its exact claim and trusted-host limits are in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2986,6 +2986,24 @@ let build_cmd file out prelude dry_run syntax =
                         | Error (`Toolchain m) -> print_diags [ cli_diagnostic ~code:"E1103" m ]))))
         )
 
+(* --- host worker (HB.2c) --- *)
+
+let host_worker_cmd store_dir =
+  if not (Sys.file_exists store_dir && Sys.is_directory store_dir) then
+    print_diags
+      [ cli_diagnostic ~code:"E0606" (Printf.sprintf "store %s does not exist" store_dir) ]
+  else
+    match Store.open_store store_dir with
+    | Error ds -> print_diags ds
+    | Ok store -> (
+        match Host_worker.prepare store with
+        | Error ds -> print_diags ds
+        | Ok prepared ->
+            set_binary_mode_in stdin true;
+            set_binary_mode_out stdout true;
+            Host_worker.exit_code
+              (Host_worker.serve prepared ~input:stdin ~output:stdout ~operator:stderr))
+
 let out_arg =
   Arg.(required & opt (some string) None & info [ "o"; "output" ] ~docv:"OUT" ~doc:"Output path.")
 
@@ -3020,6 +3038,29 @@ let tiers_t =
     Term.(
       const (configure_diagnostics tiers_cmd) $ diagnostic_format_arg $ test_files_arg $ prelude_arg)
 
+let host_t =
+  let worker =
+    Cmd.v
+      (Cmd.info "worker"
+         ~doc:
+           "Serve one opt-in jacquard-host-v0 invocation over the stdio-u32-json-v0 carrier \
+            against a host-selected store. Frames use stdin/stdout; stderr is bounded operator \
+            text. Ordinary run, check, and build never use this protocol.")
+      Term.(
+        const (configure_diagnostics host_worker_cmd)
+        $ diagnostic_format_arg
+        $ Arg.(
+            required
+            & opt (some string) None
+            & info [ "store" ] ~docv:"DIR"
+                ~doc:
+                  "Existing local store holding the target and its complete closure. The prelude \
+                   is not reloaded."))
+  in
+  Cmd.group
+    (Cmd.info "host" ~doc:"Opt-in host carriers for invoking checked Jacquard from another process.")
+    [ worker ]
+
 let main =
   Cmd.group
     (Cmd.info "jacquard" ~version:Version.version ~doc:"The Jacquard language toolchain")
@@ -3041,6 +3082,7 @@ let main =
       tiers_t;
       export_t;
       build_t;
+      host_t;
     ]
 
 let render_selected_diagnostic diagnostic =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2988,6 +2988,16 @@ let build_cmd file out prelude dry_run syntax =
 
 (* --- host worker (HB.2c) --- *)
 
+let discard_standard_output () =
+  match Unix.openfile Filename.null [ Unix.O_WRONLY ] 0 with
+  | null when null = Unix.stdout ->
+      (* descriptor 1 was closed and the null device now occupies it: keep it *)
+      ()
+  | null -> (
+      (try Unix.dup2 null Unix.stdout with Unix.Unix_error _ -> ());
+      try Unix.close null with Unix.Unix_error _ -> ())
+  | exception Unix.Unix_error _ -> ()
+
 let host_worker_cmd store_dir =
   if not (Sys.file_exists store_dir && Sys.is_directory store_dir) then
     print_diags
@@ -3001,8 +3011,17 @@ let host_worker_cmd store_dir =
         | Ok prepared ->
             set_binary_mode_in stdin true;
             set_binary_mode_out stdout true;
-            Host_worker.exit_code
-              (Host_worker.serve prepared ~input:stdin ~output:stdout ~operator:stderr))
+            let status = Host_worker.serve prepared ~input:stdin ~output:stdout ~operator:stderr in
+            (match status with
+            | Host_worker.Carrier_lost ->
+                (* A frame that failed to reach the host must never be resent: point the process's
+                   standard output at the null device so exit-time flushes discard the bytes still
+                   buffered in the channel instead of retrying the carrier. *)
+                discard_standard_output ()
+            | Host_worker.Terminal_written | Host_worker.Protocol_failure
+            | Host_worker.Internal_failure ->
+                ());
+            Host_worker.exit_code status)
 
 let out_arg =
   Arg.(required & opt (some string) None & info [ "o"; "output" ] ~docv:"OUT" ~doc:"Output path.")

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,9 @@ project shape from file names alone.
   HB.2b1 implements bounded first-order type/value codecs. HB.2b2 additionally
   preflights exact stored targets, interfaces, typed arguments, effect grants,
   and closed once-operation registries. The [session layer](host-session-v0.md)
-  accounts for serial responses and terminal evidence; no runnable carrier ships yet.
+  accounts for serial responses and terminal evidence, and the
+  [HB.2c worker](host-worker-v0.md) is the opt-in `jacquard host worker`
+  process carrier. No cross-language conformance kit ships until HB.3.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -114,6 +114,7 @@ jac governance verify-log AUDIT_LOG.audit --head HASH
 jac governance verify-run RUN_BUNDLE.jqd
 jac governance reconcile RECONCILIATION_BUNDLE.jqd
 jac governance explain PROPOSAL_ID --bundle RECONCILIATION_BUNDLE.jqd
+jac host worker --store DIR
 jac why-effect Net --source WORKSPACE.jac --output-format json-v1
 
 # Native AOT accepts public surface input directly.
@@ -903,11 +904,12 @@ Do not invent new kernel forms for surface sugar.
   recreating framing or value semantics. HB.2b2 also preflights one exact
   public stored term closure, closed monomorphic interface, typed positional
   arguments, exact effect grants, and sorted unique public `once` operation
-  registry. This returns a validated invocation but does not evaluate it. No
-  runnable worker, stable foreign-host ABI, adapter, or HTTP server ships yet.
-  `Host_protocol_v0.Session` now validates serial responses, accounts for
-  bounded evidence, and returns request/resume/terminal actions. See
-  `host-session-v0.md` for the caller-owned continuation and I/O obligations.
+  registry. `Host_protocol_v0.Session` validates serial responses, accounts
+  for bounded evidence, and returns request/resume/terminal actions
+  (`host-session-v0.md`). HB.2c ships `jac host worker --store DIR`, the
+  opt-in serial process carrier that evaluates one preflighted invocation over
+  stdin/stdout frames (`host-worker-v0.md`). No stable foreign-host ABI,
+  adapter, cross-language conformance kit, or HTTP server ships yet.
   Internal evaluator-capture and host-readiness OCaml APIs are not supported
   embedding contracts; future adapters must consume the versioned protocol and
   its executable conformance fixtures, not those OCaml seams.

--- a/docs/host-boundary.md
+++ b/docs/host-boundary.md
@@ -237,7 +237,10 @@ Core already contains useful internal pieces:
 
 These are implementation evidence, not a supported embedding surface. Their
 OCaml types may inform HB.1, but an adapter must not publish them as the
-language-neutral contract. In particular, `Host_readiness` installs no effect,
+language-neutral contract. The HB.2c [serial worker](host-worker-v0.md) is
+built on the same seams; its `jacquard host worker` command is the supported
+way to run the protocol, while `Host_worker.serve` itself remains an OCaml
+implementation detail rather than an embedding ABI. In particular, `Host_readiness` installs no effect,
 does not run a host scheduler, authenticates no trace, and promises no platform
 matrix.
 
@@ -270,7 +273,7 @@ headers are not smuggled into HB.0.
 |---|---|---|
 | First-party programs | safety for hostile uploaded Jacquard code | separate-process or equivalent isolation design, hostile resource tests, and reviewed threat model |
 | Trusted adapter and OS | protection from a lying host or broader OS credentials | independently enforced isolation/authentication plus external security review |
-| No runnable carrier yet | interoperability or embedding support | completion of the remaining HB.2 evaluator/lifecycle slices followed by HB.3 executable cross-language fixtures and evidence |
+| Experimental serial carrier without a published kit | interoperability or embedding support | HB.3 executable cross-language fixtures and evidence pinned by at least one independent adapter |
 | Experimental process carrier first | permanent ABI stability or low-overhead embedding | two independent adapters and one real integration pass the frozen fixtures before v1 |
 | One serial invocation | concurrent requests, streaming, or throughput | demonstrated need followed by the C4 scheduler contract and resource evidence |
 | No automatic side-effect retry | transparent recovery from ambiguous completion | per-operation idempotency, receipt, and crash/recovery contract |
@@ -292,7 +295,9 @@ concrete values, envelopes, framing, version negotiation, resource ceilings,
 failure schemas, and canonical positive/hostile schema/state vectors.
 
 HB.2 implements the opt-in serial carrier and interpreter seam without HTTP,
-SQLite, concurrency, or a new kernel form.
+SQLite, concurrency, or a new kernel form. HB.2a through HB.2c ship the
+codecs, the session accounting, and the `jacquard host worker` carrier
+described in [`host-worker-v0.md`](host-worker-v0.md).
 
 HB.3 publishes the language-neutral conformance kit and Core evidence. Only
 then does the external adapter start against a released pin.

--- a/docs/host-session-v0.md
+++ b/docs/host-session-v0.md
@@ -3,7 +3,8 @@
 `Host_protocol_v0.Session` implements the invocation state machine in the
 [frozen v0 protocol](../spec/host-protocol-v0.md). It builds on checked invoke
 preflight and the bounded type/value codecs. It is an OCaml library layer;
-the opt-in process worker and evaluator loop remain to be implemented.
+the opt-in process worker and evaluator loop that drive it are
+[`Host_worker`](host-worker-v0.md), exposed as `jacquard host worker`.
 
 A session starts only after the exact stored callable, complete reachable
 closure, pinned interface, arguments, grants, and operation registry pass
@@ -63,5 +64,6 @@ sections. Rejected responses are never recorded as accepted observations.
 `test/test_host_session.ml` covers both directions of typed nominal values,
 all four host-failure and nine cancellation mappings, state violations,
 strict response validation, growing evidence, and exact capacity boundaries.
-The worker's pipe, EOF, cancellation cleanup, descriptor, and ordinary-command
-compatibility evidence belongs to the remaining integration work.
+The worker's carrier loss, cancellation cleanup, descriptor ownership, exit
+statuses, and CLI transcript evidence live in `test/test_host_worker.ml` and
+`test/cli/host-worker.t`.

--- a/docs/host-worker-v0.md
+++ b/docs/host-worker-v0.md
@@ -63,6 +63,12 @@ conforming host rejects that send locally as E1608.
 | 70 | an internal Core invariant failed |
 | 74 | standard input or output was lost |
 
+The worker ignores `SIGPIPE` for its lifetime, so a host that closes its
+read end produces a structured carrier-loss result rather than a fatal
+signal. A frame that could not be written is never resent: before exiting
+74 the command points its standard output at the null device so exit-time
+channel flushes discard the buffered bytes instead of retrying the carrier.
+
 Carrier loss on standard input is reported as exit 74 even when standard
 output remained writable long enough to flush a best-effort frame. Before an
 invocation that frame is a `fatal` carrying E1611. While a response is
@@ -110,8 +116,9 @@ four host-failure and nine cancellation mappings, pre-invocation shutdown,
 preflight fatals for E1600 through E1605, unconfigured operations, stale and
 malformed responses, buffered post-terminal frames, runtime failures, raw
 framing defects, carrier loss before and during an invocation, the selected
-stderr ceiling, descriptor and channel ownership, prelude-less stores, and a
-property that doubling round-trips every bounded integer. `test/cli/host-worker.t`
+stderr ceiling, descriptor and channel ownership, prelude-less stores, a
+closed output pipe and a closed output descriptor through the installed
+binary, and a property that doubling round-trips every bounded integer. `test/cli/host-worker.t`
 pins the same exchanges through the installed `jacquard` binary, including the
 exit statuses. The HB.1 vector corpus remains the schema/state contract; its
 `noncanonical-target-hash` case names E1603 while the shipped preflight

--- a/docs/host-worker-v0.md
+++ b/docs/host-worker-v0.md
@@ -1,0 +1,119 @@
+# Serial host worker
+
+`jacquard host worker --store DIR` is the HB.2c opt-in process carrier for the
+[frozen v0 protocol](../spec/host-protocol-v0.md). It runs one
+`stdio-u32-json-v0` worker lifetime: one `core_hello`, one `host_select`, then
+either a pre-invocation `shutdown` or exactly one checked invocation whose
+root operations are exchanged with the trusted host in lockstep. The OCaml
+implementation is `Host_worker`, built on
+[`Host_protocol_v0.Session`](host-session-v0.md), the strict codecs, and the
+evaluator's sealed once-capture seam. Ordinary `jac run`, `jac check`,
+`jac build`, native artifacts, and the interpreted scheduler never use it.
+
+## Startup
+
+The host chooses a local store that already contains the prelude, the target
+term, and its complete reachable closure, typically by running
+`jacquard run DECLS.jac --store DIR` once. The worker reopens that store,
+wires builtin implementations, and seeds a checker with builtin signatures. It
+does not reload the prelude, installs no root handlers, grants no world
+effect, and reads no environment beyond the store path. A missing store fails
+with E0606 and an unpopulated store fails with the prelude's E0702 before any
+frame is written; both are startup configuration failures, not protocol
+evidence.
+
+Standard input carries host frames, standard output carries Core frames, and
+standard error carries bounded operator text. The worker owns none of the
+three descriptors and closes none of them.
+
+## Lifecycle
+
+| State | Event | Action | Next state |
+|---|---|---|---|
+| Start | process starts | write `core_hello` under the hard limits | Hello |
+| Hello | valid `host_select` | adopt the selected limits, including the lifetime stderr ceiling | Selected |
+| Hello | malformed, unsupported, or over-limit selection | one `fatal` under the hard limits | Exit 0 |
+| Selected | valid `shutdown` | one `shutdown_ack` | Exit 0 |
+| Selected | `invoke` passing preflight and terminal reservation | evaluate the checked target | Running |
+| Selected | any other frame | one `fatal` under the selected limits | Exit 0 |
+| Running | configured root operation with valid arguments | write one `effect_request`, retain one sealed once continuation | Waiting |
+| Running | unconfigured operation, invalid value, or exhausted capacity | one error `outcome`; no request leaves Core | Exit 0 |
+| Running | target returns | validate the value, one `outcome` | Exit 0 |
+| Running | runtime failure or evaluation stack exhaustion | one bounded diagnostic `outcome` | Exit 0 |
+| Waiting | matching typed `effect_ok` | resume the retained continuation exactly once | Running |
+| Waiting | valid `effect_failure` or `cancel` | drop the continuation, one `outcome` with the frozen terminal mapping | Exit 0 |
+| Waiting | invalid, stale, malformed, or over-limit frame | drop the continuation, one E1608 (or E1602) `outcome` | Exit 0 |
+| any | input ends or a read fails before a complete frame | best-effort E1611 `fatal` or `outcome`, then exit 74 | Exit 74 |
+| any | a write or flush fails | stop without retrying | Exit 74 |
+| any | no bounded fatal fits the negotiated limits | stop; nothing trustworthy was written | Exit 64 |
+| any | a Core invariant fails | stop; nothing further is written | Exit 70 |
+
+The worker reads host control only at these boundaries. It never preempts a
+pure computation, never creates a reader thread or event loop, never emits a
+second terminal frame, and never retries an invocation, request, or
+continuation. A buffered frame that arrives after the terminal is ignored; a
+conforming host rejects that send locally as E1608.
+
+## Exit statuses and carrier loss
+
+| Exit | Meaning |
+|---:|---|
+| 0 | one complete `outcome`, `fatal`, or `shutdown_ack` was flushed |
+| 64 | a protocol limit prevented any trustworthy terminal frame |
+| 70 | an internal Core invariant failed |
+| 74 | standard input or output was lost |
+
+Carrier loss on standard input is reported as exit 74 even when standard
+output remained writable long enough to flush a best-effort frame. Before an
+invocation that frame is a `fatal` carrying E1611. While a response is
+outstanding it is an error `outcome` with terminal `diagnostic`, E1611, the
+request order so far, and every already accepted host observation. That
+outcome tells the host which request had no answer; it does not classify the
+host's own outstanding outside action, and the host must not treat the
+missing response as a Core verdict about that action.
+
+## Operator output
+
+Standard error is never a protocol or evidence channel. The worker writes at
+most the hard `max_stderr_bytes` before selection and at most the selected
+value over the whole lifetime, counting bytes already written. Text that does
+not fit is cut at a UTF-8 scalar boundary, followed by a fixed truncation
+marker only when the marker also fits. Operator notes name the phase and the
+E16xx classification; they never echo frame payloads, argument values, or host
+messages.
+
+## Ownership and limits
+
+- The session owns request ordinals, response validation, terminal
+  classification, and bounded evidence. The worker owns the one retained
+  continuation, every write and flush, and the exit status.
+- Evaluation runs without root handlers, so every root operation the target
+  reaches goes through the closed configured registry or ends the invocation
+  with E1606. Interpreted Tasks, Channels, `eval`, `dist`, `infer`, and
+  `secret` operations have no v0 host encoding and cannot be configured.
+- The trusted host and operating system remain trusted (D78). The worker is
+  not a sandbox, does not isolate hostile code, enforces no path, host, port,
+  or database-row containment, and provides no deadline or memory ceiling of
+  its own. Process-level limits are host work.
+- One worker serves one invocation. Reusing a process for a second invocation
+  is a protocol error; hosts start a fresh worker instead.
+- The carrier is provisional v0 evidence (D79). No stable foreign-host ABI,
+  adapter, HTTP server, or cross-language conformance kit ships here; HB.3
+  publishes the executable fixtures that external adapters pin.
+
+## Evidence
+
+`test/test_host_worker.ml` drives the worker in-process over scripted input
+files against a store populated with the real prelude and then reopened
+without it. It covers pure and effectful invocations, sequential ordinals, all
+four host-failure and nine cancellation mappings, pre-invocation shutdown,
+preflight fatals for E1600 through E1605, unconfigured operations, stale and
+malformed responses, buffered post-terminal frames, runtime failures, raw
+framing defects, carrier loss before and during an invocation, the selected
+stderr ceiling, descriptor and channel ownership, prelude-less stores, and a
+property that doubling round-trips every bounded integer. `test/cli/host-worker.t`
+pins the same exchanges through the installed `jacquard` binary, including the
+exit statuses. The HB.1 vector corpus remains the schema/state contract; its
+`noncanonical-target-hash` case names E1603 while the shipped preflight
+classifies an uppercase hash as a malformed scalar (E1601), a discrepancy to
+resolve when HB.3 packages the executable fixtures.

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,9 +3,9 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `984`
+Test count: `1005`
 
-Cram count: `60`
+Cram count: `61`
 
 Documentation example count: `28` across `8` documents
 
@@ -51,5 +51,13 @@ unchanged; these inventory numbers describe the current source checkout.
 
 The serial host-session library adds 15 cases, bringing the current source
 inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
-finish-once accounting, and bounded evidence; the process worker remains
-unimplemented. See [the session contract](../../host-session-v0.md).
+finish-once accounting, and bounded evidence. See
+[the session contract](../../host-session-v0.md).
+
+The opt-in serial host worker adds 21 cases and one CLI transcript, bringing
+the current source inventory to `1005 / 61 / 28`. It covers the full
+`stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
+invocations, every frozen host-failure and cancellation mapping, preflight
+fatals, stale and malformed responses, carrier loss, the selected stderr
+ceiling, descriptor ownership, and exit statuses. No cross-language conformance
+kit is published until HB.3. See [the worker contract](../../host-worker-v0.md).

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `1005`
+Test count: `1007`
 
 Cram count: `61`
 
@@ -54,8 +54,8 @@ inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
 finish-once accounting, and bounded evidence. See
 [the session contract](../../host-session-v0.md).
 
-The opt-in serial host worker adds 21 cases and one CLI transcript, bringing
-the current source inventory to `1005 / 61 / 28`. It covers the full
+The opt-in serial host worker adds 23 cases and one CLI transcript, bringing
+the current source inventory to `1007 / 61 / 28`. It covers the full
 `stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
 invocations, every frozen host-failure and cancellation mapping, preflight
 fatals, stale and malformed responses, carrier loss, the selected stderr

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `1005`
+- Alcotest/QCheck cases: `1007`
 - Cram transcript files: `61`
 - Documentation examples: `28` named examples across `8` documents
 
@@ -99,8 +99,8 @@ inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
 finish-once accounting, and bounded evidence. See
 [the session contract](../../host-session-v0.md).
 
-The opt-in serial host worker adds 21 cases and one CLI transcript, bringing
-the current source inventory to `1005 / 61 / 28`. It covers the full
+The opt-in serial host worker adds 23 cases and one CLI transcript, bringing
+the current source inventory to `1007 / 61 / 28`. It covers the full
 `stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
 invocations, every frozen host-failure and cancellation mapping, preflight
 fatals, stale and malformed responses, carrier loss, the selected stderr

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,8 +32,8 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `984`
-- Cram transcript files: `60`
+- Alcotest/QCheck cases: `1005`
+- Cram transcript files: `61`
 - Documentation examples: `28` named examples across `8` documents
 
 The development suite also includes corpus goldens, release-manifest checks,
@@ -96,5 +96,13 @@ unchanged; these inventory numbers describe the current source checkout.
 
 The serial host-session library adds 15 cases, bringing the current source
 inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
-finish-once accounting, and bounded evidence; the process worker remains
-unimplemented. See [the session contract](../../host-session-v0.md).
+finish-once accounting, and bounded evidence. See
+[the session contract](../../host-session-v0.md).
+
+The opt-in serial host worker adds 21 cases and one CLI transcript, bringing
+the current source inventory to `1005 / 61 / 28`. It covers the full
+`stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
+invocations, every frozen host-failure and cancellation mapping, preflight
+fatals, stale and malformed responses, carrier loss, the selected stderr
+ceiling, descriptor ownership, and exit statuses. No cross-language conformance
+kit is published until HB.3. See [the worker contract](../../host-worker-v0.md).

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,8 +6,8 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `984`
-- Cram transcript files: `60`
+- Alcotest/QCheck cases: `1005`
+- Cram transcript files: `61`
 - Doctest examples: `28` across 8 documents
 
 The test count includes six DX.2 filesystem-boundary cases and six DX.5/DX.7

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `1005`
+- Alcotest/QCheck cases: `1007`
 - Cram transcript files: `61`
 - Doctest examples: `28` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `1005`
+- Alcotest/QCheck cases: `1007`
 - Cram transcript files: `61`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -760,8 +760,8 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `984`
-- Cram transcript files: `60`
+- Alcotest/QCheck cases: `1005`
+- Cram transcript files: `61`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled
 `channel-contract` cases plus the `store/9` Channel-private-hash case took the

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -599,8 +599,13 @@ accounting, selected descriptor limits, and constructor identity/arity
 resolution. HB.2b2 adds exact invoke-envelope and fixed-ID checks, complete
 stored-target closure validation, structural checked-interface equality, typed
 arguments including constructor fields, exact grants, and the sorted unique
-public `once` operation registry. It does not expose a runnable worker;
-evaluation and effect exchange remain later HB.2 slices.
+public `once` operation registry. HB.2c adds the opt-in `jacquard host worker`
+process carrier in `Host_worker`: it evaluates the preflighted target without
+root handlers, exchanges configured once operations through the session
+layer, flushes exactly one terminal frame, bounds operator output, and reports
+the exit statuses of section 3. Its ownership and lifecycle table is
+[`docs/host-worker-v0.md`](../docs/host-worker-v0.md). No cross-language
+conformance kit is published until HB.3.
 
 A conforming implementation must:
 

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -542,6 +542,11 @@ malformed or rejected `invoke`: no checked invocation began. Once preflight
 succeeds and evaluation starts, a violation uses the single error `outcome`.
 Carrier loss may make either frame impossible; E1611 then belongs in
 host/operator evidence and must not be pretended to have come from Core.
+When Core itself observes input loss while its output remains writable, it
+may flush one best-effort frame carrying E1611 as its only terminal; that
+frame is genuine Core evidence of the unanswered exchange, never a verdict on
+the host's outstanding outside action, and the exit status still reports
+carrier loss.
 
 The pre-invocation terminal frame has exactly
 `{"diagnostics":[DIAGNOSTIC...],"kind":"fatal","protocol":"jacquard-host-v0"}`.

--- a/src/host_worker.ml
+++ b/src/host_worker.ml
@@ -94,11 +94,16 @@ let stack_exhausted =
 
 (* --- frame delivery --- *)
 
+let first_code diagnostics =
+  match diagnostics with diagnostic :: _ -> Diag.code_or_uncoded diagnostic | [] -> "E1611"
+
 let deliver operator ~limits output json =
   match Host.write_frame ~limits output json with
   | Ok () -> Terminal_written
-  | Error _ ->
-      note operator "jacquard host worker: the terminal frame could not be written (E1611)";
+  | Error diagnostics ->
+      note operator
+        (Printf.sprintf "jacquard host worker: the terminal frame could not be written (%s)"
+           (first_code diagnostics));
       Carrier_lost
 
 let fatal operator ~limits output diagnostics =
@@ -152,8 +157,10 @@ let invoke prepared operator ~limits ~input ~output session =
         | other -> terminal other)
   and exchange request resume =
     match Host.write_frame ~limits output request with
-    | Error _ ->
-        note operator "jacquard host worker: an effect request could not be written (E1611)";
+    | Error diagnostics ->
+        note operator
+          (Printf.sprintf "jacquard host worker: an effect request could not be written (%s)"
+             (first_code diagnostics));
         Carrier_lost
     | Ok () -> (
         match Host.read_frame ~limits input with
@@ -178,14 +185,24 @@ let invoke prepared operator ~limits ~input ~output session =
 
 (* --- one worker lifetime --- *)
 
+(* A host that closes its read end must produce a structured carrier-loss result, not a fatal
+   signal. The previous disposition is restored when the lifetime ends. *)
+let with_sigpipe_ignored run =
+  match Sys.signal Sys.sigpipe Sys.Signal_ignore with
+  | previous -> Fun.protect ~finally:(fun () -> Sys.set_signal Sys.sigpipe previous) run
+  | exception Invalid_argument _ -> run ()
+
 let serve prepared ~input ~output ~operator =
   let operator =
     { channel = operator; remaining = Host.hard_limits.max_stderr_bytes; truncated = false }
   in
+  with_sigpipe_ignored @@ fun () ->
   try
     match Host.write_frame ~limits:Host.hard_limits output (Host.core_hello ()) with
-    | Error _ ->
-        note operator "jacquard host worker: core_hello could not be written (E1611)";
+    | Error diagnostics ->
+        note operator
+          (Printf.sprintf "jacquard host worker: core_hello could not be written (%s)"
+             (first_code diagnostics));
         Carrier_lost
     | Ok () -> (
         match Host.read_frame ~limits:Host.hard_limits input with

--- a/src/host_worker.ml
+++ b/src/host_worker.ml
@@ -1,0 +1,218 @@
+(* HB.2c: the opt-in serial process carrier over Host_protocol_v0.Session. *)
+
+module Host = Host_protocol_v0
+module Session = Host.Session
+
+type exit_status = Terminal_written | Protocol_failure | Internal_failure | Carrier_lost
+
+let exit_code = function
+  | Terminal_written -> 0
+  | Protocol_failure -> 64
+  | Internal_failure -> 70
+  | Carrier_lost -> 74
+
+type prepared = { ctx : Eval.ctx; checker : Check.ctx }
+
+let prepare store =
+  let ( let* ) = Result.bind in
+  let ctx = Eval.make_ctx store in
+  let* () = Prelude.wire_builtins ctx in
+  Eval.set_coverage_tracking ctx false;
+  let* checker = Check.make_ctx store in
+  let* signatures = Prelude.builtin_signatures store in
+  Check.register_builtin_signatures checker signatures;
+  Ok { ctx; checker }
+
+(* --- bounded operator output --- *)
+
+type operator = { channel : out_channel; mutable remaining : int; mutable truncated : bool }
+
+let truncation_marker = "\n[jacquard host worker: operator output truncated]\n"
+
+(* The largest prefix length no greater than [limit] that ends on a UTF-8 scalar boundary. *)
+let utf8_prefix text limit =
+  let length = String.length text in
+  let cut = ref (if limit < length then limit else length) in
+  while !cut > 0 && !cut < length && Char.code text.[!cut] land 0xC0 = 0x80 do
+    decr cut
+  done;
+  !cut
+
+let note operator text =
+  if (not operator.truncated) && operator.remaining > 0 then
+    let text = text ^ "\n" in
+    let length = String.length text in
+    try
+      if length <= operator.remaining then begin
+        output_string operator.channel text;
+        flush operator.channel;
+        operator.remaining <- operator.remaining - length
+      end
+      else begin
+        operator.truncated <- true;
+        let marker_length = String.length truncation_marker in
+        let budget =
+          if operator.remaining > marker_length then operator.remaining - marker_length
+          else operator.remaining
+        in
+        let cut = utf8_prefix text budget in
+        output_string operator.channel (String.sub text 0 cut);
+        if cut + marker_length <= operator.remaining then
+          output_string operator.channel truncation_marker;
+        flush operator.channel;
+        operator.remaining <- 0
+      end
+    with Sys_error _ -> operator.remaining <- 0
+
+(* --- diagnostics owned by the worker --- *)
+
+let has_code code diagnostics = List.exists (fun d -> Diag.code d = Some code) diagnostics
+let is_carrier_loss diagnostics = has_code "E1611" diagnostics
+
+let invalid_response diagnostics =
+  if has_code "E1602" diagnostics then diagnostics
+  else
+    [
+      Diag.error ~domain:Process ~code:"E1608" ~summary:"The host response frame is invalid"
+        ~cause:
+          "The current response slot received a malformed or unreadable frame instead of exactly \
+           one effect_ok, effect_failure, or cancel message."
+        ~next_step:
+          "Send one bounded, well-formed response for the outstanding request; the invocation is \
+           now closed and must not be retried."
+        ~contrast:None ();
+    ]
+
+let stack_exhausted =
+  Diag.error ~domain:Process ~code:"E0003"
+    ~summary:"Input exhausted the host stack before a structural nesting guard"
+    ~cause:
+      "Evaluation of the selected target reached the worker's stack limit before Jacquard could \
+       report a local depth boundary."
+    ~next_step:"Reduce the target's recursion depth and report the missing structural guard."
+    ~contrast:None ()
+
+(* --- frame delivery --- *)
+
+let deliver operator ~limits output json =
+  match Host.write_frame ~limits output json with
+  | Ok () -> Terminal_written
+  | Error _ ->
+      note operator "jacquard host worker: the terminal frame could not be written (E1611)";
+      Carrier_lost
+
+let fatal operator ~limits output diagnostics =
+  match Session.fatal ~limits diagnostics with
+  | Ok json -> deliver operator ~limits output json
+  | Error _ ->
+      note operator
+        "jacquard host worker: no bounded fatal frame fits the negotiated limits (E1602)";
+      Protocol_failure
+
+(* A control frame failed to arrive before any invocation began. Carrier loss still attempts the
+   best-effort fatal because stdout may remain writable, but it is reported as lost. *)
+let refuse_control operator ~limits output ~phase diagnostics =
+  if is_carrier_loss diagnostics then begin
+    ignore (fatal operator ~limits output diagnostics);
+    note operator
+      (Printf.sprintf "jacquard host worker: the carrier was lost while awaiting %s (E1611)" phase);
+    Carrier_lost
+  end
+  else fatal operator ~limits output diagnostics
+
+let message_kind = function
+  | `Assoc fields -> (
+      match List.assoc_opt "kind" fields with Some (`String kind) -> Some kind | _ -> None)
+  | _ -> None
+
+(* --- one invocation --- *)
+
+let run_step ctx state =
+  match Eval.run_state_capturing_once_routed ctx state with
+  | result -> result
+  | exception Stack_overflow -> Error (Runtime_err.Diagnostic stack_exhausted)
+
+let invoke prepared operator ~limits ~input ~output session =
+  let ctx = prepared.ctx in
+  let terminal = function
+    | Ok (Session.Finished json) -> deliver operator ~limits output json
+    | Ok (Session.Request _ | Session.Resume _) | Error _ ->
+        note operator "jacquard host worker: the session produced an impossible action";
+        Internal_failure
+  in
+  let abort diagnostics = terminal (Session.abort session diagnostics) in
+  let runtime_failure error = abort [ Runtime_err.to_diag error ] in
+  let rec drive state =
+    match run_step ctx state with
+    | Error error -> runtime_failure error
+    | Ok (Eval.OCValue value) -> terminal (Session.finish session value)
+    | Ok (Eval.OCOp { op; args; resume; name = _ }) -> (
+        match Session.request session ~operation:op ~arguments:args with
+        | Ok (Session.Request request) -> exchange request resume
+        | other -> terminal other)
+  and exchange request resume =
+    match Host.write_frame ~limits output request with
+    | Error _ ->
+        note operator "jacquard host worker: an effect request could not be written (E1611)";
+        Carrier_lost
+    | Ok () -> (
+        match Host.read_frame ~limits input with
+        | Error diagnostics when is_carrier_loss diagnostics ->
+            (* stdout may still be writable: keep the accepted observations and request order
+               visible, then report the loss; the host classifies its own outstanding action *)
+            ignore (abort diagnostics);
+            note operator
+              "jacquard host worker: the carrier was lost while awaiting a response (E1611)";
+            Carrier_lost
+        | Error diagnostics -> abort (invalid_response diagnostics)
+        | Ok json -> (
+            match Session.respond session json with
+            | Ok (Session.Resume value) -> drive (Eval.apply_state ctx resume [ value ])
+            | other -> terminal other))
+  in
+  let callable, arguments = Session.call session in
+  let reference = { Kernel.it = Kernel.Ref (callable, Kernel.Term); meta = Meta.empty } in
+  match Eval.run_expr ctx reference with
+  | Error error -> runtime_failure error
+  | Ok callable_value -> drive (Eval.apply_state ctx callable_value arguments)
+
+(* --- one worker lifetime --- *)
+
+let serve prepared ~input ~output ~operator =
+  let operator =
+    { channel = operator; remaining = Host.hard_limits.max_stderr_bytes; truncated = false }
+  in
+  try
+    match Host.write_frame ~limits:Host.hard_limits output (Host.core_hello ()) with
+    | Error _ ->
+        note operator "jacquard host worker: core_hello could not be written (E1611)";
+        Carrier_lost
+    | Ok () -> (
+        match Host.read_frame ~limits:Host.hard_limits input with
+        | Error diagnostics ->
+            refuse_control operator ~limits:Host.hard_limits output ~phase:"host_select" diagnostics
+        | Ok json -> (
+            match Host.parse_host_select json with
+            | Error diagnostics -> fatal operator ~limits:Host.hard_limits output diagnostics
+            | Ok limits -> (
+                (* the selected ceiling covers the whole lifetime, including bytes already written *)
+                let written = Host.hard_limits.max_stderr_bytes - operator.remaining in
+                operator.remaining <- max 0 (limits.max_stderr_bytes - written);
+                match Host.read_frame ~limits input with
+                | Error diagnostics ->
+                    refuse_control operator ~limits output ~phase:"invoke" diagnostics
+                | Ok json -> (
+                    match message_kind json with
+                    | Some "shutdown" -> (
+                        match Host.parse_shutdown ~limits json with
+                        | Error diagnostics -> fatal operator ~limits output diagnostics
+                        | Ok () -> deliver operator ~limits output (Host.shutdown_ack ()))
+                    | _ -> (
+                        match Session.start ~limits ~checker:prepared.checker json with
+                        | Error diagnostics -> fatal operator ~limits output diagnostics
+                        | Ok session -> invoke prepared operator ~limits ~input ~output session)))))
+  with exn ->
+    note operator
+      (Printf.sprintf "jacquard host worker: internal invariant failed (%s)"
+         (Printexc.to_string exn));
+    Internal_failure

--- a/src/host_worker.mli
+++ b/src/host_worker.mli
@@ -1,0 +1,40 @@
+(** Opt-in serial [stdio-u32-json-v0] worker for the frozen [jacquard-host-v0] protocol.
+
+    The worker drives exactly one host-selected invocation over an already opened local store: it
+    writes [core_hello], accepts one [host_select], then either acknowledges a pre-invocation
+    [shutdown] or evaluates one checked target while exchanging typed root operations with the
+    trusted host in lockstep. It installs no root handlers and never reloads the prelude; every root
+    operation that the checked target reaches is either served through the closed configured
+    registry or refused with a structured outcome. Ordinary [jac run], native artifacts, and the
+    interpreted scheduler do not use this module. *)
+
+type exit_status =
+  | Terminal_written
+      (** One complete [outcome], [fatal], or [shutdown_ack] frame was flushed; exit 0. *)
+  | Protocol_failure  (** No bounded terminal frame fits the negotiated limits; exit 64. *)
+  | Internal_failure  (** A Core invariant failed after preflight; exit 70. *)
+  | Carrier_lost
+      (** Standard input or output was lost. A best-effort E1611 frame may still have been flushed,
+          but the host must classify any outstanding outside action itself; exit 74. *)
+
+val exit_code : exit_status -> int
+(** [exit_code status] maps the worker result onto the process exit statuses frozen in
+    [spec/host-protocol-v0.md] section 3. *)
+
+type prepared
+(** A store with wired builtin implementations and a checker seeded with builtin signatures. *)
+
+val prepare : Store.t -> (prepared, Diag.t list) result
+(** [prepare store] wires builtins and creates the checker over an already opened store without
+    reloading the prelude. A store that was never populated with the prelude fails closed with the
+    prelude's own E0702 diagnostics. *)
+
+val serve :
+  prepared -> input:in_channel -> output:out_channel -> operator:out_channel -> exit_status
+(** [serve prepared ~input ~output ~operator] runs one complete worker lifetime. Frames are read
+    from [input] and written, one at a time and fully flushed, to [output]. [operator] receives
+    bounded human diagnostics limited to the hard and then the selected [max_stderr_bytes]; it is
+    never a protocol or evidence channel. The function closes none of the three channels and retains
+    no continuation, session, or descriptor after it returns. Every terminal action is committed
+    when written and is never retried. Exceptions are contained and reported as [Internal_failure]
+    except a stack overflow inside evaluation, which becomes a bounded E0003 outcome. *)

--- a/src/host_worker.mli
+++ b/src/host_worker.mli
@@ -36,5 +36,9 @@ val serve :
     bounded human diagnostics limited to the hard and then the selected [max_stderr_bytes]; it is
     never a protocol or evidence channel. The function closes none of the three channels and retains
     no continuation, session, or descriptor after it returns. Every terminal action is committed
-    when written and is never retried. Exceptions are contained and reported as [Internal_failure]
-    except a stack overflow inside evaluation, which becomes a bounded E0003 outcome. *)
+    when written and is never retried. [SIGPIPE] is ignored for the dynamic extent of the call so a
+    host that closes its read end yields [Carrier_lost] instead of a fatal signal; the previous
+    disposition is restored afterwards. Bytes that could not be written stay in the caller's channel
+    buffer, so a process boundary must discard them rather than flush them at exit. Exceptions are
+    contained and reported as [Internal_failure] except a stack overflow inside evaluation, which
+    becomes a bounded E0003 outcome. *)

--- a/test/cli/host-worker.t
+++ b/test/cli/host-worker.t
@@ -95,6 +95,13 @@ exits 74.
   {"carrier":"stdio-u32-json-v0","kind":"core_hello","limits":{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096},"versions":["jacquard-host-v0"]}
   {"diagnostics":[{"schema":"jacquard-diagnostic-v1","domain":"process","code":"E1611","severity":"error","span":null,"summary":"The host carrier was lost before a trustworthy frame completed.","cause":"The carrier ended before the declared frame completed.","next_step":"Treat the missing terminal exchange as host-owned carrier-failure evidence."}],"kind":"fatal","protocol":"jacquard-host-v0"}
 
+A standard output that cannot be written is carrier loss: one operator note,
+no retry of the failed frame, exit 74.
+
+  $ jacquard host worker --store store < pure.in >&-
+  jacquard host worker: core_hello could not be written (E1611)
+  [74]
+
 Startup configuration failures happen before any frame is written.
 
   $ jacquard host worker --store nowhere

--- a/test/cli/host-worker.t
+++ b/test/cli/host-worker.t
@@ -1,0 +1,107 @@
+Opt-in serial host worker over the stdio-u32-json-v0 carrier (HB.2c). A frame
+is a four-byte big-endian length followed by one JSON object, so the helpers
+below frame scripted host input and unframe Core output for readability.
+Store identities are replaced by names in the transcript; the frames
+themselves carry the exact 64-digit hashes.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ frame() {
+  >   n=$(printf '%s' "$1" | wc -c)
+  >   printf "\\000\\000\\$(printf '%03o' $((n / 256)))\\$(printf '%03o' $((n % 256)))"
+  >   printf '%s' "$1"
+  > }
+  $ unframe() {
+  >   while :; do
+  >     h=$(dd bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')
+  >     [ -z "$h" ] && break
+  >     dd bs=1 count=$((0x$h)) 2>/dev/null
+  >     echo
+  >   done
+  > }
+
+The host populates a local store once; the worker reopens it without
+reloading the prelude.
+
+  $ cat > decls.jac <<'EOF'
+  > once effect World where {
+  >   send : (Text) -> Text
+  > }
+  > double : (Int) ->{} Int
+  > double(n) = mul(n, 2)
+  > echo : (Text) ->{World} Text
+  > echo(body) = send(body)
+  > EOF
+  $ jacquard run decls.jac --store store
+  $ INT=$(sed -n 's/^(named int type #\(.*\))$/\1/p' store/names.jqd)
+  $ TEXT=$(sed -n 's/^(named text type #\(.*\))$/\1/p' store/names.jqd)
+  $ WORLD=$(sed -n 's/^(named world effect #\(.*\))$/\1/p' store/names.jqd)
+  $ SEND=$(sed -n 's/^(named send op #\(.*\))$/\1/p' store/names.jqd)
+  $ DOUBLE=$(sed -n 's/^(named double term #\(.*\))$/\1/p' store/names.jqd)
+  $ ECHO=$(sed -n 's/^(named echo term #\(.*\))$/\1/p' store/names.jqd)
+  $ names() { sed "s/$INT/<int>/g; s/$TEXT/<text>/g; s/$WORLD/<world>/g; s/$SEND/<send>/g; s/$DOUBLE/<double>/g; s/$ECHO/<echo>/g"; }
+  $ LIMITS='{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096}'
+  $ SELECT="{\"kind\":\"host_select\",\"limits\":$LIMITS,\"protocol\":\"jacquard-host-v0\"}"
+  $ INT_TYPE="{\"arguments\":[],\"identity\":\"$INT\",\"kind\":\"nominal\"}"
+  $ TEXT_TYPE="{\"arguments\":[],\"identity\":\"$TEXT\",\"kind\":\"nominal\"}"
+  $ INVOKE_DOUBLE="{\"arguments\":[{\"kind\":\"int\",\"value\":\"21\"}],\"capabilities\":{\"effects\":[],\"operations\":[]},\"interface\":{\"effects\":[],\"parameters\":[$INT_TYPE],\"result\":$INT_TYPE},\"invocation_id\":\"0000000000000000\",\"kind\":\"invoke\",\"protocol\":\"jacquard-host-v0\",\"target\":{\"callable\":\"$DOUBLE\",\"kind\":\"store-term-v0\"}}"
+  $ INVOKE_ECHO="{\"arguments\":[{\"kind\":\"text\",\"value\":\"ping\"}],\"capabilities\":{\"effects\":[\"$WORLD\"],\"operations\":[{\"effect\":\"$WORLD\",\"mode\":\"once\",\"operation\":\"$SEND\"}]},\"interface\":{\"effects\":[\"$WORLD\"],\"parameters\":[$TEXT_TYPE],\"result\":$TEXT_TYPE},\"invocation_id\":\"0000000000000000\",\"kind\":\"invoke\",\"protocol\":\"jacquard-host-v0\",\"target\":{\"callable\":\"$ECHO\",\"kind\":\"store-term-v0\"}}"
+  $ EFFECT_OK='{"invocation_id":"0000000000000000","kind":"effect_ok","protocol":"jacquard-host-v0","request_id":"0000000000000001","value":{"kind":"text","value":"pong"}}'
+
+A pure invocation: core_hello, then one outcome with the typed result and
+Core evidence that omits argument and result values.
+
+  $ { frame "$SELECT"; frame "$INVOKE_DOUBLE"; } > pure.in
+  $ jacquard host worker --store store < pure.in > pure.out
+  $ unframe < pure.out | names
+  {"carrier":"stdio-u32-json-v0","kind":"core_hello","limits":{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096},"versions":["jacquard-host-v0"]}
+  {"evidence":{"core":{"capabilities":{"effects":[],"operations":[]},"effect_requests":[],"interface":{"effects":[],"parameters":[{"arguments":[],"identity":"<int>","kind":"nominal"}],"result":{"arguments":[],"identity":"<int>","kind":"nominal"}},"invocation_id":"0000000000000000","schema":"jacquard-host-core-evidence-v0","target":{"callable":"<double>","kind":"store-term-v0"},"terminal":"ok"},"host_observations":{"responses":[],"schema":"jacquard-host-observations-v0"}},"invocation_id":"0000000000000000","kind":"outcome","protocol":"jacquard-host-v0","result":{"kind":"ok","value":{"kind":"int","value":"42"}}}
+
+One configured once operation: Core emits the request, the host answers, and
+the outcome records the request order and the accepted observation.
+
+  $ { frame "$SELECT"; frame "$INVOKE_ECHO"; frame "$EFFECT_OK"; } > echo.in
+  $ jacquard host worker --store store < echo.in > echo.out
+  $ unframe < echo.out | names
+  {"carrier":"stdio-u32-json-v0","kind":"core_hello","limits":{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096},"versions":["jacquard-host-v0"]}
+  {"arguments":[{"kind":"text","value":"ping"}],"effect":"<world>","invocation_id":"0000000000000000","kind":"effect_request","mode":"once","operation":"<send>","protocol":"jacquard-host-v0","request_id":"0000000000000001"}
+  {"evidence":{"core":{"capabilities":{"effects":["<world>"],"operations":[{"effect":"<world>","mode":"once","operation":"<send>"}]},"effect_requests":[{"effect":"<world>","operation":"<send>","ordinal":1}],"interface":{"effects":["<world>"],"parameters":[{"arguments":[],"identity":"<text>","kind":"nominal"}],"result":{"arguments":[],"identity":"<text>","kind":"nominal"}},"invocation_id":"0000000000000000","schema":"jacquard-host-core-evidence-v0","target":{"callable":"<echo>","kind":"store-term-v0"},"terminal":"ok"},"host_observations":{"responses":[{"category":"ok","completion":"completed","ordinal":1}],"schema":"jacquard-host-observations-v0"}},"invocation_id":"0000000000000000","kind":"outcome","protocol":"jacquard-host-v0","result":{"kind":"ok","value":{"kind":"text","value":"pong"}}}
+
+A pre-invocation shutdown is acknowledged and the worker exits 0.
+
+  $ { frame "$SELECT"; frame '{"kind":"shutdown","protocol":"jacquard-host-v0"}'; } > shutdown.in
+  $ jacquard host worker --store store < shutdown.in > shutdown.out
+  $ unframe < shutdown.out | names
+  {"carrier":"stdio-u32-json-v0","kind":"core_hello","limits":{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096},"versions":["jacquard-host-v0"]}
+  {"kind":"shutdown_ack","protocol":"jacquard-host-v0"}
+
+An unsupported version is refused with one fatal frame; the flushed terminal
+permits exit 0.
+
+  $ frame '{"kind":"host_select","limits":{},"protocol":"jacquard-host-v1"}' > version.in
+  $ jacquard host worker --store store < version.in > version.out
+  $ unframe < version.out | names
+  {"carrier":"stdio-u32-json-v0","kind":"core_hello","limits":{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096},"versions":["jacquard-host-v0"]}
+  {"diagnostics":[{"schema":"jacquard-diagnostic-v1","domain":"process","code":"E1600","severity":"error","span":null,"summary":"The host selected an unsupported protocol version.","cause":"The selected protocol version is not advertised.","next_step":"Select jacquard-host-v0 with the advertised stdio-u32-json-v0 carrier."}],"kind":"fatal","protocol":"jacquard-host-v0"}
+
+A truncated length prefix is carrier loss: Core still flushes a best-effort
+E1611 fatal because stdout remains writable, notes the loss on stderr, and
+exits 74.
+
+  $ printf '\000\000' > truncated.in
+  $ jacquard host worker --store store < truncated.in > truncated.out
+  jacquard host worker: the carrier was lost while awaiting host_select (E1611)
+  [74]
+  $ unframe < truncated.out | names
+  {"carrier":"stdio-u32-json-v0","kind":"core_hello","limits":{"max_arguments":64,"max_collection_items":1024,"max_diagnostic_bytes":65536,"max_diagnostics":32,"max_effect_requests":1024,"max_effects":64,"max_frame_bytes":1048576,"max_host_message_bytes":4096,"max_json_depth":64,"max_operations":256,"max_stderr_bytes":65536,"max_text_bytes":262144,"max_value_nodes":4096},"versions":["jacquard-host-v0"]}
+  {"diagnostics":[{"schema":"jacquard-diagnostic-v1","domain":"process","code":"E1611","severity":"error","span":null,"summary":"The host carrier was lost before a trustworthy frame completed.","cause":"The carrier ended before the declared frame completed.","next_step":"Treat the missing terminal exchange as host-owned carrier-failure evidence."}],"kind":"fatal","protocol":"jacquard-host-v0"}
+
+Startup configuration failures happen before any frame is written.
+
+  $ jacquard host worker --store nowhere
+  error[E0606]: Requested store is unavailable
+    Cause: store nowhere does not exist
+    Next step: Pass the path to an existing Jacquard store.
+  [1]
+  $ jacquard host worker 2>&1 | head -2
+  Usage: jacquard host worker [--help] [--diagnostic-format=FORMAT] --store=DIR
+         [OPTION]…

--- a/test/dune
+++ b/test/dune
@@ -160,11 +160,22 @@
  (modules host_session_focused)
  (libraries host_session_test_support alcotest))
 
+(library
+ (name host_worker_test_support)
+ (wrapped false)
+ (modules test_host_worker)
+ (libraries jacquard alcotest qcheck-core qcheck-alcotest unix yojson))
+
+(executable
+ (name host_worker_focused)
+ (modules host_worker_focused)
+ (libraries host_worker_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused test_host_session host_session_focused))
- (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support host_session_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused test_host_session host_session_focused test_host_worker host_worker_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support host_session_test_support host_worker_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (deps
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)

--- a/test/dune
+++ b/test/dune
@@ -164,7 +164,7 @@
  (name host_worker_test_support)
  (wrapped false)
  (modules test_host_worker)
- (libraries jacquard alcotest qcheck-core qcheck-alcotest unix yojson))
+ (libraries jacquard alcotest qcheck-core qcheck-alcotest unix str yojson))
 
 (executable
  (name host_worker_focused)
@@ -176,7 +176,10 @@
  (modules
   (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused test_host_session host_session_focused test_host_worker host_worker_focused))
  (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support host_session_test_support host_worker_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+ (action
+  (setenv JACQUARD %{bin:jacquard} (run %{test})))
  (deps
+  %{bin:jacquard}
   (glob_files_rec ../corpus/*.jqd)
   (glob_files_rec ../corpus/*.jac)
   (source_tree ../corpus/valid)

--- a/test/host_worker_focused.ml
+++ b/test/host_worker_focused.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "jacquard-host-worker" [ ("host-worker", Test_host_worker.suite) ]

--- a/test/test_host_worker.ml
+++ b/test/test_host_worker.ml
@@ -1,0 +1,738 @@
+(* HB.2c: the opt-in serial worker over scripted host input and captured Core output. *)
+
+open Jacquard
+module Host = Host_protocol_v0
+
+let fail_diagnostics diagnostics = String.concat "\n" (List.map Diag.to_string diagnostics)
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error diagnostics -> Alcotest.failf "%s failed:\n%s" label (fail_diagnostics diagnostics)
+
+let fresh_path =
+  let serial = ref 0 in
+  fun label ->
+    incr serial;
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "jacquard-host-worker-%s-%d-%d" label (Unix.getpid ()) !serial)
+
+let read_file path =
+  let channel = open_in_bin path in
+  let contents = really_input_string channel (in_channel_length channel) in
+  close_in channel;
+  contents
+
+let write_file path contents =
+  let channel = open_out_bin path in
+  output_string channel contents;
+  close_out channel
+
+let put_src store source =
+  let form =
+    expect_ok "parse fixture declaration" (Reader.parse_one ~file:"host-worker.jqd" source)
+  in
+  let declaration = expect_ok "validate fixture declaration" (Kernel.decl_of_form form) in
+  let declaration =
+    expect_ok "resolve fixture declaration"
+      (Resolve.resolve_decl (Store.names_view store) declaration)
+  in
+  expect_ok "store fixture declaration" (Store.put_decl store declaration)
+
+let named name hashes = List.assoc name hashes.Canon.named
+
+type fixture = {
+  prepared : Host_worker.prepared;
+  int_type : Hash.t;
+  text_type : Hash.t;
+  world_effect : Hash.t;
+  send_operation : Hash.t;
+  double : Hash.t;
+  echo : Hash.t;
+  twice : Hash.t;
+  crash : Hash.t;
+}
+
+(* Populate a store with the real prelude, then reopen it without reloading the prelude: this is
+   exactly the startup path of [jacquard host worker --store DIR]. *)
+let make_fixture () =
+  let dir = fresh_path "store" in
+  let store = expect_ok "open fixture store" (Store.open_store dir) in
+  ignore (expect_ok "load prelude" (Prelude.load ~dir:"../prelude" store));
+  let world =
+    put_src store "(defeffect worker-world () (op worker.send once ((tref text)) (tref text)))"
+  in
+  let double =
+    put_src store
+      "(defterm ((binding worker.double ((tarrow ((tref int)) (row) (tref int))) (lam ((pvar n)) \
+       (app (var mul) (var n) (lit 2))))))"
+  in
+  let echo =
+    put_src store
+      "(defterm ((binding worker.echo ((tarrow ((tref text)) (row (eref worker-world)) (tref \
+       text))) (lam ((pvar body)) (app (var worker.send) (var body))))))"
+  in
+  let twice =
+    put_src store
+      "(defterm ((binding worker.twice ((tarrow ((tref text)) (row (eref worker-world)) (tref \
+       text))) (lam ((pvar body)) (app (var worker.send) (app (var worker.send) (var body)))))))"
+  in
+  let crash =
+    put_src store
+      "(defterm ((binding worker.crash ((tarrow ((tref int)) (row) (tref int))) (lam ((pvar n)) \
+       (app (var div) (var n) (lit 0))))))"
+  in
+  let reopened = expect_ok "reopen fixture store" (Store.open_store dir) in
+  let prepared = expect_ok "prepare reopened store" (Host_worker.prepare reopened) in
+  let checker = expect_ok "fixture checker" (Check.make_ctx reopened) in
+  let primitives = Check.primitive_types checker in
+  {
+    prepared;
+    int_type = primitives.Check.int_type;
+    text_type = primitives.Check.text_type;
+    world_effect = named "worker-world" world;
+    send_operation = named "worker.send" world;
+    double = named "worker.double" double;
+    echo = named "worker.echo" echo;
+    twice = named "worker.twice" twice;
+    crash = named "worker.crash" crash;
+  }
+
+let fixture = lazy (make_fixture ())
+let fixture () = Lazy.force fixture
+
+(* --- wire helpers --- *)
+
+let encode json =
+  expect_ok "encode host frame" (Host.encode_frame_bytes ~limits:Host.hard_limits json)
+
+let script frames = String.concat "" (List.map encode frames)
+
+let bytes_of_hex hex =
+  String.init
+    (String.length hex / 2)
+    (fun i -> Char.chr (int_of_string ("0x" ^ String.sub hex (2 * i) 2)))
+
+let decode_frames bytes =
+  let length = String.length bytes in
+  let rec go offset acc =
+    if offset = length then List.rev acc
+    else if offset + 4 > length then Alcotest.fail "truncated Core frame prefix"
+    else
+      let size =
+        (Char.code bytes.[offset] lsl 24)
+        lor (Char.code bytes.[offset + 1] lsl 16)
+        lor (Char.code bytes.[offset + 2] lsl 8)
+        lor Char.code bytes.[offset + 3]
+      in
+      if offset + 4 + size > length then Alcotest.fail "truncated Core frame payload"
+      else
+        let payload = String.sub bytes (offset + 4) size in
+        go (offset + 4 + size) (Yojson.Safe.from_string payload :: acc)
+  in
+  go 0 []
+
+type run = { status : Host_worker.exit_status; frames : Yojson.Safe.t list; operator : string }
+
+let run ?(prepared = (fixture ()).prepared) host_bytes =
+  let base = fresh_path "io" in
+  let input_path = base ^ ".in" and output_path = base ^ ".out" and operator_path = base ^ ".err" in
+  write_file input_path host_bytes;
+  let input = open_in_bin input_path in
+  let output = open_out_bin output_path in
+  let operator = open_out_bin operator_path in
+  let status = Host_worker.serve prepared ~input ~output ~operator in
+  close_in input;
+  close_out output;
+  close_out operator;
+  let frames = decode_frames (read_file output_path) in
+  let operator = read_file operator_path in
+  List.iter Sys.remove [ input_path; output_path; operator_path ];
+  { status; frames; operator }
+
+(* --- envelope builders --- *)
+
+let hash_json hash = `String (Hash.to_hex hash)
+
+let nominal hash =
+  `Assoc [ ("arguments", `List []); ("identity", hash_json hash); ("kind", `String "nominal") ]
+
+let int_value n = `Assoc [ ("kind", `String "int"); ("value", `String (string_of_int n)) ]
+let text_value text = `Assoc [ ("kind", `String "text"); ("value", `String text) ]
+
+let select ?(limits = Host.hard_limits) () =
+  `Assoc
+    [
+      ("kind", `String "host_select");
+      ("limits", Host.limits_to_yojson limits);
+      ("protocol", `String Host.protocol);
+    ]
+
+let shutdown = `Assoc [ ("kind", `String "shutdown"); ("protocol", `String Host.protocol) ]
+
+let invoke ~target ~parameters ~result ~effects ~operations ~arguments =
+  `Assoc
+    [
+      ("arguments", `List arguments);
+      ( "capabilities",
+        `Assoc [ ("effects", `List (List.map hash_json effects)); ("operations", `List operations) ]
+      );
+      ( "interface",
+        `Assoc
+          [
+            ("effects", `List (List.map hash_json effects));
+            ("parameters", `List parameters);
+            ("result", result);
+          ] );
+      ("invocation_id", `String "0000000000000000");
+      ("kind", `String "invoke");
+      ("protocol", `String Host.protocol);
+      ("target", `Assoc [ ("callable", hash_json target); ("kind", `String "store-term-v0") ]);
+    ]
+
+let send_entry ?(mode = "once") f =
+  `Assoc
+    [
+      ("effect", hash_json f.world_effect);
+      ("mode", `String mode);
+      ("operation", hash_json f.send_operation);
+    ]
+
+let double_invoke f n =
+  invoke ~target:f.double
+    ~parameters:[ nominal f.int_type ]
+    ~result:(nominal f.int_type) ~effects:[] ~operations:[]
+    ~arguments:[ int_value n ]
+
+let crash_invoke f n =
+  invoke ~target:f.crash
+    ~parameters:[ nominal f.int_type ]
+    ~result:(nominal f.int_type) ~effects:[] ~operations:[]
+    ~arguments:[ int_value n ]
+
+let world_invoke ?(configured = true) f target body =
+  invoke ~target
+    ~parameters:[ nominal f.text_type ]
+    ~result:(nominal f.text_type) ~effects:[ f.world_effect ]
+    ~operations:(if configured then [ send_entry f ] else [])
+    ~arguments:[ text_value body ]
+
+let echo_invoke ?configured f body = world_invoke ?configured f f.echo body
+
+let response ?(ordinal = 1) kind fields =
+  `Assoc
+    ([
+       ("invocation_id", `String "0000000000000000");
+       ("kind", `String kind);
+       ("protocol", `String Host.protocol);
+       ("request_id", `String (Printf.sprintf "%016x" ordinal));
+     ]
+    @ fields)
+
+let effect_ok ?ordinal value = response ?ordinal "effect_ok" [ ("value", value) ]
+
+let effect_failure category completion =
+  response "effect_failure"
+    [
+      ("category", `String category);
+      ("completion", `String completion);
+      ("message", `String "redacted host detail");
+    ]
+
+let cancel reason completion =
+  response "cancel" [ ("reason", `String reason); ("completion", `String completion) ]
+
+let replace_field name value = function
+  | `Assoc fields ->
+      `Assoc (List.map (fun (k, v) -> if k = name then (k, value) else (k, v)) fields)
+  | json -> json
+
+let append_field name value = function
+  | `Assoc fields -> `Assoc (fields @ [ (name, value) ])
+  | json -> json
+
+let update_path path f json =
+  let rec go path json =
+    match (path, json) with
+    | [], json -> f json
+    | key :: rest, `Assoc fields ->
+        `Assoc (List.map (fun (k, v) -> if k = key then (k, go rest v) else (k, v)) fields)
+    | key :: rest, `List items ->
+        `List (List.mapi (fun i v -> if string_of_int i = key then go rest v else v) items)
+    | _ -> json
+  in
+  go path json
+
+(* --- accessors --- *)
+
+let get name json = Yojson.Safe.Util.member name json
+let text json = Yojson.Safe.Util.to_string json
+let items json = Yojson.Safe.Util.to_list json
+let kind json = text (get "kind" json)
+let core json = get "core" (get "evidence" json)
+let requests json = items (get "effect_requests" (core json))
+let observations json = items (get "responses" (get "host_observations" (get "evidence" json)))
+let diagnostics json = items (get "diagnostics" json)
+let outcome_diagnostics json = diagnostics (get "result" json)
+let first_code diagnostics = text (get "code" (List.hd diagnostics))
+
+let check_json label expected actual =
+  Alcotest.(check string) label (Yojson.Safe.to_string expected) (Yojson.Safe.to_string actual)
+
+let check_status label expected actual =
+  Alcotest.(check int) label (Host_worker.exit_code expected) (Host_worker.exit_code actual)
+
+let check_hello json =
+  Alcotest.(check string) "first frame" "core_hello" (kind json);
+  Alcotest.(check string) "carrier" Host.carrier (text (get "carrier" json));
+  check_json "hard limits" (Host.limits_to_yojson Host.hard_limits) (get "limits" json);
+  check_json "versions" (`List [ `String Host.protocol ]) (get "versions" json)
+
+(* Every run starts with core_hello and ends with exactly one terminal frame. *)
+let terminal_after ?(requests = 0) label run =
+  match run.frames with
+  | hello :: rest ->
+      check_hello hello;
+      Alcotest.(check int) (label ^ " frame count") (requests + 1) (List.length rest);
+      List.iteri
+        (fun i frame ->
+          if i < requests then
+            Alcotest.(check string) (label ^ " request kind") "effect_request" (kind frame))
+        rest;
+      List.nth rest requests
+  | [] -> Alcotest.fail (label ^ " produced no frames")
+
+let check_fatal label ~code run =
+  let terminal = terminal_after label run in
+  Alcotest.(check string) (label ^ " terminal kind") "fatal" (kind terminal);
+  Alcotest.(check string) (label ^ " code") code (first_code (diagnostics terminal));
+  check_json (label ^ " protocol") (`String Host.protocol) (get "protocol" terminal);
+  Alcotest.(check bool)
+    (label ^ " carries no invocation")
+    true
+    (get "invocation_id" terminal = `Null && get "evidence" terminal = `Null)
+
+let check_outcome ?requests label ~code ~terminal run =
+  let frame = terminal_after ?requests label run in
+  Alcotest.(check string) (label ^ " terminal kind") "outcome" (kind frame);
+  Alcotest.(check string) (label ^ " result kind") "error" (kind (get "result" frame));
+  Alcotest.(check string) (label ^ " code") code (first_code (outcome_diagnostics frame));
+  Alcotest.(check string) (label ^ " terminal") terminal (text (get "terminal" (core frame)));
+  frame
+
+(* --- tests --- *)
+
+let test_exit_codes () =
+  Alcotest.(check (list int))
+    "frozen exit statuses" [ 0; 64; 70; 74 ]
+    (List.map Host_worker.exit_code
+       Host_worker.[ Terminal_written; Protocol_failure; Internal_failure; Carrier_lost ])
+
+let test_pure_success () =
+  let f = fixture () in
+  let run = run (script [ select (); double_invoke f 21 ]) in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let outcome = terminal_after "pure" run in
+  Alcotest.(check string) "kind" "outcome" (kind outcome);
+  check_json "result"
+    (`Assoc [ ("kind", `String "ok"); ("value", int_value 42) ])
+    (get "result" outcome);
+  Alcotest.(check string) "terminal" "ok" (text (get "terminal" (core outcome)));
+  check_json "target"
+    (`Assoc [ ("callable", hash_json f.double); ("kind", `String "store-term-v0") ])
+    (get "target" (core outcome));
+  Alcotest.(check int) "no requests" 0 (List.length (requests outcome));
+  Alcotest.(check int) "no observations" 0 (List.length (observations outcome));
+  Alcotest.(check string) "quiet operator channel" "" run.operator
+
+let test_effect_exchange () =
+  let f = fixture () in
+  let run = run (script [ select (); echo_invoke f "ping"; effect_ok (text_value "pong") ]) in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  match run.frames with
+  | [ hello; request; outcome ] ->
+      check_hello hello;
+      Alcotest.(check string) "request kind" "effect_request" (kind request);
+      check_json "request id" (`String "0000000000000001") (get "request_id" request);
+      check_json "request effect" (hash_json f.world_effect) (get "effect" request);
+      check_json "request operation" (hash_json f.send_operation) (get "operation" request);
+      check_json "request mode" (`String "once") (get "mode" request);
+      check_json "request arguments" (`List [ text_value "ping" ]) (get "arguments" request);
+      check_json "request protocol" (`String Host.protocol) (get "protocol" request);
+      check_json "result"
+        (`Assoc [ ("kind", `String "ok"); ("value", text_value "pong") ])
+        (get "result" outcome);
+      check_json "request evidence"
+        (`List
+           [
+             `Assoc
+               [
+                 ("effect", hash_json f.world_effect);
+                 ("operation", hash_json f.send_operation);
+                 ("ordinal", `Int 1);
+               ];
+           ])
+        (get "effect_requests" (core outcome));
+      check_json "observation"
+        (`List
+           [
+             `Assoc
+               [
+                 ("category", `String "ok"); ("completion", `String "completed"); ("ordinal", `Int 1);
+               ];
+           ])
+        (`List (observations outcome))
+  | frames -> Alcotest.failf "expected hello, request, outcome; got %d frames" (List.length frames)
+
+let test_sequential_requests () =
+  let f = fixture () in
+  let run =
+    run
+      (script
+         [
+           select ();
+           world_invoke f f.twice "first";
+           effect_ok ~ordinal:1 (text_value "second");
+           effect_ok ~ordinal:2 (text_value "third");
+         ])
+  in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  match run.frames with
+  | [ _; first; second; outcome ] ->
+      check_json "first id" (`String "0000000000000001") (get "request_id" first);
+      check_json "first argument" (`List [ text_value "first" ]) (get "arguments" first);
+      check_json "second id" (`String "0000000000000002") (get "request_id" second);
+      check_json "second argument carries the first response"
+        (`List [ text_value "second" ])
+        (get "arguments" second);
+      check_json "final value" (text_value "third") (get "value" (get "result" outcome));
+      Alcotest.(check int) "two requests" 2 (List.length (requests outcome));
+      Alcotest.(check int) "two observations" 2 (List.length (observations outcome))
+  | frames -> Alcotest.failf "expected four frames; got %d" (List.length frames)
+
+let test_host_failures () =
+  let f = fixture () in
+  List.iter
+    (fun (category, completion, code, terminal) ->
+      let run =
+        run (script [ select (); echo_invoke f "ping"; effect_failure category completion ])
+      in
+      check_status category Host_worker.Terminal_written run.status;
+      let outcome = check_outcome ~requests:1 category ~code ~terminal run in
+      check_json (category ^ " observation")
+        (`Assoc
+           [
+             ("category", `String category); ("completion", `String completion); ("ordinal", `Int 1);
+           ])
+        (List.hd (observations outcome)))
+    [
+      ("unsupported_operation", "not_started", "E1606", "host_failure");
+      ("refused_authority", "not_started", "E1607", "host_failure");
+      ("outside_failure", "failed", "E1613", "host_failure");
+      ("completion_unknown", "unknown", "E1612", "completion_unknown");
+    ]
+
+let test_cancellations () =
+  let f = fixture () in
+  List.iter
+    (fun (reason, known_code) ->
+      List.iter
+        (fun completion ->
+          let label = reason ^ "/" ^ completion in
+          let run = run (script [ select (); echo_invoke f "ping"; cancel reason completion ]) in
+          check_status label Host_worker.Terminal_written run.status;
+          let code = if completion = "unknown" then "E1612" else known_code in
+          let terminal = if completion = "unknown" then "completion_unknown" else "cancelled" in
+          let outcome = check_outcome ~requests:1 label ~code ~terminal run in
+          check_json (label ^ " observation")
+            (`Assoc
+               [
+                 ("category", `String reason);
+                 ("completion", `String completion);
+                 ("ordinal", `Int 1);
+               ])
+            (List.hd (observations outcome)))
+        [ "not_started"; "failed"; "unknown" ])
+    [ ("cancelled", "E1614"); ("timeout", "E1609"); ("host_shutdown", "E1610") ]
+
+let test_shutdown () =
+  let run = run (script [ select (); shutdown ]) in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let ack = terminal_after "shutdown" run in
+  check_json "acknowledgement" (Host.shutdown_ack ()) ack;
+  Alcotest.(check string) "quiet operator channel" "" run.operator
+
+let test_preflight_fatals () =
+  let f = fixture () in
+  let cases =
+    [
+      ( "unknown-version",
+        [ replace_field "protocol" (`String "jacquard-host-v1") (select ()) ],
+        "E1600" );
+      ( "nonpositive-selected-limit",
+        [ select ~limits:{ Host.hard_limits with max_frame_bytes = 0 } () ],
+        "E1602" );
+      ( "unknown-invoke-field",
+        [ select (); append_field "display_name" (`String "mutable-name") (double_invoke f 1) ],
+        "E1601" );
+      ( "malformed-target-identity",
+        [
+          select ();
+          update_path [ "target"; "callable" ]
+            (fun _ -> `String (String.make 64 'A'))
+            (double_invoke f 1);
+        ],
+        "E1601" );
+      ( "absent-target",
+        [
+          select ();
+          update_path [ "target"; "callable" ]
+            (fun _ -> `String (String.make 64 'a'))
+            (double_invoke f 1);
+        ],
+        "E1603" );
+      ( "interface-mismatch",
+        [
+          select ();
+          update_path
+            [ "interface"; "parameters"; "0" ]
+            (fun _ -> `Assoc [ ("items", `List []); ("kind", `String "tuple") ])
+            (double_invoke f 1);
+        ],
+        "E1603" );
+      ( "unsupported-secret-value",
+        [
+          select ();
+          update_path [ "arguments"; "0" ]
+            (fun _ -> `Assoc [ ("kind", `String "secret"); ("value", `String "must-not-cross") ])
+            (double_invoke f 1);
+        ],
+        "E1604" );
+      ( "extra-capability",
+        [
+          select ();
+          update_path [ "capabilities"; "effects" ]
+            (fun effects -> `List (items effects @ [ `String (String.make 64 'e') ]))
+            (echo_invoke f "ping");
+        ],
+        "E1605" );
+      ( "multi-operation-registry-entry",
+        [
+          select ();
+          update_path
+            [ "capabilities"; "operations"; "0" ]
+            (fun _ -> send_entry ~mode:"multi" f)
+            (echo_invoke f "ping");
+        ],
+        "E1605" );
+      ("response-before-invoke", [ select (); effect_ok (text_value "early") ], "E1601");
+      ("host-select-twice", [ select (); select () ], "E1601");
+    ]
+  in
+  List.iter
+    (fun (label, frames, code) ->
+      let run = run (script frames) in
+      check_status label Host_worker.Terminal_written run.status;
+      check_fatal label ~code run)
+    cases
+
+let test_unconfigured_operation () =
+  let f = fixture () in
+  let run = run (script [ select (); echo_invoke ~configured:false f "ping" ]) in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let outcome = check_outcome "unconfigured" ~code:"E1606" ~terminal:"diagnostic" run in
+  Alcotest.(check int) "no request left Core" 0 (List.length (requests outcome));
+  check_json "empty registry retained" (`List [])
+    (get "operations" (get "capabilities" (core outcome)))
+
+let test_wrong_response_id () =
+  let f = fixture () in
+  let run =
+    run (script [ select (); echo_invoke f "ping"; effect_ok ~ordinal:2 (text_value "pong") ])
+  in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let outcome = check_outcome ~requests:1 "stale id" ~code:"E1608" ~terminal:"diagnostic" run in
+  Alcotest.(check int) "request retained" 1 (List.length (requests outcome));
+  Alcotest.(check int) "rejected response not observed" 0 (List.length (observations outcome))
+
+let test_message_after_outcome () =
+  let f = fixture () in
+  let run =
+    run
+      (script
+         [
+           select ();
+           echo_invoke f "ping";
+           effect_ok (text_value "pong");
+           effect_ok (text_value "late");
+         ])
+  in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let outcome = terminal_after ~requests:1 "late message" run in
+  check_json "single terminal is the ok outcome"
+    (`Assoc [ ("kind", `String "ok"); ("value", text_value "pong") ])
+    (get "result" outcome)
+
+let test_runtime_failure () =
+  let f = fixture () in
+  let run = run (script [ select (); crash_invoke f 7 ]) in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let outcome = terminal_after "runtime failure" run in
+  Alcotest.(check string) "error result" "error" (kind (get "result" outcome));
+  Alcotest.(check string) "terminal" "diagnostic" (text (get "terminal" (core outcome)));
+  let diagnostic = List.hd (outcome_diagnostics outcome) in
+  Alcotest.(check string)
+    "runtime summary" "Arithmetic operation failed"
+    (text (get "summary" diagnostic));
+  Alcotest.(check string) "runtime domain" "runtime" (text (get "domain" diagnostic))
+
+let test_malformed_response_frame () =
+  let f = fixture () in
+  let run = run (script [ select (); echo_invoke f "ping" ] ^ bytes_of_hex "000000037bff7d") in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  let outcome =
+    check_outcome ~requests:1 "malformed response" ~code:"E1608" ~terminal:"diagnostic" run
+  in
+  Alcotest.(check int) "no observation" 0 (List.length (observations outcome))
+
+let test_oversized_response_frame () =
+  let f = fixture () in
+  let limits = { Host.hard_limits with max_frame_bytes = 4096 } in
+  let run = run (script [ select ~limits (); echo_invoke f "ping" ] ^ bytes_of_hex "00002000") in
+  check_status "exit" Host_worker.Terminal_written run.status;
+  ignore (check_outcome ~requests:1 "oversized response" ~code:"E1602" ~terminal:"diagnostic" run)
+
+let test_raw_framing () =
+  List.iter
+    (fun (label, hex, code) ->
+      let run = run (bytes_of_hex hex) in
+      check_status label Host_worker.Terminal_written run.status;
+      check_fatal label ~code run)
+    [
+      ( "duplicate-json-key",
+        "000000267b226b696e64223a22686f73745f73656c656374222c226b696e64223a22696e766f6b65227d",
+        "E1601" );
+      ("invalid-utf8", "000000037bff7d", "E1601");
+      ("oversized-frame-prefix", "00100001", "E1602");
+    ]
+
+let test_carrier_loss_before_invocation () =
+  List.iter
+    (fun (label, hex) ->
+      let run = run (bytes_of_hex hex) in
+      check_status label Host_worker.Carrier_lost run.status;
+      check_fatal label ~code:"E1611" run;
+      Alcotest.(check bool)
+        (label ^ " operator note") true
+        (String.length run.operator > 0
+        && String.length run.operator <= Host.hard_limits.max_stderr_bytes))
+    [
+      ("truncated-length-prefix", "0000");
+      ("truncated-frame-payload", "000000057b7d");
+      ("empty-input", "");
+    ]
+
+let test_carrier_loss_while_waiting () =
+  let f = fixture () in
+  let run = run (script [ select (); echo_invoke f "ping" ]) in
+  check_status "exit" Host_worker.Carrier_lost run.status;
+  let outcome =
+    check_outcome ~requests:1 "lost while waiting" ~code:"E1611" ~terminal:"diagnostic" run
+  in
+  Alcotest.(check int) "request retained" 1 (List.length (requests outcome));
+  Alcotest.(check int) "no observation" 0 (List.length (observations outcome))
+
+let test_stderr_bound () =
+  List.iter
+    (fun ceiling ->
+      let limits = { Host.hard_limits with max_stderr_bytes = ceiling } in
+      let run = run (script [ select ~limits () ] ^ bytes_of_hex "0000") in
+      check_status "exit" Host_worker.Carrier_lost run.status;
+      Alcotest.(check bool)
+        (Printf.sprintf "operator bytes within %d" ceiling)
+        true
+        (String.length run.operator <= ceiling))
+    [ 1; 8; 40; 200 ]
+
+let test_descriptors_and_channels () =
+  let f = fixture () in
+  let count_descriptors () =
+    if Sys.file_exists "/proc/self/fd" then Some (Array.length (Sys.readdir "/proc/self/fd"))
+    else None
+  in
+  let before = count_descriptors () in
+  let base = fresh_path "channels" in
+  let input_path = base ^ ".in" and output_path = base ^ ".out" and operator_path = base ^ ".err" in
+  write_file input_path (script [ select (); double_invoke f 2 ]);
+  let input = open_in_bin input_path in
+  let output = open_out_bin output_path in
+  let operator = open_out_bin operator_path in
+  let status = Host_worker.serve f.prepared ~input ~output ~operator in
+  check_status "exit" Host_worker.Terminal_written status;
+  (* the worker closes none of the caller's channels *)
+  output_string output "tail";
+  output_string operator "tail";
+  close_out output;
+  close_out operator;
+  close_in input;
+  let after = count_descriptors () in
+  Alcotest.(check (option int)) "no descriptor leak" before after;
+  Alcotest.(check bool)
+    "output channel still owned by the caller" true
+    (Filename.check_suffix (read_file output_path) "tail");
+  Alcotest.(check string)
+    "operator channel still owned by the caller" "tail" (read_file operator_path);
+  List.iter Sys.remove [ input_path; output_path; operator_path ]
+
+let test_prepare_requires_prelude () =
+  let store = expect_ok "open empty store" (Store.open_store (fresh_path "empty")) in
+  match Host_worker.prepare store with
+  | Ok _ -> Alcotest.fail "an unpopulated store must not prepare"
+  | Error (diagnostic :: _) ->
+      Alcotest.(check string) "prelude diagnostic" "E0702" (Diag.code_or_uncoded diagnostic)
+  | Error [] -> Alcotest.fail "prepare returned no diagnostic"
+
+let prop_double_round_trip =
+  QCheck.Test.make ~count:25 ~name:"prop_worker_doubles_every_bounded_int"
+    QCheck.(int_range (-1_000_000) 1_000_000)
+    (fun n ->
+      let f = fixture () in
+      let run = run (script [ select (); double_invoke f n ]) in
+      run.status = Host_worker.Terminal_written
+      &&
+      match run.frames with
+      | [ _; outcome ] ->
+          Yojson.Safe.to_string (get "value" (get "result" outcome))
+          = Yojson.Safe.to_string (int_value (2 * n))
+      | _ -> false)
+
+let suite =
+  [
+    Alcotest.test_case "exit codes are frozen" `Quick test_exit_codes;
+    Alcotest.test_case "pure invocation succeeds on a reopened store" `Quick test_pure_success;
+    Alcotest.test_case "one once operation round-trips through the host" `Quick test_effect_exchange;
+    Alcotest.test_case "sequential requests use increasing ordinals" `Quick test_sequential_requests;
+    Alcotest.test_case "host failures map to frozen terminals" `Quick test_host_failures;
+    Alcotest.test_case "all nine cancellations map to frozen terminals" `Quick test_cancellations;
+    Alcotest.test_case "selected shutdown is acknowledged" `Quick test_shutdown;
+    Alcotest.test_case "preflight failures produce one fatal" `Quick test_preflight_fatals;
+    Alcotest.test_case "unconfigured root operation finishes with E1606" `Quick
+      test_unconfigured_operation;
+    Alcotest.test_case "stale response id finishes with E1608" `Quick test_wrong_response_id;
+    Alcotest.test_case "buffered message after outcome is ignored" `Quick test_message_after_outcome;
+    Alcotest.test_case "runtime failure becomes a bounded diagnostic outcome" `Quick
+      test_runtime_failure;
+    Alcotest.test_case "malformed response frame finishes with E1608" `Quick
+      test_malformed_response_frame;
+    Alcotest.test_case "oversized response frame retains E1602" `Quick test_oversized_response_frame;
+    Alcotest.test_case "raw framing defects produce one fatal" `Quick test_raw_framing;
+    Alcotest.test_case "carrier loss before invocation reports E1611 and exit 74" `Quick
+      test_carrier_loss_before_invocation;
+    Alcotest.test_case "carrier loss while waiting keeps evidence and exits 74" `Quick
+      test_carrier_loss_while_waiting;
+    Alcotest.test_case "operator output honours the selected stderr ceiling" `Quick
+      test_stderr_bound;
+    Alcotest.test_case "worker leaks no descriptor and closes no caller channel" `Quick
+      test_descriptors_and_channels;
+    Alcotest.test_case "prepare fails closed without a prelude" `Quick test_prepare_requires_prelude;
+    QCheck_alcotest.to_alcotest prop_double_round_trip;
+  ]

--- a/test/test_host_worker.ml
+++ b/test/test_host_worker.ml
@@ -41,6 +41,7 @@ let put_src store source =
 let named name hashes = List.assoc name hashes.Canon.named
 
 type fixture = {
+  store_dir : string;
   prepared : Host_worker.prepared;
   int_type : Hash.t;
   text_type : Hash.t;
@@ -86,6 +87,7 @@ let make_fixture () =
   let checker = expect_ok "fixture checker" (Check.make_ctx reopened) in
   let primitives = Check.primitive_types checker in
   {
+    store_dir = dir;
     prepared;
     int_type = primitives.Check.int_type;
     text_type = primitives.Check.text_type;
@@ -683,6 +685,97 @@ let test_descriptors_and_channels () =
     "operator channel still owned by the caller" "tail" (read_file operator_path);
   List.iter Sys.remove [ input_path; output_path; operator_path ]
 
+(* The host closes its read end before Core writes: SIGPIPE must not kill the worker, and the
+   failed frame must not be retried. *)
+let test_output_pipe_closed_in_process () =
+  let f = fixture () in
+  let read_end, write_end = Unix.pipe ~cloexec:true () in
+  Unix.close read_end;
+  let base = fresh_path "epipe" in
+  let input_path = base ^ ".in" and operator_path = base ^ ".err" in
+  write_file input_path (script [ select (); double_invoke f 2 ]);
+  let input = open_in_bin input_path in
+  let output = Unix.out_channel_of_descr write_end in
+  let operator = open_out_bin operator_path in
+  (* keep SIGPIPE ignored around the whole exchange: closing the channel below retries the
+     buffered write, and this test process must not die from the resulting EPIPE *)
+  let previous = Sys.signal Sys.sigpipe Sys.Signal_ignore in
+  let status = Host_worker.serve f.prepared ~input ~output ~operator in
+  Alcotest.(check bool)
+    "SIGPIPE disposition restored to the caller's setting" true
+    (Sys.signal Sys.sigpipe Sys.Signal_ignore == Sys.Signal_ignore);
+  close_in input;
+  close_out_noerr output;
+  close_out operator;
+  Sys.set_signal Sys.sigpipe previous;
+  check_status "exit" Host_worker.Carrier_lost status;
+  let note = read_file operator_path in
+  Alcotest.(check bool)
+    "operator note names the lost hello" true
+    (String.length note > 0
+    && Str.string_match (Str.regexp ".*core_hello could not be written (E1611)") note 0);
+  List.iter Sys.remove [ input_path; operator_path ]
+
+(* Drive the installed binary with a dead standard output. Both cases must exit 74 with one
+   operator note and without any exit-time retry or uncaught exception. *)
+let worker_binary () =
+  match Sys.getenv_opt "JACQUARD" with
+  | Some binary -> binary
+  | None ->
+      let fallback = "../bin/main.exe" in
+      if Sys.file_exists fallback then fallback
+      else Alcotest.fail "set JACQUARD to the built jacquard binary"
+
+let spawn_worker ~store_dir ~stdin_path ~stdout_fd =
+  let binary = worker_binary () in
+  let base = fresh_path "spawn" in
+  let stderr_path = base ^ ".err" in
+  let stdin_fd = Unix.openfile stdin_path [ Unix.O_RDONLY ] 0 in
+  let stderr_fd = Unix.openfile stderr_path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o600 in
+  let pid =
+    Unix.create_process binary
+      [| binary; "host"; "worker"; "--store"; store_dir |]
+      stdin_fd stdout_fd stderr_fd
+  in
+  Unix.close stdin_fd;
+  Unix.close stderr_fd;
+  let _, status = Unix.waitpid [] pid in
+  let stderr_text = read_file stderr_path in
+  Sys.remove stderr_path;
+  (status, stderr_text)
+
+let check_spawned_loss label (status, stderr_text) =
+  (match status with
+  | Unix.WEXITED code -> Alcotest.(check int) (label ^ " exit status") 74 code
+  | Unix.WSIGNALED signal -> Alcotest.failf "%s died from signal %d" label signal
+  | Unix.WSTOPPED _ -> Alcotest.failf "%s stopped" label);
+  Alcotest.(check bool)
+    (label ^ " operator note present")
+    true
+    (Str.string_match (Str.regexp ".*could not be written (E1611)") stderr_text 0);
+  Alcotest.(check bool)
+    (label ^ " no uncaught exception")
+    false
+    (Str.string_match (Str.regexp ".*\\(Fatal error\\|internal error\\)") stderr_text 0)
+
+let test_binary_output_lost () =
+  let f = fixture () in
+  let base = fresh_path "binary" in
+  let stdin_path = base ^ ".in" in
+  write_file stdin_path (script [ select (); double_invoke f 3 ]);
+  (* a pipe whose reader is already gone: every write fails with EPIPE *)
+  let read_end, write_end = Unix.pipe ~cloexec:true () in
+  Unix.close read_end;
+  let pipe_result = spawn_worker ~store_dir:f.store_dir ~stdin_path ~stdout_fd:write_end in
+  Unix.close write_end;
+  check_spawned_loss "closed pipe" pipe_result;
+  (* a descriptor that cannot be written at all *)
+  let unwritable = Unix.openfile Filename.null [ Unix.O_RDONLY ] 0 in
+  let descriptor_result = spawn_worker ~store_dir:f.store_dir ~stdin_path ~stdout_fd:unwritable in
+  Unix.close unwritable;
+  check_spawned_loss "unwritable descriptor" descriptor_result;
+  Sys.remove stdin_path
+
 let test_prepare_requires_prelude () =
   let store = expect_ok "open empty store" (Store.open_store (fresh_path "empty")) in
   match Host_worker.prepare store with
@@ -733,6 +826,10 @@ let suite =
       test_stderr_bound;
     Alcotest.test_case "worker leaks no descriptor and closes no caller channel" `Quick
       test_descriptors_and_channels;
+    Alcotest.test_case "closed output pipe yields carrier loss without a signal" `Quick
+      test_output_pipe_closed_in_process;
+    Alcotest.test_case "installed binary exits 74 on a dead standard output" `Quick
+      test_binary_output_lost;
     Alcotest.test_case "prepare fails closed without a prelude" `Quick test_prepare_requires_prelude;
     QCheck_alcotest.to_alcotest prop_double_round_trip;
   ]

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -28,6 +28,7 @@ let () =
       ("host-boundary-codec", Test_host_boundary_codec.suite);
       ("host-invoke-preflight", Test_host_invoke_preflight.suite);
       ("host-session", Test_host_session.suite);
+      ("host-worker", Test_host_worker.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Context

The host protocol had strict framing, typed codecs, checked invoke preflight,
and a serial session state machine, but no process that a host could start.
A host adapter therefore had nothing executable to pin, and the HB.3
conformance kit could not be produced.

## What changed

`jacquard host worker --store DIR` is the opt-in HB.2c carrier for
`jacquard-host-v0` over `stdio-u32-json-v0`. `Host_worker` runs one worker
lifetime against a host-selected local store:

- writes `core_hello`, accepts one `host_select`, then either answers a
  pre-invocation `shutdown` or evaluates one preflighted invocation;
- installs no root handlers and does not reload the prelude, so every root
  operation the target reaches is served through the closed configured
  registry or ends the invocation with E1606;
- exchanges configured `once` operations in lockstep through
  `Host_protocol_v0.Session`, retaining exactly one sealed continuation while
  a response is outstanding and resuming it at most once;
- flushes exactly one terminal frame, never retries, and ignores buffered
  frames after the terminal;
- bounds standard error to the hard and then the selected `max_stderr_bytes`
  for the whole lifetime, cutting at UTF-8 scalar boundaries;
- ignores `SIGPIPE` for its lifetime and, on carrier loss, discards the
  bytes that could not be written instead of letting an exit-time flush
  resend them;
- reports the frozen exit statuses 0, 64, 70, and 74.

Carrier loss on standard input still flushes a best-effort E1611 frame when
standard output remains writable (a `fatal` before invocation, an error
`outcome` retaining accepted observations while waiting) and then exits 74.
The outcome tells the host which request went unanswered; it does not classify
the host's own outstanding outside action. A malformed or unreadable response
frame ends the invocation with E1608 (E1602 when a selected limit was
exceeded), mirroring the session's classification of parsed responses.

The change is additive to the frozen v0 protocol. Ordinary `jac run`, `check`,
`build`, native artifacts, the interpreted scheduler, kernel forms, hashes,
and canonical identities retain their existing behavior. The contract is in
`docs/host-worker-v0.md`.

## Limits

No stable foreign-host ABI, adapter, cross-language conformance kit, HTTP
server, deadline, memory ceiling, or sandbox claim ships. The worker trusts
the host and operating system (D78). Interpreted Tasks, Channels, `eval`,
`dist`, `infer`, and `secret` operations have no v0 host encoding.

One discrepancy is recorded rather than resolved: the HB.1 vector
`noncanonical-target-hash` expects E1603, while the shipped HB.2b2 preflight
already pins an uppercase hash as a malformed scalar (E1601). HB.3 needs a
reviewed decision before packaging the executable fixtures.

## Validation and review

- Clean `dune build @all @doc`, `NO_COLOR=1 dune runtest`, formatting, and
  version smoke pass on the final head: 1007 Alcotest/QCheck cases,
  61 cram transcript files, 28 documentation examples. The four release
  inventory records are updated to `1007 / 61`.
- The 23 worker cases cover a reopened prelude-less startup, pure and
  effectful invocations, sequential ordinals, all four host-failure and nine
  cancellation mappings, shutdown, preflight fatals for E1600–E1605, an
  unconfigured operation, stale and malformed responses, buffered
  post-terminal frames, runtime failures, raw framing defects, carrier loss
  before and during an invocation, a dead output pipe both in-process and
  through the installed binary, an unwritable output descriptor, the selected
  stderr ceiling, descriptor and channel ownership, an unpopulated store, and
  a QCheck round-trip property.
- `test/cli/host-worker.t` pins the same exchanges and exit statuses through
  the installed binary against a store populated by `jacquard run --store`,
  including a closed standard output.
- Historical manifests are unchanged. Native parity, governance/browser, and
  GM.12B evidence apply to unchanged semantic inputs; the required CI contexts
  rerun them before merge.

Independent review (fresh reviewer per pass, base `9232e38`):

- Review 1 on `87d02ea`: **BLOCK**. A host that closed its read end killed
  the worker with SIGPIPE (exit 141); with SIGPIPE ignored, the exit-time
  channel flush retried the failed frame and crashed (exit 2). Fixed in
  `f191ee2` as described above. Nonblocking notes were dispositioned: write
  failure notes now name the actual diagnostic code; spec section 11 states
  when Core may flush a best-effort E1611 frame; the untested multibyte
  stderr cut and the unreachable exit 64 path remain deferred debt.
- Review 2 on `f191ee29e5d8239326d8f8587ac92af5fb8f480a`: **PASS**, no
  blockers. The reviewer rebuilt, populated a store, and reproduced the
  original failure modes under strace: a reader closed before `core_hello`,
  a closed descriptor 1, a read-only descriptor 1, and a reader that closes
  mid-invocation all exit 74 with one operator note, no signal death, and no
  write reaching the host after the failed one; the SIGPIPE disposition is
  restored after `serve` returns.
- Deferred debt recorded for follow-up, not changed here to keep the
  reviewed head: the in-process pipe test's disposition assertion is weaker
  than the strace evidence; a startup guard for closed descriptors 0-2 would
  remove a dependency on store loading retaining no descriptor; startup
  configuration failures exit 1 rather than a protocol status.

Final checks: the required contexts run on the reviewed head; auto-merge
(squash) is enabled only after they pass. No delta since review.
