### PR TITLE
HB.3a: add the executable host-protocol conformance kit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,10 @@ When adding valid corpus files, regenerate the golden hashes with
   accounting: `Host_protocol_v0.Session`, `test/test_host_session.ml`, and
   `docs/host-session-v0.md`. The opt-in serial carrier `jac host worker`:
   `src/host_worker.ml`, `test/test_host_worker.ml`, `test/cli/host-worker.t`,
-  and `docs/host-worker-v0.md`. Existing evaluator capture and host-readiness
+  and `docs/host-worker-v0.md`. The executable conformance kit and its fake
+  host: `spec/host-protocol-v0/kit/`, `test/host_kit.ml`,
+  `test/test_host_kit.ml`, regenerated with `dune exec test/gen_host_kit.exe`.
+  Existing evaluator capture and host-readiness
   modules are internal seams, not a public ABI; adapters and application
   servers belong outside this repository.
 - Dist and inference: `prelude/06-dist.jqd`, `prelude/13-dist-lib.jqd`,

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,8 @@ project shape from file names alone.
   and closed once-operation registries. The [session layer](host-session-v0.md)
   accounts for serial responses and terminal evidence, and the
   [HB.2c worker](host-worker-v0.md) is the opt-in `jacquard host worker`
-  process carrier. No cross-language conformance kit ships until HB.3.
+  process carrier. The [HB.3 kit](../spec/host-protocol-v0/kit/README.md)
+  binds the vectors to real fixtures and replays them through the worker.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -908,8 +908,9 @@ Do not invent new kernel forms for surface sugar.
   for bounded evidence, and returns request/resume/terminal actions
   (`host-session-v0.md`). HB.2c ships `jac host worker --store DIR`, the
   opt-in serial process carrier that evaluates one preflighted invocation over
-  stdin/stdout frames (`host-worker-v0.md`). No stable foreign-host ABI,
-  adapter, cross-language conformance kit, or HTTP server ships yet.
+  stdin/stdout frames (`host-worker-v0.md`). HB.3a publishes the executable
+  conformance kit under `spec/host-protocol-v0/kit/`. No stable foreign-host
+  ABI, adapter, or HTTP server ships yet.
   Internal evaluator-capture and host-readiness OCaml APIs are not supported
   embedding contracts; future adapters must consume the versioned protocol and
   its executable conformance fixtures, not those OCaml seams.

--- a/docs/host-worker-v0.md
+++ b/docs/host-worker-v0.md
@@ -122,5 +122,5 @@ binary, and a property that doubling round-trips every bounded integer. `test/cl
 pins the same exchanges through the installed `jacquard` binary, including the
 exit statuses. The HB.1 vector corpus remains the schema/state contract; its
 `noncanonical-target-hash` case names E1603 while the shipped preflight
-classifies an uppercase hash as a malformed scalar (E1601), a discrepancy to
-resolve when HB.3 packages the executable fixtures.
+classifies an uppercase hash as a malformed scalar (E1601); the kit records
+this under its pending decisions for a reviewed resolution.

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `1007`
+Test count: `1014`
 
 Cram count: `61`
 
@@ -59,5 +59,13 @@ the current source inventory to `1007 / 61 / 28`. It covers the full
 `stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
 invocations, every frozen host-failure and cancellation mapping, preflight
 fatals, stale and malformed responses, carrier loss, the selected stderr
-ceiling, descriptor ownership, and exit statuses. No cross-language conformance
-kit is published until HB.3. See [the worker contract](../../host-worker-v0.md).
+ceiling, descriptor ownership, and exit statuses. See
+[the worker contract](../../host-worker-v0.md).
+
+The HB.3 conformance kit adds 7 cases, bringing the current source inventory
+to `1014 / 61 / 28`. It installs the kit fixtures with the published recipe,
+binds every synthetic HB.1 vector identity to a real store member, replays all
+21 vector transcripts and all 13 terminal mappings through the installed
+worker with a deterministic fake host, and fails on any divergence that is not
+an explicitly recorded pending decision. See
+[the kit README](../../../spec/host-protocol-v0/kit/README.md).

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `1007`
+- Alcotest/QCheck cases: `1014`
 - Cram transcript files: `61`
 - Documentation examples: `28` named examples across `8` documents
 
@@ -104,5 +104,13 @@ the current source inventory to `1007 / 61 / 28`. It covers the full
 `stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
 invocations, every frozen host-failure and cancellation mapping, preflight
 fatals, stale and malformed responses, carrier loss, the selected stderr
-ceiling, descriptor ownership, and exit statuses. No cross-language conformance
-kit is published until HB.3. See [the worker contract](../../host-worker-v0.md).
+ceiling, descriptor ownership, and exit statuses. See
+[the worker contract](../../host-worker-v0.md).
+
+The HB.3 conformance kit adds 7 cases, bringing the current source inventory
+to `1014 / 61 / 28`. It installs the kit fixtures with the published recipe,
+binds every synthetic HB.1 vector identity to a real store member, replays all
+21 vector transcripts and all 13 terminal mappings through the installed
+worker with a deterministic fake host, and fails on any divergence that is not
+an explicitly recorded pending decision. See
+[the kit README](../../../spec/host-protocol-v0/kit/README.md).

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `1007`
+- Alcotest/QCheck cases: `1014`
 - Cram transcript files: `61`
 - Doctest examples: `28` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `1007`
+- Alcotest/QCheck cases: `1014`
 - Cram transcript files: `61`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled

--- a/spec/host-protocol-v0.md
+++ b/spec/host-protocol-v0.md
@@ -609,8 +609,11 @@ process carrier in `Host_worker`: it evaluates the preflighted target without
 root handlers, exchanges configured once operations through the session
 layer, flushes exactly one terminal frame, bounds operator output, and reports
 the exit statuses of section 3. Its ownership and lifecycle table is
-[`docs/host-worker-v0.md`](../docs/host-worker-v0.md). No cross-language
-conformance kit is published until HB.3.
+[`docs/host-worker-v0.md`](../docs/host-worker-v0.md). HB.3 publishes the
+executable kit under [`host-protocol-v0/kit/`](host-protocol-v0/kit/README.md):
+fixture declarations, a manifest binding every synthetic vector identity to a
+real store member, and one replayable transcript per vector, produced and
+checked by a deterministic fake host against the installed worker.
 
 A conforming implementation must:
 

--- a/spec/host-protocol-v0/kit/README.md
+++ b/spec/host-protocol-v0/kit/README.md
@@ -45,9 +45,15 @@ case exists to prove that Core rejects it.
    and `transcripts.json` in the adapter's compatibility record.
 2. Build the store with the recipe and check that the identities in
    `kit.json` resolve, so the adapter is talking to the same fixtures.
-3. For each transcript, start one worker, send the recorded host input in
-   lockstep (one host frame after each expected Core frame), and compare the
-   Core frames, exit status, and observed summary with the transcript.
+3. For each transcript, start one worker and play the recorded steps in
+   order: read one Core frame for each `core_to_host` step and write one host
+   frame (or the raw bytes) for each `host_to_core` step. The two negotiation
+   frames, `host_select` and `invoke`, are consecutive host steps. Never write
+   after a terminal frame has been read: a recorded host step that follows
+   the terminal is counted under `host_inputs_skipped_after_terminal`, and the
+   `after_terminal` step of the terminal-phase case must be refused locally
+   as E1608. Compare the Core frames, exit status, and observed summary with
+   the transcript.
 4. Compare semantic JSON: key order and insignificant whitespace do not
    matter. Diagnostic prose (`summary`, `cause`, `next_step`, `contrast`) is
    Core-authored human text and is not normative; the schema, domain, code,

--- a/spec/host-protocol-v0/kit/README.md
+++ b/spec/host-protocol-v0/kit/README.md
@@ -1,0 +1,90 @@
+# Host protocol v0 conformance kit
+
+This directory turns the frozen HB.1 schema/state vectors in
+[`../vectors.json`](../vectors.json) into executable fixtures for the
+`jacquard-host-v0` protocol over the `stdio-u32-json-v0` carrier. An adapter
+in any language pins this kit, drives the installed `jacquard host worker`,
+and must observe exactly the Core frames recorded here.
+
+## Files
+
+- `fixtures.jac`: first-party fixture declarations. Install them once with
+  the published recipe, `jacquard run fixtures.jac --store DIR`, using the
+  prelude shipped with the same Core release.
+- `kit.json`: the manifest. It records the protocol and carrier names, the
+  Core version that produced the kit, the recipe, the exact identities of
+  every fixture member, the binding from each synthetic 64-digit vector
+  identity to a kit member, the hard limits, the fields an adapter owns, and
+  every pending decision.
+- `transcripts.json`: one entry per positive and hostile vector. Each entry
+  lists the host frames in order (or the raw bytes for wire cases), the Core
+  frames the worker emitted, the exit status, the observed primary code and
+  terminal classification, the host's local refusal for the terminal-phase
+  case, and a status of `conforms` or `diverges`.
+
+## Binding
+
+The vectors use synthetic identities so that they can be frozen without a
+store. The kit binds them to real content-addressed members:
+
+| Vector identity | Kit member |
+|---|---|
+| `aaaa…` | `kit-ready : () ->{} ()` |
+| `dddd…` | `kit-echo : (Text) ->{KitWorld} Text` |
+| `bbbb…` | the `KitWorld` effect |
+| `cccc…` | its `send : (Text) -> Text` operation |
+| `1111…` | the `Text` type |
+
+Every other synthetic identity in a hostile mutation (for example the extra
+capability `eeee…` or the uppercase target) is left as written, because the
+case exists to prove that Core rejects it.
+
+## How an adapter uses the kit
+
+1. Pin `protocol`, `carrier`, `core_version`, and the SHA-256 of `kit.json`
+   and `transcripts.json` in the adapter's compatibility record.
+2. Build the store with the recipe and check that the identities in
+   `kit.json` resolve, so the adapter is talking to the same fixtures.
+3. For each transcript, start one worker, send the recorded host input in
+   lockstep (one host frame after each expected Core frame), and compare the
+   Core frames, exit status, and observed summary with the transcript.
+4. Compare semantic JSON: key order and insignificant whitespace do not
+   matter. Diagnostic prose (`summary`, `cause`, `next_step`, `contrast`) is
+   Core-authored human text and is not normative; the schema, domain, code,
+   severity, and span are, and an `effect_failure` message must end the first
+   diagnostic's cause exactly.
+5. Treat any divergence as a protocol or implementation finding. An adapter
+   must never normalise its own frames to make a transcript pass.
+
+Fields an adapter owns and may add outside the Core frames are named under
+`host_owned` in `kit.json`; nothing inside a Core frame is host-owned.
+
+## The fake host
+
+`test/host_kit.ml` contains the deterministic fake host used to produce and
+replay these transcripts. It spawns the installed worker over pipes, writes
+host frames only when it is the host's turn, refuses to send after it has
+observed a terminal frame (recording the local E1608 the protocol requires),
+closes its input after raw wire cases, and records every Core frame, the exit
+status, and the bounded operator text. It is evidence tooling, not an adapter
+or embedding contract.
+
+## Regeneration and drift
+
+`dune exec test/gen_host_kit.exe` from the repository root rebuilds the store
+with the recipe, replays every vector, and rewrites `kit.json` and
+`transcripts.json`. `test/test_host_kit.ml` fails when a regenerated
+transcript differs from the checked-in one, when a positive sequence stops
+matching its bound HB.1 template, when a hostile case stops producing its
+expected primary code, or when a divergence appears that is not listed under
+`pending_decisions`.
+
+Changing a vector's expected code or shape remains a reviewed protocol
+decision, never a mechanical refresh. Two kinds of drift are recorded rather
+than resolved here:
+
+- `pending_decisions` lists `noncanonical-target-hash`, whose vector expects
+  E1603 while the shipped preflight classifies an uppercase hash as a
+  malformed scalar (E1601) under the frozen fail-fast order.
+- `diagnostic_prose.drift` lists the outcome diagnostics whose vector prose
+  differs from the prose the shipped session layer emits for the same code.

--- a/spec/host-protocol-v0/kit/fixtures.jac
+++ b/spec/host-protocol-v0/kit/fixtures.jac
@@ -1,0 +1,21 @@
+-- Conformance kit fixtures for jacquard-host-v0.
+-- Install once with `jacquard run fixtures.jac --store DIR`; kit.json records
+-- the resulting identities and binds them to the synthetic HB.1 vectors.
+once effect KitWorld where {
+  send : (Text) -> Text
+}
+
+kit-ready : () ->{} ()
+kit-ready() = ()
+
+kit-echo : (Text) ->{KitWorld} Text
+kit-echo(body) = send(body)
+
+kit-twice : (Text) ->{KitWorld} Text
+kit-twice(body) = send(send(body))
+
+kit-double : (Int) ->{} Int
+kit-double(n) = mul(n, 2)
+
+kit-fail : (Int) ->{} Int
+kit-fail(n) = div(n, 0)

--- a/spec/host-protocol-v0/kit/kit.json
+++ b/spec/host-protocol-v0/kit/kit.json
@@ -1,0 +1,106 @@
+{
+  "bindings": {
+    "1111111111111111111111111111111111111111111111111111111111111111": {
+      "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+      "member": "text"
+    },
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+      "identity": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+      "member": "kit-ready"
+    },
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+      "identity": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+      "member": "kit-world"
+    },
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc": {
+      "identity": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+      "member": "send"
+    },
+    "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd": {
+      "identity": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+      "member": "kit-echo"
+    }
+  },
+  "carrier": "stdio-u32-json-v0",
+  "core_version": "0.2.0",
+  "diagnostic_prose": {
+    "cause_suffix_rule": "an effect_failure message must end the first diagnostic's cause",
+    "compared": [ "schema", "domain", "code", "severity", "span" ],
+    "drift": [
+      {
+        "path": "refused_outcome/result/diagnostics/0/summary",
+        "transcript": "refused-authority"
+      },
+      {
+        "path": "refused_outcome/result/diagnostics/0/cause",
+        "transcript": "refused-authority"
+      },
+      {
+        "path": "refused_outcome/result/diagnostics/0/next_step",
+        "transcript": "refused-authority"
+      },
+      {
+        "path": "timeout_unknown_outcome/result/diagnostics/0/summary",
+        "transcript": "timeout-with-unknown-completion"
+      },
+      {
+        "path": "timeout_unknown_outcome/result/diagnostics/0/cause",
+        "transcript": "timeout-with-unknown-completion"
+      },
+      {
+        "path": "timeout_unknown_outcome/result/diagnostics/0/next_step",
+        "transcript": "timeout-with-unknown-completion"
+      }
+    ],
+    "normative": false
+  },
+  "hard_limits": {
+    "max_arguments": 64,
+    "max_collection_items": 1024,
+    "max_diagnostic_bytes": 65536,
+    "max_diagnostics": 32,
+    "max_effect_requests": 1024,
+    "max_effects": 64,
+    "max_frame_bytes": 1048576,
+    "max_host_message_bytes": 4096,
+    "max_json_depth": 64,
+    "max_operations": 256,
+    "max_stderr_bytes": 65536,
+    "max_text_bytes": 262144,
+    "max_value_nodes": 4096
+  },
+  "host_owned": [
+    "operator text on the worker's standard error",
+    "the exact moment a carrier loss is observed",
+    "any run identifier, timestamp, peer identity, or receipt an adapter records outside the Core frames"
+  ],
+  "identities": {
+    "int": "907085f5670ab5835e5356feb10ae729496e3816b863ddbb21cfe289e7d34f0d",
+    "kit-double": "1e5b4939f0d7b13b0502fbb04d75659a7e01ee4927ad8a5f1c64637c90357c8f",
+    "kit-echo": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+    "kit-fail": "d337c5d51261e63407923b4aaaf6c411bee7185711358523e9c77626d9152a36",
+    "kit-ready": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+    "kit-twice": "2451609ed1af76f59a8ec47a9f3bd792e1e888e0ffaa6518e3f097a66339cd23",
+    "kit-world": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+    "send": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+    "text": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3"
+  },
+  "pending_decisions": [
+    {
+      "expected": "E1603",
+      "name": "noncanonical-target-hash",
+      "observed": "E1601"
+    }
+  ],
+  "protocol": "jacquard-host-v0",
+  "recipe": {
+    "command": "jacquard run fixtures.jac --store DIR",
+    "fixtures": "fixtures.jac",
+    "prelude": "the prelude shipped with the same Core release",
+    "worker": "jacquard host worker --store DIR"
+  },
+  "schema": "jacquard-host-kit-v0",
+  "transcript_count": 21,
+  "transcripts": "transcripts.json",
+  "vectors": "../vectors.json"
+}

--- a/spec/host-protocol-v0/kit/transcripts.json
+++ b/spec/host-protocol-v0/kit/transcripts.json
@@ -1,0 +1,3066 @@
+[
+  {
+    "name": "pure-success",
+    "kind": "positive",
+    "base": null,
+    "phase": null,
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": { "terminal": "ok" },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": { "effects": [], "operations": [] },
+            "effect_requests": [],
+            "interface": {
+              "effects": [],
+              "parameters": [],
+              "result": { "items": [], "kind": "tuple" }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+              "kind": "store-term-v0"
+            },
+            "terminal": "ok"
+          },
+          "host_observations": {
+            "responses": [],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": { "kind": "ok", "value": { "items": [], "kind": "tuple" } }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": null,
+      "terminal": "ok",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "one-once-effect-success",
+    "kind": "positive",
+    "base": null,
+    "phase": null,
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": { "terminal": "ok" },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "arguments": [ { "kind": "text", "value": "ping" } ],
+        "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_request",
+        "mode": "once",
+        "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "operations": [
+                {
+                  "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                  "mode": "once",
+                  "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+              "kind": "store-term-v0"
+            },
+            "terminal": "ok"
+          },
+          "host_observations": {
+            "responses": [
+              { "category": "ok", "completion": "completed", "ordinal": 1 }
+            ],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "kind": "ok",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": null,
+      "terminal": "ok",
+      "effect_requests": 1,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "refused-authority",
+    "kind": "positive",
+    "base": null,
+    "phase": null,
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_refused", "refused_outcome"
+    ],
+    "expect": { "terminal": "host_failure" },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_refused",
+        "frame": {
+          "category": "refused_authority",
+          "completion": "not_started",
+          "invocation_id": "0000000000000000",
+          "kind": "effect_failure",
+          "message": "policy denied",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001"
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "refused_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "arguments": [ { "kind": "text", "value": "ping" } ],
+        "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_request",
+        "mode": "once",
+        "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "operations": [
+                {
+                  "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                  "mode": "once",
+                  "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+              "kind": "store-term-v0"
+            },
+            "terminal": "host_failure"
+          },
+          "host_observations": {
+            "responses": [
+              {
+                "category": "refused_authority",
+                "completion": "not_started",
+                "ordinal": 1
+              }
+            ],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "diagnostics": [
+            {
+              "cause": "The host reported an outside failure. Host detail: policy denied",
+              "code": "E1607",
+              "domain": "process",
+              "next_step": "Review the host's authority policy before starting a new invocation.",
+              "schema": "jacquard-diagnostic-v1",
+              "severity": "error",
+              "span": null,
+              "summary": "The host refused authority before starting the outside action."
+            }
+          ],
+          "kind": "error"
+        }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": "E1607",
+      "terminal": "host_failure",
+      "effect_requests": 1,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [
+      "refused_outcome/result/diagnostics/0/summary",
+      "refused_outcome/result/diagnostics/0/cause",
+      "refused_outcome/result/diagnostics/0/next_step"
+    ],
+    "status": "conforms"
+  },
+  {
+    "name": "timeout-with-unknown-completion",
+    "kind": "positive",
+    "base": null,
+    "phase": null,
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "timeout_unknown_cancel", "timeout_unknown_outcome"
+    ],
+    "expect": { "terminal": "completion_unknown" },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "timeout_unknown_cancel",
+        "frame": {
+          "completion": "unknown",
+          "invocation_id": "0000000000000000",
+          "kind": "cancel",
+          "protocol": "jacquard-host-v0",
+          "reason": "timeout",
+          "request_id": "0000000000000001"
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "timeout_unknown_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "arguments": [ { "kind": "text", "value": "ping" } ],
+        "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_request",
+        "mode": "once",
+        "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "operations": [
+                {
+                  "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                  "mode": "once",
+                  "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+              "kind": "store-term-v0"
+            },
+            "terminal": "completion_unknown"
+          },
+          "host_observations": {
+            "responses": [
+              {
+                "category": "timeout",
+                "completion": "unknown",
+                "ordinal": 1
+              }
+            ],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "diagnostics": [
+            {
+              "cause": "The host ended the response slot without a successful value.",
+              "code": "E1612",
+              "domain": "process",
+              "next_step": "Reconcile host-owned evidence; do not automatically retry the action or invocation.",
+              "schema": "jacquard-diagnostic-v1",
+              "severity": "error",
+              "span": null,
+              "summary": "The outside action's completion is unknown."
+            }
+          ],
+          "kind": "error"
+        }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": "E1612",
+      "terminal": "completion_unknown",
+      "effect_requests": 1,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [
+      "timeout_unknown_outcome/result/diagnostics/0/summary",
+      "timeout_unknown_outcome/result/diagnostics/0/cause",
+      "timeout_unknown_outcome/result/diagnostics/0/next_step"
+    ],
+    "status": "conforms"
+  },
+  {
+    "name": "selected-shutdown",
+    "kind": "positive",
+    "base": null,
+    "phase": null,
+    "sequence": [ "core_hello", "host_select", "shutdown", "shutdown_ack" ],
+    "expect": { "terminal": "shutdown" },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "shutdown",
+        "frame": { "kind": "shutdown", "protocol": "jacquard-host-v0" }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "shutdown_ack" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      { "kind": "shutdown_ack", "protocol": "jacquard-host-v0" }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "shutdown_ack",
+      "primary_code": null,
+      "terminal": "shutdown",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "unknown-version",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "host_select",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1600",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v1"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The selected protocol version is not advertised.",
+            "code": "E1600",
+            "domain": "process",
+            "next_step": "Select jacquard-host-v0 with the advertised stdio-u32-json-v0 carrier.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host selected an unsupported protocol version."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1600",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "unknown-invoke-field",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "invoke",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1601",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "display_name": "mutable-name",
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The protocol envelope has a missing or unknown field.",
+            "code": "E1601",
+            "domain": "process",
+            "next_step": "Send one exact UTF-8 JSON object using the frozen jacquard-host-v0 envelope.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host protocol frame is malformed."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1601",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "duplicate-json-key",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "framing",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1601",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "raw_hex": "000000267b226b696e64223a22686f73745f73656c656374222c226b696e64223a22696e766f6b65227d"
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "A JSON object contains a duplicate field name.",
+            "code": "E1601",
+            "domain": "process",
+            "next_step": "Send one exact UTF-8 JSON object using the frozen jacquard-host-v0 envelope.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host protocol frame is malformed."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1601",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "invalid-utf8",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "framing",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1601",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      { "step": 1, "direction": "host_to_core", "raw_hex": "000000037bff7d" },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The frame payload is not valid Unicode scalar UTF-8.",
+            "code": "E1601",
+            "domain": "process",
+            "next_step": "Send one exact UTF-8 JSON object using the frozen jacquard-host-v0 envelope.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host protocol frame is malformed."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1601",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "oversized-frame-prefix",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "framing",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1602",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      { "step": 1, "direction": "host_to_core", "raw_hex": "00100001" },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The frame payload length exceeds max_frame_bytes.",
+            "code": "E1602",
+            "domain": "process",
+            "next_step": "Choose positive advertised limits and keep the frame within the selected ceilings.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host protocol limit was exceeded or cannot represent a mandatory result."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1602",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "nonpositive-selected-limit",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "host_select",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1602",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 0,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The selected max_frame_bytes is not positive and advertised.",
+            "code": "E1602",
+            "domain": "process",
+            "next_step": "Choose positive advertised limits and keep the frame within the selected ceilings.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host protocol limit was exceeded or cannot represent a mandatory result."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1602",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "noncanonical-target-hash",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "invoke",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1603",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The target callable identity must be exactly 64 lowercase hexadecimal digits.",
+            "code": "E1601",
+            "domain": "process",
+            "next_step": "Send one exact UTF-8 JSON object using the frozen jacquard-host-v0 envelope.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host protocol frame is malformed."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1601",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "diverges"
+  },
+  {
+    "name": "interface-mismatch",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "invoke",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1603",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [ { "items": [], "kind": "tuple" } ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The pinned interface disagrees with the checked target arrow.",
+            "code": "E1603",
+            "domain": "process",
+            "next_step": "Select one complete checked store-term closure and use its exact first-order interface.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The selected Jacquard target or pinned interface is invalid."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1603",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 1
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "unsupported-secret-value",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "invoke",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1604",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "secret", "value": "must-not-cross" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "Boundary value kind \"secret\" is not supported in jacquard-host-v0.",
+            "code": "E1604",
+            "domain": "process",
+            "next_step": "Use only the frozen closed first-order type and lossless value descriptor subset.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "A Jacquard type or value is unsupported at the v0 host boundary."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1604",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 1
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "extra-capability",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "invoke",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1605",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+              "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "Capability effects do not exactly equal the pinned interface row.",
+            "code": "E1605",
+            "domain": "process",
+            "next_step": "Use the exact checked effect set and a sorted unique registry of its public once operations.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The selected host capability or operation registry is invalid."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1605",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 1
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "multi-operation-registry-entry",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "invoke",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1605",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "multi",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "A registry entry does not select mode once.",
+            "code": "E1605",
+            "domain": "process",
+            "next_step": "Use the exact checked effect set and a sorted unique registry of its public once operations.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The selected host capability or operation registry is invalid."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1605",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 1
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "unconfigured-root-operation",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "evaluation",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1606",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": []
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "operations": []
+            },
+            "effect_requests": [],
+            "interface": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+              "kind": "store-term-v0"
+            },
+            "terminal": "diagnostic"
+          },
+          "host_observations": {
+            "responses": [],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "diagnostics": [
+            {
+              "cause": "The root operation is absent from the configured registry.",
+              "code": "E1606",
+              "domain": "process",
+              "next_step": "Configure the exact operation before starting a new invocation.",
+              "schema": "jacquard-diagnostic-v1",
+              "severity": "error",
+              "span": null,
+              "summary": "The root operation has no configured host implementation."
+            }
+          ],
+          "kind": "error"
+        }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": "E1606",
+      "terminal": "diagnostic",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 1
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "wrong-response-id",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "effect_response",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1608",
+      "effect_requests_before_failure": 1,
+      "forbid_outside_action": false,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000002",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "arguments": [ { "kind": "text", "value": "ping" } ],
+        "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_request",
+        "mode": "once",
+        "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "operations": [
+                {
+                  "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                  "mode": "once",
+                  "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+              "kind": "store-term-v0"
+            },
+            "terminal": "diagnostic"
+          },
+          "host_observations": {
+            "responses": [],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "diagnostics": [
+            {
+              "cause": "The host response is malformed or disagrees with its checked result type.",
+              "code": "E1608",
+              "domain": "process",
+              "next_step": "Send only the next message permitted by the serial jacquard-host-v0 state machine.",
+              "schema": "jacquard-diagnostic-v1",
+              "severity": "error",
+              "span": null,
+              "summary": "The host protocol message is invalid in the current state."
+            }
+          ],
+          "kind": "error"
+        }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": "E1608",
+      "terminal": "diagnostic",
+      "effect_requests": 1,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "message-after-outcome",
+    "kind": "hostile",
+    "base": "one-once-effect-success",
+    "phase": "terminal",
+    "sequence": [
+      "core_hello", "host_select", "effect_invoke", "effect_request",
+      "effect_ok", "effect_outcome"
+    ],
+    "expect": {
+      "code": "E1608",
+      "effect_requests_before_failure": 1,
+      "forbid_outside_action": false,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      {
+        "step": 1,
+        "direction": "host_to_core",
+        "template": "host_select",
+        "frame": {
+          "kind": "host_select",
+          "limits": {
+            "max_arguments": 64,
+            "max_collection_items": 1024,
+            "max_diagnostic_bytes": 65536,
+            "max_diagnostics": 32,
+            "max_effect_requests": 1024,
+            "max_effects": 64,
+            "max_frame_bytes": 1048576,
+            "max_host_message_bytes": 4096,
+            "max_json_depth": 64,
+            "max_operations": 256,
+            "max_stderr_bytes": 65536,
+            "max_text_bytes": 262144,
+            "max_value_nodes": 4096
+          },
+          "protocol": "jacquard-host-v0"
+        }
+      },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "effect_invoke",
+        "frame": {
+          "arguments": [ { "kind": "text", "value": "ping" } ],
+          "capabilities": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "operations": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "mode": "once",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+              }
+            ]
+          },
+          "interface": {
+            "effects": [
+              "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+            ],
+            "parameters": [
+              {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            ],
+            "result": {
+              "arguments": [],
+              "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+              "kind": "nominal"
+            }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      {
+        "step": 3,
+        "direction": "core_to_host",
+        "template": "effect_request"
+      },
+      {
+        "step": 4,
+        "direction": "host_to_core",
+        "template": "effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      },
+      {
+        "step": 5,
+        "direction": "core_to_host",
+        "template": "effect_outcome"
+      },
+      {
+        "step": 6,
+        "direction": "host_to_core",
+        "template": "late_effect_ok",
+        "frame": {
+          "invocation_id": "0000000000000000",
+          "kind": "effect_ok",
+          "protocol": "jacquard-host-v0",
+          "request_id": "0000000000000001",
+          "value": { "kind": "text", "value": "late" }
+        },
+        "after_terminal": true
+      }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "arguments": [ { "kind": "text", "value": "ping" } ],
+        "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+        "invocation_id": "0000000000000000",
+        "kind": "effect_request",
+        "mode": "once",
+        "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+        "protocol": "jacquard-host-v0",
+        "request_id": "0000000000000001"
+      },
+      {
+        "evidence": {
+          "core": {
+            "capabilities": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "operations": [
+                {
+                  "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                  "mode": "once",
+                  "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722"
+                }
+              ]
+            },
+            "effect_requests": [
+              {
+                "effect": "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0",
+                "operation": "3120a126f44773feba44f437ef0d2514e5e55764e1c0667f6434561f430c5722",
+                "ordinal": 1
+              }
+            ],
+            "interface": {
+              "effects": [
+                "44b60d80136d8f1366f32889d56ced087381a1ef31646d7ff173d5c36bbe4db0"
+              ],
+              "parameters": [
+                {
+                  "arguments": [],
+                  "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                  "kind": "nominal"
+                }
+              ],
+              "result": {
+                "arguments": [],
+                "identity": "ca456459bd7fbe8c9694388e1246c4333221817248d24707f05b7423828516e3",
+                "kind": "nominal"
+              }
+            },
+            "invocation_id": "0000000000000000",
+            "schema": "jacquard-host-core-evidence-v0",
+            "target": {
+              "callable": "91d93eb6a5a3390035a17eb4d4ce24cf8e18369e458d0382f17328fd9df303d2",
+              "kind": "store-term-v0"
+            },
+            "terminal": "ok"
+          },
+          "host_observations": {
+            "responses": [
+              { "category": "ok", "completion": "completed", "ordinal": 1 }
+            ],
+            "schema": "jacquard-host-observations-v0"
+          }
+        },
+        "invocation_id": "0000000000000000",
+        "kind": "outcome",
+        "protocol": "jacquard-host-v0",
+        "result": {
+          "kind": "ok",
+          "value": { "kind": "text", "value": "pong" }
+        }
+      }
+    ],
+    "exit_status": 0,
+    "observed": {
+      "terminal_kind": "outcome",
+      "primary_code": null,
+      "terminal": "ok",
+      "effect_requests": 1,
+      "terminal_frames": 1,
+      "host_local_refusal": "E1608",
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "truncated-length-prefix",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "framing",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1611",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      { "step": 1, "direction": "host_to_core", "raw_hex": "0000" },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The carrier ended before the declared frame completed.",
+            "code": "E1611",
+            "domain": "process",
+            "next_step": "Treat the missing terminal exchange as host-owned carrier-failure evidence.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host carrier was lost before a trustworthy frame completed."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 74,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1611",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  },
+  {
+    "name": "truncated-frame-payload",
+    "kind": "hostile",
+    "base": "pure-success",
+    "phase": "framing",
+    "sequence": [
+      "core_hello", "host_select", "pure_invoke", "pure_outcome"
+    ],
+    "expect": {
+      "code": "E1611",
+      "effect_requests_before_failure": 0,
+      "forbid_outside_action": true,
+      "terminal_frames_max": 1
+    },
+    "host_input": [
+      { "step": 0, "direction": "core_to_host", "template": "core_hello" },
+      { "step": 1, "direction": "host_to_core", "raw_hex": "000000057b7d" },
+      {
+        "step": 2,
+        "direction": "host_to_core",
+        "template": "pure_invoke",
+        "frame": {
+          "arguments": [],
+          "capabilities": { "effects": [], "operations": [] },
+          "interface": {
+            "effects": [],
+            "parameters": [],
+            "result": { "items": [], "kind": "tuple" }
+          },
+          "invocation_id": "0000000000000000",
+          "kind": "invoke",
+          "protocol": "jacquard-host-v0",
+          "target": {
+            "callable": "2af2f2e66770cf0597374a97b4c3988dc0c3f9b42d87f6f430be53525ce6a7ec",
+            "kind": "store-term-v0"
+          }
+        }
+      },
+      { "step": 3, "direction": "core_to_host", "template": "pure_outcome" }
+    ],
+    "core_output": [
+      {
+        "carrier": "stdio-u32-json-v0",
+        "kind": "core_hello",
+        "limits": {
+          "max_arguments": 64,
+          "max_collection_items": 1024,
+          "max_diagnostic_bytes": 65536,
+          "max_diagnostics": 32,
+          "max_effect_requests": 1024,
+          "max_effects": 64,
+          "max_frame_bytes": 1048576,
+          "max_host_message_bytes": 4096,
+          "max_json_depth": 64,
+          "max_operations": 256,
+          "max_stderr_bytes": 65536,
+          "max_text_bytes": 262144,
+          "max_value_nodes": 4096
+        },
+        "versions": [ "jacquard-host-v0" ]
+      },
+      {
+        "diagnostics": [
+          {
+            "cause": "The carrier ended before the declared frame completed.",
+            "code": "E1611",
+            "domain": "process",
+            "next_step": "Treat the missing terminal exchange as host-owned carrier-failure evidence.",
+            "schema": "jacquard-diagnostic-v1",
+            "severity": "error",
+            "span": null,
+            "summary": "The host carrier was lost before a trustworthy frame completed."
+          }
+        ],
+        "kind": "fatal",
+        "protocol": "jacquard-host-v0"
+      }
+    ],
+    "exit_status": 74,
+    "observed": {
+      "terminal_kind": "fatal",
+      "primary_code": "E1611",
+      "terminal": "fatal",
+      "effect_requests": 0,
+      "terminal_frames": 1,
+      "host_local_refusal": null,
+      "host_inputs_skipped_after_terminal": 0
+    },
+    "prose_drift": [],
+    "status": "conforms"
+  }
+]

--- a/test/dune
+++ b/test/dune
@@ -227,6 +227,7 @@
   ../spec/host-protocol-v0.md
   ../spec/host-protocol-v0/README.md
   ../spec/host-protocol-v0/vectors.json
+  (source_tree ../spec/host-protocol-v0/kit)
   ../docs/concurrency.md
   ../docs/README.md
   ../docs/release/0.2/DECISION.md

--- a/test/dune
+++ b/test/dune
@@ -171,11 +171,33 @@
  (modules host_worker_focused)
  (libraries host_worker_test_support alcotest))
 
+(library
+ (name host_kit_support)
+ (wrapped false)
+ (modules host_kit)
+ (libraries jacquard unix str yojson))
+
+(executable
+ (name gen_host_kit)
+ (modules gen_host_kit)
+ (libraries jacquard host_kit_support yojson))
+
+(library
+ (name host_kit_test_support)
+ (wrapped false)
+ (modules test_host_kit)
+ (libraries jacquard host_kit_support alcotest unix yojson))
+
+(executable
+ (name host_kit_focused)
+ (modules host_kit_focused)
+ (libraries host_kit_test_support alcotest))
+
 (test
  (name test_jacquard)
  (modules
-  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused test_host_session host_session_focused test_host_worker host_worker_focused))
- (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support host_session_test_support host_worker_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
+  (:standard \ corpus_support gen_goldens gen_surface_twins gen_prelude_goldens gen_sig_goldens gen_freeze_goldens gen_diag_goldens gen_native_parity gen_governance_playground_fixtures native_fuzz effect_payload_runtime_probe once_interpreter_probe gen_once_hostile scope_policy_trace round_robin_trace run_transcript_trace test_governance_review_diff governance_review_diff_focused test_host_protocol_vectors host_protocol_vectors_focused test_host_protocol_codec host_protocol_codec_focused test_host_boundary_codec host_boundary_codec_focused test_host_invoke_preflight host_invoke_preflight_focused test_host_session host_session_focused test_host_worker host_worker_focused host_kit gen_host_kit test_host_kit host_kit_focused))
+ (libraries jacquard governance_review_diff_test_support host_protocol_vectors_test_support host_protocol_codec_test_support host_boundary_codec_test_support host_invoke_preflight_test_support host_session_test_support host_worker_test_support host_kit_test_support corpus_support alcotest fmt qcheck-core qcheck-alcotest unix str yojson)
  (action
   (setenv JACQUARD %{bin:jacquard} (run %{test})))
  (deps

--- a/test/gen_host_kit.ml
+++ b/test/gen_host_kit.ml
@@ -59,5 +59,6 @@ let () =
   Host_kit.write_file
     (Filename.concat kit "transcripts.json")
     (Yojson.Safe.pretty_to_string (`List transcripts) ^ "\n");
+  Host_kit.remove_tree store;
   Printf.printf "host kit: %d transcripts, %d diverging\n" (List.length transcripts)
     (List.length pending)

--- a/test/gen_host_kit.ml
+++ b/test/gen_host_kit.ml
@@ -1,0 +1,63 @@
+(* Regenerates spec/host-protocol-v0/kit/kit.json and transcripts.json by installing the kit
+   fixtures with the published recipe and playing every HB.1 vector through the installed worker.
+   Run from the repository root: `dune exec test/gen_host_kit.exe`. *)
+
+let () =
+  let kit = Host_kit.kit_dir () in
+  let binary = Host_kit.default_binary () in
+  let store = Host_kit.fresh_path "store" in
+  (match
+     Host_kit.build_store ~binary
+       ~fixtures:(Filename.concat kit "fixtures.jac")
+       ~prelude:(Host_kit.prelude_dir ()) ~store
+   with
+  | Ok () -> ()
+  | Error message ->
+      prerr_endline ("gen_host_kit: " ^ message);
+      exit 1);
+  let store_handle =
+    match Jacquard.Store.open_store store with
+    | Ok handle -> handle
+    | Error diagnostics ->
+        prerr_endline (String.concat "\n" (List.map Jacquard.Diag.to_string diagnostics));
+        exit 1
+  in
+  let ids =
+    match Host_kit.identities_of_store store_handle with
+    | Ok ids -> ids
+    | Error message ->
+        prerr_endline ("gen_host_kit: " ^ message);
+        exit 1
+  in
+  let doc = Host_kit.load_vectors (Filename.concat (Filename.dirname kit) "vectors.json") in
+  let transcripts =
+    List.map
+      (fun case ->
+        let observed = Host_kit.play ~binary ~store case in
+        Host_kit.transcript_of case observed)
+      (Host_kit.cases doc ids)
+  in
+  let pending =
+    List.filter_map
+      (fun transcript ->
+        match Host_kit.member "status" transcript with
+        | `String "diverges" ->
+            Some
+              (`Assoc
+                 [
+                   ("name", Host_kit.member "name" transcript);
+                   ("expected", Host_kit.member "code" (Host_kit.member "expect" transcript));
+                   ( "observed",
+                     Host_kit.member "primary_code" (Host_kit.member "observed" transcript) );
+                 ])
+        | _ -> None)
+      transcripts
+  in
+  let manifest = Host_kit.manifest ~ids ~doc ~transcripts ~pending in
+  Host_kit.write_file (Filename.concat kit "kit.json")
+    (Yojson.Safe.pretty_to_string (Host_kit.canonical manifest) ^ "\n");
+  Host_kit.write_file
+    (Filename.concat kit "transcripts.json")
+    (Yojson.Safe.pretty_to_string (`List transcripts) ^ "\n");
+  Printf.printf "host kit: %d transcripts, %d diverging\n" (List.length transcripts)
+    (List.length pending)

--- a/test/host_kit.ml
+++ b/test/host_kit.ml
@@ -84,6 +84,14 @@ let write_file path contents =
   let channel = open_out_bin path in
   Fun.protect ~finally:(fun () -> close_out channel) (fun () -> output_string channel contents)
 
+let rec remove_tree path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun entry -> remove_tree (Filename.concat path entry)) (Sys.readdir path);
+      Unix.rmdir path
+  | _ -> Sys.remove path
+  | exception Unix.Unix_error _ -> ()
+
 let bytes_of_hex hex =
   String.init
     (String.length hex / 2)
@@ -482,21 +490,37 @@ let play ~binary ~store case =
       ()
     done
   in
+  let reaped = ref None in
+  let reap () =
+    match !reaped with
+    | Some status -> status
+    | None ->
+        let status = snd (Unix.waitpid [] pid) in
+        reaped := Some status;
+        status
+  in
   let status =
     Fun.protect
       ~finally:(fun () ->
         close_input ();
         close_in_noerr output;
-        Sys.set_signal Sys.sigpipe previous)
+        Sys.set_signal Sys.sigpipe previous;
+        (* any other failure must still reap the worker and drop its operator file *)
+        (if Option.is_none !reaped then
+           try
+             Unix.kill pid Sys.sigkill;
+             ignore (reap ())
+           with Unix.Unix_error _ -> ());
+        ())
       (fun () ->
         (try with_deadline 30 run
          with Timeout ->
            Unix.kill pid Sys.sigkill;
            frames := `Assoc [ ("kind", `String "fake-host-timeout") ] :: !frames);
-        snd (Unix.waitpid [] pid))
+        reap ())
   in
-  let stderr = read_file stderr_path in
-  Sys.remove stderr_path;
+  let stderr = if Sys.file_exists stderr_path then read_file stderr_path else "" in
+  if Sys.file_exists stderr_path then Sys.remove stderr_path;
   {
     core_frames = List.rev !frames;
     exit_code = (match status with Unix.WEXITED code -> Some code | _ -> None);

--- a/test/host_kit.ml
+++ b/test/host_kit.ml
@@ -1,0 +1,772 @@
+(* HB.3 conformance kit: binds the synthetic HB.1 vectors to real fixture identities, plays them
+   through the installed worker with a deterministic fake host, and renders executable transcripts.
+   Shared by the generator executable and the Alcotest suite. *)
+
+open Jacquard
+module Host = Host_protocol_v0
+
+exception Timeout
+
+(* --- JSON helpers --- *)
+
+let rec canonical = function
+  | `Assoc fields ->
+      `Assoc
+        (List.sort
+           (fun (a, _) (b, _) -> String.compare a b)
+           (List.map (fun (key, value) -> (key, canonical value)) fields))
+  | `List items -> `List (List.map canonical items)
+  | json -> json
+
+let to_string json = Yojson.Safe.to_string (canonical json)
+let equal a b = String.equal (to_string a) (to_string b)
+
+(* Diagnostic prose is Core-authored human text: the stable contract is the code, domain,
+   severity, span, and schema, plus the host message suffix in the cause. *)
+let prose_fields = [ "summary"; "cause"; "next_step"; "contrast" ]
+
+let is_diagnostic = function
+  | `Assoc fields -> List.assoc_opt "schema" fields = Some (`String "jacquard-diagnostic-v1")
+  | _ -> false
+
+let rec strip_prose json =
+  match json with
+  | `Assoc fields when is_diagnostic json ->
+      `Assoc
+        (List.filter_map
+           (fun (key, value) ->
+             if List.mem key prose_fields then None else Some (key, strip_prose value))
+           fields)
+  | `Assoc fields -> `Assoc (List.map (fun (key, value) -> (key, strip_prose value)) fields)
+  | `List values -> `List (List.map strip_prose values)
+  | json -> json
+
+let equal_semantic a b = equal (strip_prose a) (strip_prose b)
+
+(* Paths of diagnostic prose fields whose text differs between two semantically equal frames. *)
+let prose_drift expected observed =
+  let rec go path expected observed acc =
+    match (expected, observed) with
+    | `Assoc e, `Assoc o when is_diagnostic expected ->
+        List.fold_left
+          (fun acc key ->
+            match (List.assoc_opt key e, List.assoc_opt key o) with
+            | Some a, Some b when not (equal a b) -> (path ^ "/" ^ key) :: acc
+            | _ -> acc)
+          acc prose_fields
+    | `Assoc e, `Assoc o ->
+        List.fold_left
+          (fun acc (key, a) ->
+            match List.assoc_opt key o with Some b -> go (path ^ "/" ^ key) a b acc | None -> acc)
+          acc e
+    | `List e, `List o when List.length e = List.length o ->
+        List.fold_left2
+          (fun acc (i, a) b -> go (path ^ "/" ^ string_of_int i) a b acc)
+          acc
+          (List.mapi (fun i a -> (i, a)) e)
+          o
+    | _ -> acc
+  in
+  List.rev (go "" expected observed [])
+
+let member = Yojson.Safe.Util.member
+let text = Yojson.Safe.Util.to_string
+let items = Yojson.Safe.Util.to_list
+let integer = Yojson.Safe.Util.to_int
+
+let read_file path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+
+let write_file path contents =
+  let channel = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out channel) (fun () -> output_string channel contents)
+
+let bytes_of_hex hex =
+  String.init
+    (String.length hex / 2)
+    (fun i -> Char.chr (int_of_string ("0x" ^ String.sub hex (2 * i) 2)))
+
+let hex_of_bytes bytes =
+  String.concat ""
+    (List.init (String.length bytes) (fun i -> Printf.sprintf "%02x" (Char.code bytes.[i])))
+
+(* --- the HB.1 vector document --- *)
+
+type template = { direction : string; message : Yojson.Safe.t }
+type positive = { positive_name : string; sequence : string list; terminal : string }
+
+type hostile = {
+  hostile_name : string;
+  base : string;
+  phase : string;
+  expect : Yojson.Safe.t;
+  mutation : Yojson.Safe.t;
+}
+
+type document = {
+  hard_limits : Yojson.Safe.t;
+  templates : (string * template) list;
+  positives : positive list;
+  hostiles : hostile list;
+}
+
+let load_vectors path =
+  let json = Yojson.Safe.from_file path in
+  let templates =
+    match member "templates" json with
+    | `Assoc fields ->
+        List.map
+          (fun (name, value) ->
+            (name, { direction = text (member "direction" value); message = member "message" value }))
+          fields
+    | _ -> failwith "vectors: templates must be an object"
+  in
+  let positives =
+    items (member "positive" json)
+    |> List.map (fun item ->
+        {
+          positive_name = text (member "name" item);
+          sequence = List.map text (items (member "sequence" item));
+          terminal = text (member "terminal" item);
+        })
+  in
+  let hostiles =
+    items (member "hostile" json)
+    |> List.map (fun item ->
+        {
+          hostile_name = text (member "name" item);
+          base = text (member "base" item);
+          phase = text (member "phase" item);
+          expect = member "expect" item;
+          mutation = member "mutation" item;
+        })
+  in
+  { hard_limits = member "hard_limits" json; templates; positives; hostiles }
+
+let rec expand_refs hard_limits = function
+  | `Assoc [ ("$ref", `String "hard_limits") ] -> hard_limits
+  | `Assoc fields ->
+      `Assoc (List.map (fun (key, value) -> (key, expand_refs hard_limits value)) fields)
+  | `List values -> `List (List.map (expand_refs hard_limits) values)
+  | json -> json
+
+(* --- kit identities --- *)
+
+type identities = {
+  ready : Hash.t;
+  echo : Hash.t;
+  twice : Hash.t;
+  double : Hash.t;
+  fail : Hash.t;
+  world : Hash.t;
+  send : Hash.t;
+  int_type : Hash.t;
+  text_type : Hash.t;
+}
+
+let identity_names =
+  [
+    ("kit-ready", Resolve.KTerm);
+    ("kit-echo", Resolve.KTerm);
+    ("kit-twice", Resolve.KTerm);
+    ("kit-double", Resolve.KTerm);
+    ("kit-fail", Resolve.KTerm);
+    ("kit-world", Resolve.KEffect);
+    ("send", Resolve.KOp);
+    ("int", Resolve.KType);
+    ("text", Resolve.KType);
+  ]
+
+let identities_of_store store =
+  let lookup name kind =
+    match Store.lookup_kind store name kind with
+    | Some { Resolve.hash; _ } -> Ok hash
+    | None -> Error (Printf.sprintf "kit store is missing `%s`" name)
+  in
+  let ( let* ) = Result.bind in
+  let* ready = lookup "kit-ready" Resolve.KTerm in
+  let* echo = lookup "kit-echo" Resolve.KTerm in
+  let* twice = lookup "kit-twice" Resolve.KTerm in
+  let* double = lookup "kit-double" Resolve.KTerm in
+  let* fail = lookup "kit-fail" Resolve.KTerm in
+  let* world = lookup "kit-world" Resolve.KEffect in
+  let* send = lookup "send" Resolve.KOp in
+  let* int_type = lookup "int" Resolve.KType in
+  let* text_type = lookup "text" Resolve.KType in
+  Ok { ready; echo; twice; double; fail; world; send; int_type; text_type }
+
+let identities_json ids =
+  `Assoc
+    (List.map
+       (fun (name, hash) -> (name, `String (Hash.to_hex hash)))
+       [
+         ("kit-ready", ids.ready);
+         ("kit-echo", ids.echo);
+         ("kit-twice", ids.twice);
+         ("kit-double", ids.double);
+         ("kit-fail", ids.fail);
+         ("kit-world", ids.world);
+         ("send", ids.send);
+         ("int", ids.int_type);
+         ("text", ids.text_type);
+       ])
+
+let synthetic character = String.make 64 character
+
+(* The synthetic identities used by the frozen vectors and the kit member each one denotes. *)
+let bindings ids =
+  [
+    (synthetic 'a', ("kit-ready", ids.ready));
+    (synthetic 'd', ("kit-echo", ids.echo));
+    (synthetic 'b', ("kit-world", ids.world));
+    (synthetic 'c', ("send", ids.send));
+    (synthetic '1', ("text", ids.text_type));
+  ]
+
+let bindings_json ids =
+  `Assoc
+    (List.map
+       (fun (syn, (name, hash)) ->
+         (syn, `Assoc [ ("member", `String name); ("identity", `String (Hash.to_hex hash)) ]))
+       (bindings ids))
+
+let bind ids value =
+  List.fold_left
+    (fun value (syn, (_, hash)) ->
+      Str.global_replace (Str.regexp_string syn) (Hash.to_hex hash) value)
+    value (bindings ids)
+
+let rec substitute ids = function
+  | `String value -> `String (bind ids value)
+  | `Assoc fields -> `Assoc (List.map (fun (key, value) -> (key, substitute ids value)) fields)
+  | `List values -> `List (List.map (substitute ids) values)
+  | json -> json
+
+(* --- JSON pointer mutations --- *)
+
+let pointer_tokens path =
+  match String.split_on_char '/' path with
+  | "" :: tokens ->
+      List.map
+        (fun token ->
+          Str.global_replace (Str.regexp_string "~1") "/"
+            (Str.global_replace (Str.regexp_string "~0") "~" token))
+        tokens
+  | _ -> failwith ("invalid JSON pointer " ^ path)
+
+type operation = Replace of Yojson.Safe.t | Add of Yojson.Safe.t | Remove
+
+let rec mutate operation tokens json =
+  match (tokens, json) with
+  | [], _ -> ( match operation with Replace value | Add value -> value | Remove -> `Null)
+  | [ key ], `Assoc fields -> (
+      match operation with
+      | Replace value ->
+          `Assoc (List.map (fun (k, v) -> if String.equal k key then (k, value) else (k, v)) fields)
+      | Add value ->
+          if List.mem_assoc key fields then
+            `Assoc
+              (List.map (fun (k, v) -> if String.equal k key then (k, value) else (k, v)) fields)
+          else `Assoc (fields @ [ (key, value) ])
+      | Remove -> `Assoc (List.filter (fun (k, _) -> not (String.equal k key)) fields))
+  | [ key ], `List values -> (
+      let index = int_of_string key in
+      match operation with
+      | Replace value -> `List (List.mapi (fun i v -> if i = index then value else v) values)
+      | Add value ->
+          let before = List.filteri (fun i _ -> i < index) values in
+          let after = List.filteri (fun i _ -> i >= index) values in
+          `List (before @ [ value ] @ after)
+      | Remove -> `List (List.filteri (fun i _ -> i <> index) values))
+  | key :: rest, `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (k, v) -> if String.equal k key then (k, mutate operation rest v) else (k, v))
+           fields)
+  | key :: rest, `List values ->
+      let index = int_of_string key in
+      `List (List.mapi (fun i v -> if i = index then mutate operation rest v else v) values)
+  | _ -> failwith "JSON pointer does not resolve"
+
+(* --- executable cases --- *)
+
+type host_input = Frame of string * Yojson.Safe.t | Raw of string
+type step = Core_frame of string | Host_input of host_input
+
+type case = {
+  name : string;
+  kind : string;
+  base : string option;
+  phase : string option;
+  sequence : string list;
+  expect : Yojson.Safe.t;
+  steps : step list;
+  append_after_terminal : (string * Yojson.Safe.t) option;
+  expected_core : (string * Yojson.Safe.t) list;
+}
+
+let frame_of doc ids name =
+  let template = List.assoc name doc.templates in
+  (template.direction, substitute ids (expand_refs doc.hard_limits template.message))
+
+let steps_of doc ids ?mutation sequence =
+  List.mapi
+    (fun index name ->
+      let direction, frame = frame_of doc ids name in
+      if String.equal direction "core_to_host" then Core_frame name
+      else
+        match mutation with
+        | Some (`Raw (at, bytes)) when at = index -> Host_input (Raw bytes)
+        | Some (`Json (at, operation, path)) when at = index ->
+            Host_input (Frame (name, mutate operation (pointer_tokens path) frame))
+        | _ -> Host_input (Frame (name, frame)))
+    sequence
+
+let expected_core doc ids sequence =
+  List.filter_map
+    (fun name ->
+      let direction, frame = frame_of doc ids name in
+      if String.equal direction "core_to_host" then Some (name, frame) else None)
+    sequence
+
+let positive_case doc ids positive =
+  {
+    name = positive.positive_name;
+    kind = "positive";
+    base = None;
+    phase = None;
+    sequence = positive.sequence;
+    expect = `Assoc [ ("terminal", `String positive.terminal) ];
+    steps = steps_of doc ids positive.sequence;
+    append_after_terminal = None;
+    expected_core = expected_core doc ids positive.sequence;
+  }
+
+let hostile_case doc ids (hostile : hostile) =
+  let base =
+    match List.find_opt (fun p -> String.equal p.positive_name hostile.base) doc.positives with
+    | Some base -> base
+    | None -> failwith ("hostile base " ^ hostile.base ^ " is not a positive case")
+  in
+  let op = text (member "op" hostile.mutation) in
+  let frame () = integer (member "frame" hostile.mutation) in
+  let path () = text (member "path" hostile.mutation) in
+  let mutation, append =
+    match op with
+    | "replace" ->
+        (Some (`Json (frame (), Replace (member "value" hostile.mutation), path ())), None)
+    | "add" -> (Some (`Json (frame (), Add (member "value" hostile.mutation), path ())), None)
+    | "remove" -> (Some (`Json (frame (), Remove, path ())), None)
+    | "raw_wire" ->
+        (Some (`Raw (frame (), bytes_of_hex (text (member "wire_hex" hostile.mutation)))), None)
+    | "append" ->
+        let name = text (member "template" hostile.mutation) in
+        (None, Some (name, snd (frame_of doc ids name)))
+    | other -> failwith ("unknown mutation op " ^ other)
+  in
+  {
+    name = hostile.hostile_name;
+    kind = "hostile";
+    base = Some hostile.base;
+    phase = Some hostile.phase;
+    sequence = base.sequence;
+    expect = hostile.expect;
+    steps = steps_of doc ids ?mutation base.sequence;
+    append_after_terminal = append;
+    expected_core = expected_core doc ids base.sequence;
+  }
+
+let cases doc ids =
+  List.map (positive_case doc ids) doc.positives @ List.map (hostile_case doc ids) doc.hostiles
+
+(* --- the fake host --- *)
+
+type observed = {
+  core_frames : Yojson.Safe.t list;
+  exit_code : int option;
+  signal : int option;
+  stderr : string;
+  host_refusal : string option;
+  skipped_after_terminal : int;
+  write_failure : bool;
+}
+
+let is_terminal json =
+  match member "kind" json with
+  | `String ("outcome" | "fatal" | "shutdown_ack") -> true
+  | _ -> false
+
+let encode json =
+  match Host.encode_frame_bytes ~limits:Host.hard_limits json with
+  | Ok bytes -> bytes
+  | Error diagnostics -> failwith (String.concat "\n" (List.map Diag.to_string diagnostics))
+
+let with_deadline seconds run =
+  let previous = Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> raise Timeout)) in
+  ignore (Unix.alarm seconds);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Unix.alarm 0);
+      Sys.set_signal Sys.sigalrm previous)
+    run
+
+let fresh_path =
+  let serial = ref 0 in
+  fun label ->
+    incr serial;
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "jacquard-host-kit-%s-%d-%d" label (Unix.getpid ()) !serial)
+
+(* Play one case in lockstep against a freshly spawned worker. The host writes only when the
+   sequence says it is the host's turn and never after it has observed a terminal frame. *)
+let play ~binary ~store case =
+  let in_r, in_w = Unix.pipe ~cloexec:true () in
+  let out_r, out_w = Unix.pipe ~cloexec:true () in
+  let stderr_path = fresh_path "stderr" in
+  let err_fd = Unix.openfile stderr_path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o600 in
+  let pid =
+    Unix.create_process binary [| binary; "host"; "worker"; "--store"; store |] in_r out_w err_fd
+  in
+  Unix.close in_r;
+  Unix.close out_w;
+  Unix.close err_fd;
+  let input = Unix.out_channel_of_descr in_w in
+  let output = Unix.in_channel_of_descr out_r in
+  let previous = Sys.signal Sys.sigpipe Sys.Signal_ignore in
+  let frames = ref [] in
+  let terminal = ref false in
+  let refusal = ref None in
+  let skipped = ref 0 in
+  let write_failure = ref false in
+  let input_open = ref true in
+  let read_frame () =
+    match Host.read_frame ~limits:Host.hard_limits output with
+    | Ok json ->
+        frames := json :: !frames;
+        if is_terminal json then terminal := true;
+        true
+    | Error _ -> false
+  in
+  let close_input () =
+    if !input_open then begin
+      input_open := false;
+      close_out_noerr input
+    end
+  in
+  let write bytes =
+    if !input_open then (
+      try
+        output_string input bytes;
+        flush input
+      with Sys_error _ ->
+        write_failure := true;
+        close_input ())
+  in
+  let run () =
+    List.iter
+      (function
+        | Core_frame _ -> ignore (read_frame ())
+        | Host_input (Raw bytes) ->
+            write bytes;
+            close_input ()
+        | Host_input (Frame (_, json)) -> if !terminal then incr skipped else write (encode json))
+      case.steps;
+    (match case.append_after_terminal with
+    | Some (_, json) -> if !terminal then refusal := Some "E1608" else write (encode json)
+    | None -> ());
+    close_input ();
+    while read_frame () do
+      ()
+    done
+  in
+  let status =
+    Fun.protect
+      ~finally:(fun () ->
+        close_input ();
+        close_in_noerr output;
+        Sys.set_signal Sys.sigpipe previous)
+      (fun () ->
+        (try with_deadline 30 run
+         with Timeout ->
+           Unix.kill pid Sys.sigkill;
+           frames := `Assoc [ ("kind", `String "fake-host-timeout") ] :: !frames);
+        snd (Unix.waitpid [] pid))
+  in
+  let stderr = read_file stderr_path in
+  Sys.remove stderr_path;
+  {
+    core_frames = List.rev !frames;
+    exit_code = (match status with Unix.WEXITED code -> Some code | _ -> None);
+    signal = (match status with Unix.WSIGNALED signal -> Some signal | _ -> None);
+    stderr;
+    host_refusal = !refusal;
+    skipped_after_terminal = !skipped;
+    write_failure = !write_failure;
+  }
+
+(* --- observed summary and conformance --- *)
+
+let first_code diagnostics =
+  match diagnostics with
+  | first :: _ -> ( match member "code" first with `String code -> Some code | _ -> None)
+  | [] -> None
+
+let summary observed =
+  let terminal = List.find_opt is_terminal observed.core_frames in
+  let kind = Option.map (fun json -> text (member "kind" json)) terminal in
+  let primary_code =
+    match terminal with
+    | Some json when kind = Some "fatal" -> first_code (items (member "diagnostics" json))
+    | Some json when kind = Some "outcome" -> (
+        match member "kind" (member "result" json) with
+        | `String "error" -> first_code (items (member "diagnostics" (member "result" json)))
+        | _ -> None)
+    | _ -> None
+  in
+  let terminal_class =
+    match terminal with
+    | Some json when kind = Some "outcome" ->
+        Some (text (member "terminal" (member "core" (member "evidence" json))))
+    | Some _ when kind = Some "fatal" -> Some "fatal"
+    | Some _ when kind = Some "shutdown_ack" -> Some "shutdown"
+    | _ -> None
+  in
+  let count predicate = List.length (List.filter predicate observed.core_frames) in
+  let effect_requests = count (fun json -> member "kind" json = `String "effect_request") in
+  let terminal_frames = count is_terminal in
+  (kind, primary_code, terminal_class, effect_requests, terminal_frames)
+
+(* Spec section 8: the exact decoded host message must end the diagnostic cause. *)
+let host_message_suffix_honoured case observed =
+  let messages =
+    List.filter_map
+      (function
+        | Host_input (Frame (_, json)) when member "kind" json = `String "effect_failure" ->
+            Some (text (member "message" json))
+        | _ -> None)
+      case.steps
+  in
+  match (messages, List.find_opt is_terminal observed.core_frames) with
+  | [], _ | _, None -> true
+  | message :: _, Some terminal -> (
+      match member "kind" terminal with
+      | `String "outcome" -> (
+          match member "diagnostics" (member "result" terminal) with
+          | `List (first :: _) -> (
+              match member "cause" first with
+              | `String cause -> Filename.check_suffix cause message
+              | _ -> false)
+          | _ -> false)
+      | _ -> false)
+
+let conforms case observed =
+  let _, primary_code, terminal_class, effect_requests, terminal_frames = summary observed in
+  match case.kind with
+  | "positive" ->
+      let expected = text (member "terminal" case.expect) in
+      let observed_core =
+        List.filter
+          (fun json -> member "kind" json <> `String "fake-host-timeout")
+          observed.core_frames
+      in
+      terminal_class = Some expected && observed.exit_code = Some 0
+      && List.length observed_core = List.length case.expected_core
+      && List.for_all2
+           (fun (_, expected) actual -> equal_semantic expected actual)
+           case.expected_core observed_core
+      && host_message_suffix_honoured case observed
+  | _ ->
+      let code = text (member "code" case.expect) in
+      let before = integer (member "effect_requests_before_failure" case.expect) in
+      let max_terminals = integer (member "terminal_frames_max" case.expect) in
+      let forbid = Yojson.Safe.Util.to_bool (member "forbid_outside_action" case.expect) in
+      let expected_exit = if String.equal code "E1611" then 74 else 0 in
+      effect_requests = before && terminal_frames <= max_terminals
+      && ((not forbid) || effect_requests = 0)
+      && observed.exit_code = Some expected_exit
+      &&
+      if case.phase = Some "terminal" then
+        observed.host_refusal = Some code && terminal_class = Some "ok"
+      else primary_code = Some code
+
+let transcript_of case observed =
+  let kind, primary_code, terminal_class, effect_requests, terminal_frames = summary observed in
+  let host_input =
+    List.mapi
+      (fun index step ->
+        match step with
+        | Core_frame name ->
+            `Assoc
+              [
+                ("step", `Int index);
+                ("direction", `String "core_to_host");
+                ("template", `String name);
+              ]
+        | Host_input (Frame (name, json)) ->
+            `Assoc
+              [
+                ("step", `Int index);
+                ("direction", `String "host_to_core");
+                ("template", `String name);
+                ("frame", canonical json);
+              ]
+        | Host_input (Raw bytes) ->
+            `Assoc
+              [
+                ("step", `Int index);
+                ("direction", `String "host_to_core");
+                ("raw_hex", `String (hex_of_bytes bytes));
+              ])
+      case.steps
+    @
+    match case.append_after_terminal with
+    | Some (name, json) ->
+        [
+          `Assoc
+            [
+              ("step", `Int (List.length case.steps));
+              ("direction", `String "host_to_core");
+              ("template", `String name);
+              ("frame", canonical json);
+              ("after_terminal", `Bool true);
+            ];
+        ]
+    | None -> []
+  in
+  let optional = function Some value -> `String value | None -> `Null in
+  `Assoc
+    [
+      ("name", `String case.name);
+      ("kind", `String case.kind);
+      ("base", optional case.base);
+      ("phase", optional case.phase);
+      ("sequence", `List (List.map (fun name -> `String name) case.sequence));
+      ("expect", canonical case.expect);
+      ("host_input", `List host_input);
+      ("core_output", `List (List.map canonical observed.core_frames));
+      ("exit_status", match observed.exit_code with Some code -> `Int code | None -> `Null);
+      ( "observed",
+        `Assoc
+          [
+            ("terminal_kind", optional kind);
+            ("primary_code", optional primary_code);
+            ("terminal", optional terminal_class);
+            ("effect_requests", `Int effect_requests);
+            ("terminal_frames", `Int terminal_frames);
+            ("host_local_refusal", optional observed.host_refusal);
+            ("host_inputs_skipped_after_terminal", `Int observed.skipped_after_terminal);
+          ] );
+      ( "prose_drift",
+        `List
+          (if
+             String.equal case.kind "positive"
+             && List.length case.expected_core = List.length observed.core_frames
+           then
+             List.concat
+               (List.map2
+                  (fun (template, expected) actual ->
+                    List.map (fun path -> `String (template ^ path)) (prose_drift expected actual))
+                  case.expected_core observed.core_frames)
+           else []) );
+      ("status", `String (if conforms case observed then "conforms" else "diverges"));
+    ]
+
+(* --- the kit store --- *)
+
+let default_binary () =
+  match Sys.getenv_opt "JACQUARD" with
+  | Some binary -> binary
+  | None ->
+      List.find_opt Sys.file_exists [ "_build/default/bin/main.exe"; "../bin/main.exe" ]
+      |> Option.value ~default:"jacquard"
+
+let kit_dir () =
+  if Sys.file_exists "spec/host-protocol-v0/kit" then "spec/host-protocol-v0/kit"
+  else "../spec/host-protocol-v0/kit"
+
+let prelude_dir () = if Sys.file_exists "prelude" then "prelude" else "../prelude"
+
+(* Follow the published recipe exactly: `jacquard run fixtures.jac --store DIR`. *)
+let build_store ~binary ~fixtures ~prelude ~store =
+  let absolute path =
+    if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path else path
+  in
+  let env =
+    Array.append
+      [| "JACQUARD_PRELUDE=" ^ absolute prelude; "TMPDIR=" ^ Filename.get_temp_dir_name () |]
+      (Array.of_list
+         (List.filter
+            (fun entry ->
+              not
+                (String.starts_with ~prefix:"JACQUARD_PRELUDE=" entry
+                || String.starts_with ~prefix:"TMPDIR=" entry))
+            (Array.to_list (Unix.environment ()))))
+  in
+  let null = Unix.openfile Filename.null [ Unix.O_RDWR ] 0 in
+  let pid =
+    Unix.create_process_env binary
+      [| binary; "run"; fixtures; "--store"; store |]
+      env null null Unix.stderr
+  in
+  Unix.close null;
+  match snd (Unix.waitpid [] pid) with
+  | Unix.WEXITED 0 -> Ok ()
+  | Unix.WEXITED code -> Error (Printf.sprintf "recipe exited %d" code)
+  | _ -> Error "recipe was killed"
+
+let manifest ~ids ~doc ~transcripts ~pending =
+  `Assoc
+    [
+      ("schema", `String "jacquard-host-kit-v0");
+      ("protocol", `String Host.protocol);
+      ("carrier", `String Host.carrier);
+      ("core_version", `String Version.version);
+      ( "recipe",
+        `Assoc
+          [
+            ("fixtures", `String "fixtures.jac");
+            ("command", `String "jacquard run fixtures.jac --store DIR");
+            ("prelude", `String "the prelude shipped with the same Core release");
+            ("worker", `String "jacquard host worker --store DIR");
+          ] );
+      ("identities", identities_json ids);
+      ("bindings", bindings_json ids);
+      ("hard_limits", canonical doc.hard_limits);
+      ("vectors", `String "../vectors.json");
+      ("transcripts", `String "transcripts.json");
+      ("transcript_count", `Int (List.length transcripts));
+      ( "host_owned",
+        `List
+          (List.map
+             (fun value -> `String value)
+             [
+               "operator text on the worker's standard error";
+               "the exact moment a carrier loss is observed";
+               "any run identifier, timestamp, peer identity, or receipt an adapter records \
+                outside the Core frames";
+             ]) );
+      ( "diagnostic_prose",
+        `Assoc
+          [
+            ("normative", `Bool false);
+            ( "compared",
+              `List
+                (List.map (fun f -> `String f) [ "schema"; "domain"; "code"; "severity"; "span" ])
+            );
+            ( "cause_suffix_rule",
+              `String "an effect_failure message must end the first diagnostic's cause" );
+            ( "drift",
+              `List
+                (List.concat_map
+                   (fun transcript ->
+                     List.map
+                       (fun path ->
+                         `Assoc [ ("transcript", member "name" transcript); ("path", path) ])
+                       (items (member "prose_drift" transcript)))
+                   transcripts) );
+          ] );
+      ("pending_decisions", `List pending);
+    ]

--- a/test/host_kit_focused.ml
+++ b/test/host_kit_focused.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "jacquard-host-kit" [ ("host-kit", Test_host_kit.suite) ]

--- a/test/test_host_kit.ml
+++ b/test/test_host_kit.ml
@@ -1,0 +1,232 @@
+(* HB.3: the executable conformance kit agrees with the frozen vectors, the published recipe, and
+   the installed worker. *)
+
+open Jacquard
+module Host = Host_protocol_v0
+module K = Host_kit
+
+let fail_diagnostics diagnostics = String.concat "\n" (List.map Diag.to_string diagnostics)
+
+type fixture = {
+  store : string;
+  ids : K.identities;
+  doc : K.document;
+  kit : Yojson.Safe.t;
+  transcripts : Yojson.Safe.t list;
+}
+
+let kit_path name = Filename.concat (K.kit_dir ()) name
+
+let make_fixture () =
+  let binary = K.default_binary () in
+  let store = K.fresh_path "store" in
+  (match
+     K.build_store ~binary ~fixtures:(kit_path "fixtures.jac") ~prelude:(K.prelude_dir ()) ~store
+   with
+  | Ok () -> ()
+  | Error message -> Alcotest.fail ("recipe failed: " ^ message));
+  let handle =
+    match Store.open_store store with
+    | Ok handle -> handle
+    | Error diagnostics -> Alcotest.fail (fail_diagnostics diagnostics)
+  in
+  let ids = match K.identities_of_store handle with Ok ids -> ids | Error m -> Alcotest.fail m in
+  let doc = K.load_vectors (Filename.concat (Filename.dirname (K.kit_dir ())) "vectors.json") in
+  let kit = Yojson.Safe.from_file (kit_path "kit.json") in
+  let transcripts = K.items (Yojson.Safe.from_file (kit_path "transcripts.json")) in
+  { store; ids; doc; kit; transcripts }
+
+let fixture = lazy (make_fixture ())
+let fixture () = Lazy.force fixture
+let binary () = K.default_binary ()
+
+let check_json label expected actual =
+  Alcotest.(check string) label (K.to_string expected) (K.to_string actual)
+
+let test_recipe_reproduces_identities () =
+  let f = fixture () in
+  check_json "identities" (K.member "identities" f.kit) (K.identities_json f.ids);
+  check_json "bindings" (K.member "bindings" f.kit) (K.bindings_json f.ids);
+  Alcotest.(check string) "protocol" Host.protocol (K.text (K.member "protocol" f.kit));
+  Alcotest.(check string) "carrier" Host.carrier (K.text (K.member "carrier" f.kit));
+  Alcotest.(check string) "core version" Version.version (K.text (K.member "core_version" f.kit));
+  check_json "hard limits" (Host.limits_to_yojson Host.hard_limits) (K.member "hard_limits" f.kit);
+  check_json "vector hard limits" f.doc.K.hard_limits (K.member "hard_limits" f.kit)
+
+let test_transcripts_cover_every_vector () =
+  let f = fixture () in
+  let names = List.map (fun t -> K.text (K.member "name" t)) f.transcripts in
+  let expected =
+    List.map (fun p -> p.K.positive_name) f.doc.K.positives
+    @ List.map (fun h -> h.K.hostile_name) f.doc.K.hostiles
+  in
+  Alcotest.(check (list string)) "one transcript per vector" expected names;
+  Alcotest.(check int)
+    "manifest count" (List.length expected)
+    (K.integer (K.member "transcript_count" f.kit))
+
+let pending_names f =
+  K.items (K.member "pending_decisions" f.kit) |> List.map (fun p -> K.text (K.member "name" p))
+
+let test_every_transcript_replays () =
+  let f = fixture () in
+  List.iter2
+    (fun case transcript ->
+      let observed = K.play ~binary:(binary ()) ~store:f.store case in
+      let fresh = K.transcript_of case observed in
+      check_json (case.K.name ^ " transcript is reproducible") transcript fresh;
+      let status = K.text (K.member "status" transcript) in
+      if List.mem case.K.name (pending_names f) then
+        Alcotest.(check string) (case.K.name ^ " is a recorded divergence") "diverges" status
+      else Alcotest.(check string) (case.K.name ^ " conforms") "conforms" status)
+    (K.cases f.doc f.ids) f.transcripts
+
+let test_positive_frames_equal_templates () =
+  let f = fixture () in
+  List.iter
+    (fun positive ->
+      let case = K.positive_case f.doc f.ids positive in
+      let observed = K.play ~binary:(binary ()) ~store:f.store case in
+      Alcotest.(check int)
+        (case.K.name ^ " frame count")
+        (List.length case.K.expected_core)
+        (List.length observed.K.core_frames);
+      List.iter2
+        (fun (template, expected) actual ->
+          check_json (case.K.name ^ " " ^ template) (K.strip_prose expected) (K.strip_prose actual))
+        case.K.expected_core observed.K.core_frames;
+      Alcotest.(check bool)
+        (case.K.name ^ " host message suffix")
+        true
+        (K.host_message_suffix_honoured case observed);
+      Alcotest.(check (option int)) (case.K.name ^ " exit") (Some 0) observed.K.exit_code)
+    f.doc.K.positives
+
+let test_pending_decisions_are_explicit () =
+  let f = fixture () in
+  let pending = K.items (K.member "pending_decisions" f.kit) in
+  List.iter
+    (fun entry ->
+      let name = K.text (K.member "name" entry) in
+      let transcript = List.find (fun t -> K.text (K.member "name" t) = name) f.transcripts in
+      Alcotest.(check string)
+        (name ^ " expected code")
+        (K.text (K.member "expected" entry))
+        (K.text (K.member "code" (K.member "expect" transcript)));
+      Alcotest.(check string)
+        (name ^ " observed code")
+        (K.text (K.member "observed" entry))
+        (K.text (K.member "primary_code" (K.member "observed" transcript))))
+    pending;
+  Alcotest.(check (list string))
+    "only the known discrepancy is pending" [ "noncanonical-target-hash" ]
+    (List.map (fun e -> K.text (K.member "name" e)) pending)
+
+let test_terminal_mappings_execute () =
+  let f = fixture () in
+  let mappings =
+    K.items
+      (K.member "terminal_mappings"
+         (Yojson.Safe.from_file (Filename.concat (Filename.dirname (K.kit_dir ())) "vectors.json")))
+  in
+  let base = List.find (fun p -> p.K.positive_name = "one-once-effect-success") f.doc.K.positives in
+  List.iter
+    (fun mapping ->
+      let kind = K.text (K.member "kind" mapping) in
+      let response =
+        `Assoc
+          ([
+             ("invocation_id", `String "0000000000000000");
+             ("kind", `String kind);
+             ("protocol", `String Host.protocol);
+             ("request_id", `String "0000000000000001");
+           ]
+          @
+          if kind = "effect_failure" then
+            [
+              ("category", K.member "category" mapping);
+              ("completion", K.member "completion" mapping);
+              ("message", `String "redacted");
+            ]
+          else
+            [ ("reason", K.member "reason" mapping); ("completion", K.member "completion" mapping) ]
+          )
+      in
+      let steps =
+        List.map
+          (function
+            | K.Host_input (K.Frame ("effect_ok", _)) -> K.Host_input (K.Frame (kind, response))
+            | step -> step)
+          (K.steps_of f.doc f.ids base.K.sequence)
+      in
+      let case =
+        {
+          (K.positive_case f.doc f.ids base) with
+          K.name = "mapping";
+          kind = "hostile";
+          phase = Some "effect_response";
+          steps;
+          expect =
+            `Assoc
+              [
+                ("code", K.member "primary_code" mapping);
+                ("effect_requests_before_failure", `Int 1);
+                ("forbid_outside_action", `Bool false);
+                ("terminal_frames_max", `Int 1);
+              ];
+        }
+      in
+      let observed = K.play ~binary:(binary ()) ~store:f.store case in
+      let _, code, terminal, _, _ = K.summary observed in
+      let label =
+        kind ^ "/"
+        ^ Yojson.Safe.to_string (K.member "category" mapping)
+        ^ Yojson.Safe.to_string (K.member "reason" mapping)
+        ^ "/"
+        ^ K.text (K.member "completion" mapping)
+      in
+      Alcotest.(check (option string))
+        (label ^ " code")
+        (Some (K.text (K.member "primary_code" mapping)))
+        code;
+      Alcotest.(check (option string))
+        (label ^ " terminal")
+        (Some (K.text (K.member "terminal" mapping)))
+        terminal)
+    mappings
+
+let test_prose_drift_is_recorded () =
+  let f = fixture () in
+  let drift = K.items (K.member "drift" (K.member "diagnostic_prose" f.kit)) in
+  Alcotest.(check bool)
+    "prose is declared non-normative" false
+    (Yojson.Safe.Util.to_bool (K.member "normative" (K.member "diagnostic_prose" f.kit)));
+  List.iter
+    (fun entry ->
+      let path = K.text (K.member "path" entry) in
+      Alcotest.(check bool)
+        (path ^ " is a prose field") true
+        (List.exists (fun field -> Filename.check_suffix path ("/" ^ field)) K.prose_fields))
+    drift;
+  Alcotest.(check (list string))
+    "drifting transcripts"
+    [ "refused-authority"; "timeout-with-unknown-completion" ]
+    (List.sort_uniq String.compare (List.map (fun e -> K.text (K.member "transcript" e)) drift))
+
+let suite =
+  [
+    Alcotest.test_case "template prose drift is recorded, never silently normalised" `Quick
+      test_prose_drift_is_recorded;
+    Alcotest.test_case "recipe reproduces the published identities and limits" `Quick
+      test_recipe_reproduces_identities;
+    Alcotest.test_case "transcripts cover every positive and hostile vector" `Quick
+      test_transcripts_cover_every_vector;
+    Alcotest.test_case "every transcript replays byte-for-byte through the worker" `Quick
+      test_every_transcript_replays;
+    Alcotest.test_case "positive sequences equal the bound HB.1 templates" `Quick
+      test_positive_frames_equal_templates;
+    Alcotest.test_case "pending decisions are explicit and exact" `Quick
+      test_pending_decisions_are_explicit;
+    Alcotest.test_case "all thirteen terminal mappings execute" `Quick
+      test_terminal_mappings_execute;
+  ]

--- a/test/test_host_kit.ml
+++ b/test/test_host_kit.ml
@@ -34,6 +34,7 @@ let make_fixture () =
   let doc = K.load_vectors (Filename.concat (Filename.dirname (K.kit_dir ())) "vectors.json") in
   let kit = Yojson.Safe.from_file (kit_path "kit.json") in
   let transcripts = K.items (Yojson.Safe.from_file (kit_path "transcripts.json")) in
+  at_exit (fun () -> K.remove_tree store);
   { store; ids; doc; kit; transcripts }
 
 let fixture = lazy (make_fixture ())

--- a/test/test_jacquard.ml
+++ b/test/test_jacquard.ml
@@ -29,6 +29,7 @@ let () =
       ("host-invoke-preflight", Test_host_invoke_preflight.suite);
       ("host-session", Test_host_session.suite);
       ("host-worker", Test_host_worker.suite);
+      ("host-kit", Test_host_kit.suite);
       ("scheduler-core", Test_scheduler_core.suite);
       ("channel-contract", Test_channel_contract.suite);
       ("structured-scope", Test_structured_scope.suite);


### PR DESCRIPTION
## Context

`spec/host-protocol-v0/vectors.json` freezes the HB.1 schema and state
machine with synthetic identities, so until now it could only be checked for
shape. The worker landed in #114, which makes the vectors executable. An
adapter in another language still had nothing to pin: no fixtures with real
identities, no recorded Core frames, and no statement of what "agreement"
means.

## What changed

`spec/host-protocol-v0/kit/` publishes the executable conformance kit:

- `fixtures.jac`: first-party fixture declarations, installed with the
  recipe `jacquard run fixtures.jac --store DIR`.
- `kit.json`: protocol, carrier, Core version, recipe, the exact identity of
  every fixture member, the binding from each synthetic vector identity to a
  member, the hard limits, host-owned fields, the diagnostic-prose rule, and
  every pending decision.
- `transcripts.json`: one entry per positive and hostile vector with the
  host frames or raw bytes in order, the Core frames the worker emitted, the
  exit status, the observed summary, the host's local refusal for the
  terminal-phase case, and a conformance status.
- `README.md`: the binding table, how an adapter pins and replays the kit,
  what is compared, and what drift is recorded.

`test/host_kit.ml` is the deterministic fake host and kit derivation shared
by `test/gen_host_kit.exe` (regeneration) and `test/test_host_kit.ml`. The
suite installs the fixtures with the recipe, checks the manifest identities
and limits, replays all 21 transcripts through the installed binary and
compares them byte-for-byte with the checked-in ones, checks that every
positive sequence equals its bound HB.1 template, executes all 13 terminal
mappings, and fails on any divergence that is not an explicitly recorded
pending decision.

## Decisions recorded, not taken

- Diagnostic prose (`summary`, `cause`, `next_step`, `contrast`) is compared
  semantically: schema, domain, code, severity, span, and the spec's
  requirement that an `effect_failure` message ends the first cause. Two
  vector templates (`refused_outcome`, `timeout_unknown_outcome`) carry
  prose that differs from what the shipped session layer emits for the same
  codes; the manifest lists each drifting field. Refreshing the vector prose
  or declaring prose non-normative in the spec is a reviewed decision.
- `noncanonical-target-hash` expects E1603 while the shipped preflight
  returns E1601 for an uppercase hash under the frozen fail-fast order. It is
  the single entry under `pending_decisions`; the transcript records the
  observed frames and the suite requires it to stay recorded until decided.

No vector expectation, kernel form, hash, checker, evaluator, native, or
ordinary CLI behavior changes. The kit contains no adapter, HTTP server, or
embedding ABI.

## Validation and review

- Clean `dune build @all`, `NO_COLOR=1 dune runtest`, and formatting pass on
  the final head `c9947c2`: 1014 Alcotest/QCheck cases, 61 cram transcript
  files, 28 documentation examples; the four release inventory records say
  `1014 / 61`. Two consecutive regenerations of `kit.json` and
  `transcripts.json` are byte-identical, and regeneration leaves the tree
  clean.
- The 7 kit cases: the recipe reproduces the published identities and limits;
  one transcript per vector; every transcript replays byte-for-byte through
  the installed binary; positive sequences equal their bound templates modulo
  diagnostic prose; pending decisions are explicit and exact; all 13 terminal
  mappings execute; prose drift is recorded, never normalised.
- The first CI run on `26fc627` failed in the full suite because the test
  stanza did not stage the kit files for a fresh checkout; `de074e8` adds the
  dependency. `c9947c2` removes the fixture store the suite installs, reaps
  the worker on every fake-host exit path, and corrects README and status
  prose.

Independent review (fresh reviewer per pass, base `128fbaf`):

- Review on `de074e8`: **PASS**, no blockers. Verified vectors unchanged,
  21 transcripts and deterministic regeneration, positive frames equal bound
  templates modulo prose with the host-message cause suffix honoured,
  hostile codes/counts/exit statuses, fake-host discipline, binding of
  synthetic identities, inventory. Nonblocking debt: fixture-store leak,
  reaping on exception paths, README lockstep wording, stale prose; all
  addressed in `c9947c2`.
- Delta review on `c9947c22554196a809b780bc1f1afd8ba06274de`: **PASS**, no
  blockers; store removal, reaping, README wording, and invariants verified by
  the reviewer's own runs. Deferred to the evidence-pack PR: the fake host's
  stderr file is not removed when its run raises; two remaining sentences in
  `README.md` and `docs/host-worker-v0.md` still say no conformance kit ships.
- Both reviewers agree that recording the two vector decisions (target-hash
  code; diagnostic prose) without resolving them is acceptable for this PR and
  that the evidence-pack PR must present the decision.

Final checks: the required contexts run on the reviewed head; auto-merge
(squash) is enabled only after they pass. No delta since review.
