### PR TITLE
HB.3b: publish the host boundary evidence pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,8 @@ When adding valid corpus files, regenerate the golden hashes with
   `src/host_worker.ml`, `test/test_host_worker.ml`, `test/cli/host-worker.t`,
   and `docs/host-worker-v0.md`. The executable conformance kit and its fake
   host: `spec/host-protocol-v0/kit/`, `test/host_kit.ml`,
-  `test/test_host_kit.ml`, regenerated with `dune exec test/gen_host_kit.exe`.
+  `test/test_host_kit.ml`, regenerated with `dune exec test/gen_host_kit.exe`;
+  the HB.3 evidence pack is `docs/release/host-boundary/`.
   Existing evaluator capture and host-readiness
   modules are internal seams, not a public ABI; adapters and application
   servers belong outside this repository.

--- a/README.md
+++ b/README.md
@@ -730,8 +730,10 @@ proofs also do not ship. World grants remain coarse. See
 `docs/host-boundary.md` freezes the ownership and trust model, and
 `spec/host-protocol-v0.md` freezes the experimental language-neutral envelopes,
 process framing, limits, and schema/state vectors. `jac host worker` is the
-experimental serial carrier for that protocol; no stable ABI, adapter,
-cross-language conformance kit, or HTTP server ships in this repository today.
+experimental serial carrier for that protocol, and
+`spec/host-protocol-v0/kit/` is the executable conformance kit external
+adapters pin, with its evidence and limits in `docs/release/host-boundary/`;
+no stable ABI, adapter, or HTTP server ships in this repository.
 The deterministic Workspace v0 governance boundary is separately advertised
 as an evidence-backed research reference implementation, not as a sandbox or
 production security system; its exact claim and trusted-host limits are in

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,9 @@ project shape from file names alone.
   accounts for serial responses and terminal evidence, and the
   [HB.2c worker](host-worker-v0.md) is the opt-in `jacquard host worker`
   process carrier. The [HB.3 kit](../spec/host-protocol-v0/kit/README.md)
-  binds the vectors to real fixtures and replays them through the worker.
+  binds the vectors to real fixtures and replays them through the worker;
+  [`release/host-boundary/`](release/host-boundary/EVIDENCE.md) is its
+  evidence pack with the still-active limits and the two pending decisions.
 - `development-plan.md`: completed historical task plan and milestone
   discipline; not the current backlog.
 - `host-boundary.md`: HB.0 transport-neutral ownership, trust, containment,

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -908,9 +908,10 @@ Do not invent new kernel forms for surface sugar.
   for bounded evidence, and returns request/resume/terminal actions
   (`host-session-v0.md`). HB.2c ships `jac host worker --store DIR`, the
   opt-in serial process carrier that evaluates one preflighted invocation over
-  stdin/stdout frames (`host-worker-v0.md`). HB.3a publishes the executable
-  conformance kit under `spec/host-protocol-v0/kit/`. No stable foreign-host
-  ABI, adapter, or HTTP server ships yet.
+  stdin/stdout frames (`host-worker-v0.md`). HB.3 publishes the executable
+  conformance kit under `spec/host-protocol-v0/kit/` with its evidence pack in
+  `docs/release/host-boundary/`; one external adapter (jacquard-host) replays
+  it. No stable foreign-host ABI, adapter, or HTTP server ships here.
   Internal evaluator-capture and host-readiness OCaml APIs are not supported
   embedding contracts; future adapters must consume the versioned protocol and
   its executable conformance fixtures, not those OCaml seams.

--- a/docs/host-boundary.md
+++ b/docs/host-boundary.md
@@ -273,7 +273,7 @@ headers are not smuggled into HB.0.
 |---|---|---|
 | First-party programs | safety for hostile uploaded Jacquard code | separate-process or equivalent isolation design, hostile resource tests, and reviewed threat model |
 | Trusted adapter and OS | protection from a lying host or broader OS credentials | independently enforced isolation/authentication plus external security review |
-| Experimental serial carrier without a published kit | interoperability or embedding support | HB.3 executable cross-language fixtures and evidence pinned by at least one independent adapter |
+| Experimental serial carrier with a published kit pinned by one adapter | interoperability beyond one language, or embedding support | a second independent adapter passes the same fixtures (see `release/host-boundary/LIMITS.md`) |
 | Experimental process carrier first | permanent ABI stability or low-overhead embedding | two independent adapters and one real integration pass the frozen fixtures before v1 |
 | One serial invocation | concurrent requests, streaming, or throughput | demonstrated need followed by the C4 scheduler contract and resource evidence |
 | No automatic side-effect retry | transparent recovery from ambiguous completion | per-operation idempotency, receipt, and crash/recovery contract |
@@ -299,8 +299,12 @@ SQLite, concurrency, or a new kernel form. HB.2a through HB.2c ship the
 codecs, the session accounting, and the `jacquard host worker` carrier
 described in [`host-worker-v0.md`](host-worker-v0.md).
 
-HB.3 publishes the language-neutral conformance kit and Core evidence. Only
-then does the external adapter start against a released pin.
+HB.3 published the language-neutral conformance kit
+([`spec/host-protocol-v0/kit/`](../spec/host-protocol-v0/kit/README.md)) and
+its evidence pack ([`release/host-boundary/`](release/host-boundary/EVIDENCE.md)).
+The first external adapter, jacquard-host, pinned that kit, replayed it in
+full, and returned its authority inventory and a versioned requirements
+report; those are the inputs to the gates below.
 
 The external serial HTTP integration reports concrete authority needs back to
 Core. That report gates resource attenuation. Measured concurrency need gates

--- a/docs/host-worker-v0.md
+++ b/docs/host-worker-v0.md
@@ -104,8 +104,10 @@ messages.
 - One worker serves one invocation. Reusing a process for a second invocation
   is a protocol error; hosts start a fresh worker instead.
 - The carrier is provisional v0 evidence (D79). No stable foreign-host ABI,
-  adapter, HTTP server, or cross-language conformance kit ships here; HB.3
-  publishes the executable fixtures that external adapters pin.
+  adapter, or HTTP server ships here; the HB.3 kit under
+  `spec/host-protocol-v0/kit/` is what external adapters pin, and
+  `docs/release/host-boundary/` records its evidence, limits, and pending
+  decisions.
 
 ## Evidence
 

--- a/docs/release/host-boundary/DECISION.md
+++ b/docs/release/host-boundary/DECISION.md
@@ -1,0 +1,47 @@
+# Host boundary decisions
+
+Status: two decisions are prepared for the owner and remain PENDING. The kit
+records both without resolving them; nothing below is approved until this
+file says so.
+
+## HBD-1 — `noncanonical-target-hash`: E1603 or E1601
+
+The frozen vector expects E1603 (target invalid) for an uppercase target
+identity. Spec section 4 requires exactly 64 lowercase hexadecimal digits and
+the fail-fast order in the same section places scalar and envelope shape
+(E1601) before target preflight (E1603). The shipped HB.2b2 preflight follows
+that order and `test/test_host_invoke_preflight.ml` pins E1601.
+
+Options:
+
+1. Correct the vector to E1601 (spec-consistent; changes a frozen expected
+   code, so it is a reviewed protocol-corpus change, not a refresh).
+2. Keep E1603 and change preflight to classify malformed identities as target
+   failures (contradicts the frozen fail-fast order and an existing pin).
+3. Replace the mutation with a well-formed absent identity so the case keeps
+   meaning "target absent" (E1603), and add an additive case
+   `malformed-target-identity` expecting E1601.
+
+Recommended: option 3. It preserves every existing expectation, adds the
+missing malformed-scalar case, and matches both the spec text and the
+shipped behavior. Until decided the kit lists the case under
+`pending_decisions`.
+
+## HBD-2 — diagnostic prose in vector templates
+
+Two outcome templates (`refused_outcome`, `timeout_unknown_outcome`) carry
+illustrative `summary`, `cause`, and `next_step` text that differs from the
+prose the shipped session layer emits for E1607 and E1612. Codes, domain,
+severity, span, schema, evidence, and the host-message cause suffix agree.
+
+Options:
+
+1. Declare diagnostic prose non-normative in spec section 10 and keep the
+   templates as they are (the kit already compares this way).
+2. Refresh the two templates from the shipped prose (a vectors change).
+3. Freeze the shipped prose in the spec and treat any change as a protocol
+   version bump.
+
+Recommended: option 1, with the kit's semantic comparison as the published
+rule; prose remains free to improve without a protocol version. Until decided
+the kit lists each drifting field under `diagnostic_prose.drift`.

--- a/docs/release/host-boundary/EVIDENCE.md
+++ b/docs/release/host-boundary/EVIDENCE.md
@@ -1,0 +1,98 @@
+# Host boundary evidence
+
+Status: HB.3 publication, September 2026. This pack records what the host
+boundary work has shipped, the exact artifacts an adapter pins, and the
+evidence behind each claim. It repeats the still-active limits in
+[LIMITS.md](LIMITS.md) and records the two open vector decisions in
+[DECISION.md](DECISION.md).
+
+## Shipped slices
+
+| Slice | Content | Landed |
+|---|---|---|
+| HB.0 | ownership and trust contract, `docs/host-boundary.md` | #107 |
+| HB.1 | frozen envelopes, framing, limits, vectors, `spec/host-protocol-v0.md` | #108 |
+| HB.2a | strict framing and selection codec | #109 |
+| HB.2b1 | bounded first-order type and value codecs | #110 |
+| HB.2b2 | checked invoke preflight | #111 |
+| HB.2b3 | serial session accounting, `docs/host-session-v0.md` | #113 |
+| HB.2c | opt-in worker `jacquard host worker`, `docs/host-worker-v0.md` | #114 (main `128fbafa255ba3bb688e4f795d58cb6f09432424`) |
+| HB.3a | executable conformance kit, `spec/host-protocol-v0/kit/` | #115 (main `61575c7bcd98c8922e739de647556d1368729ad8`) |
+
+The TS.0 repair that the publication gate required (checked effect payload
+constraints preserved through handlers) landed in #112 before the worker.
+
+## Artifacts an adapter pins
+
+| Artifact | SHA-256 at publication |
+|---|---|
+| `spec/host-protocol-v0/vectors.json` (frozen HB.1) | `9ba1bff8eee0b6dbea6475dc0c7e9cc6313d847ad80bd8d832457115eb1c738a` |
+| `spec/host-protocol-v0/kit/fixtures.jac` | `037bb8209ca0344ba0a2cd0fcc16e69f13c8f9b91e3404dc3f3161e351831d80` |
+| `spec/host-protocol-v0/kit/kit.json` | `a286328c457696a898aaa6731f0044fb90c78d8657d57270384a76976b070b53` |
+| `spec/host-protocol-v0/kit/transcripts.json` | `ebaf590e3d1b7e8399f56de5ad85043ac3658416dd7f0af7b55b9f9f3ce93240` |
+
+Protocol `jacquard-host-v0`, carrier `stdio-u32-json-v0`, Core version
+`0.2.0` at the commits above. The recipe
+`jacquard run fixtures.jac --store DIR` with the prelude of the same
+checkout reproduces every identity in `kit.json`.
+
+## Executable results
+
+- 21 of 21 vector transcripts replay byte-for-byte through the installed
+  worker via the deterministic fake host; two consecutive regenerations hash
+  identically.
+- 20 transcripts conform to their vector expectation. The single recorded
+  divergence is `noncanonical-target-hash` (vector E1603, observed E1601);
+  see DECISION.md.
+- All 5 positive sequences equal their bound HB.1 templates except the
+  diagnostic prose fields of two outcome templates, which are listed under
+  `diagnostic_prose.drift` in `kit.json`; see DECISION.md.
+- All 13 terminal mappings execute with the frozen primary code and terminal
+  classification.
+- Worker evidence: 23 cases in `test/test_host_worker.ml` and
+  `test/cli/host-worker.t`, including dead-output and carrier-loss exit
+  statuses; kit evidence: 7 cases in `test/test_host_kit.ml`.
+- Source inventory at publication: `1014 / 61 / 28` Alcotest-QCheck cases,
+  cram transcript files, and documentation examples.
+
+## The first independent adapter
+
+[`jacquard-host`](https://github.com/jbwinters/jacquard-host) (Python,
+standard library only) pinned this kit by the SHA-256 values above, vendored
+the four files, and replays every transcript against the installed worker
+with its own fake host (`python -m jacquard_host.kit`): 21 of 21 transcripts
+match their recordings, `noncanonical-target-hash` is reproduced as the
+recorded divergence, and no diagnostic prose drift is observed. On the same
+pin it built an embedding adapter (Python functions serve a term's `once`
+operations by exact identity), a serial loopback socket host, an HTTP/1.1
+subset parser written in Jacquard, a host-owned SQLite operation, and an
+end-to-end synthetic trial, each independently reviewed and merged. Its
+`docs/EVIDENCE.md`, `docs/AUTHORITY.md`, and `docs/CORE-REQUIREMENTS.md`
+(`jacquard-host-core-requirements-v1`) are the adapter-side record. The
+requirements it reports back to Core, in its words, are: no bytes boundary
+value; single-source store population until the store-reopen repair lands;
+`--print-sigs` printing a one-item tuple as `(Int)`; `jacquard hash` printing
+a type and a same-named constructor without a kind; prelude type identities
+recoverable only by hashing prelude files; `Session.request` matching
+registry bindings by operation hash only; the pending
+`noncanonical-target-hash` decision; no frozen pair for a completed but
+unrepresentable result; no host-side handler deadline in the protocol
+(recorded as a host limit); and this evidence pack itself. None of them
+blocked the adapter; each names the Core change that would remove a
+workaround.
+
+## Gates
+
+Required contexts on each PR above: Development gate, Native parity (clang),
+Native parity (gcc), Governance playground, GM12B exhaustive forwarding
+evidence. Independent review: #114 review 1 BLOCK (standard-output carrier
+loss) fixed in the same PR, review 2 PASS; #115 review PASS.
+
+## Reproduction
+
+```sh
+eval "$(opam env)"
+opam exec -- dune build @all
+NO_COLOR=1 opam exec -- dune runtest
+opam exec -- dune exec test/gen_host_kit.exe && git diff --exit-code spec/host-protocol-v0/kit
+```

--- a/docs/release/host-boundary/EVIDENCE.md
+++ b/docs/release/host-boundary/EVIDENCE.md
@@ -49,7 +49,8 @@ checkout reproduces every identity in `kit.json`.
   `diagnostic_prose.drift` in `kit.json`; see DECISION.md.
 - All 13 terminal mappings execute with the frozen primary code and terminal
   classification.
-- Worker evidence: 23 cases in `test/test_host_worker.ml` and
+- Worker evidence: 23 cases (22 Alcotest cases and one QCheck property) in
+  `test/test_host_worker.ml` and
   `test/cli/host-worker.t`, including dead-output and carrier-loss exit
   statuses; kit evidence: 7 cases in `test/test_host_kit.ml`.
 - Source inventory at publication: `1014 / 61 / 28` Alcotest-QCheck cases,
@@ -78,15 +79,16 @@ registry bindings by operation hash only; the pending
 `noncanonical-target-hash` decision; no frozen pair for a completed but
 unrepresentable result; no host-side handler deadline in the protocol
 (recorded as a host limit); and this evidence pack itself. None of them
-blocked the adapter; each names the Core change that would remove a
-workaround.
+blocked the adapter; nine name the Core change that would remove a
+workaround and the tenth confirms HP0.8 needs nothing.
 
 ## Gates
 
 Required contexts on each PR above: Development gate, Native parity (clang),
 Native parity (gcc), Governance playground, GM12B exhaustive forwarding
 evidence. Independent review: #114 review 1 BLOCK (standard-output carrier
-loss) fixed in the same PR, review 2 PASS; #115 review PASS.
+loss) fixed in the same PR, review 2 PASS; #115 review 1 aborted without a
+verdict, reviews 2 and 3 PASS.
 
 ## Reproduction
 
@@ -96,3 +98,5 @@ opam exec -- dune build @all
 NO_COLOR=1 opam exec -- dune runtest
 opam exec -- dune exec test/gen_host_kit.exe && git diff --exit-code spec/host-protocol-v0/kit
 ```
+
+In a nested worktree add `--root .` to each dune command.

--- a/docs/release/host-boundary/LIMITS.md
+++ b/docs/release/host-boundary/LIMITS.md
@@ -1,0 +1,23 @@
+# Host boundary limits
+
+These limits are part of the HB.3 publication, not a future-work appendix.
+Each names the condition for its removal. Silence never widens a claim.
+
+| Limit | What we do not claim | Removal gate |
+|---|---|---|
+| First-party programs | safety for hostile uploaded Jacquard code | separate-process or equivalent isolation design, hostile resource tests, reviewed threat model |
+| Trusted adapter and operating system (D78) | protection from a lying host or broader OS credentials | independently enforced isolation and authentication plus external security review |
+| Experimental provisional carrier (D79) | a stable foreign-host ABI or low-overhead embedding | two independent adapters and one real serial integration passing the kit before any v1 claim |
+| One independent adapter (jacquard-host, Python) | interoperability beyond one language | a second independent adapter (jacquard-host's Rust track) passes the same kit before any v1 claim |
+| One serial invocation, one outstanding request | concurrency, streaming, callbacks, throughput | demonstrated need, then the C4 scheduler contract and resource evidence |
+| No automatic side-effect retry (D83) | transparent recovery from ambiguous completion | per-operation idempotency, receipts, and a crash/recovery contract |
+| Coarse Core 0.2 grants | domain, path, port, or database-row containment | the host authority report, then Task 202's reviewed attenuation algebra |
+| No deadline or memory ceiling in the worker | protection from a runaway target | host process limits (jacquard-host) and Core fuel/allocation limits |
+| Startup configuration failures exit 1 | a protocol status for a missing or unpopulated store | a later protocol version or a documented host-side classification |
+| Diagnostic prose is not normative | byte-equal diagnostics across Core versions | a reviewed decision to refresh the vector prose or freeze prose in the spec |
+| One recorded vector divergence | a fully conforming hostile corpus | the E1603/E1601 decision in DECISION.md |
+| Linux-first evidence | a portable host-runtime claim | CI, lifecycle, cleanup, and packaging evidence per added platform |
+| No HTTP, sockets, SQLite, or RPC in Core | a bundled web framework or hosted service | intentionally not a removal target |
+
+The kit's fake host is evidence tooling in the test tree; it is not an
+adapter, an embedding contract, or a supported library surface.

--- a/docs/release/host-boundary/LIMITS.md
+++ b/docs/release/host-boundary/LIMITS.md
@@ -11,6 +11,7 @@ Each names the condition for its removal. Silence never widens a claim.
 | One independent adapter (jacquard-host, Python) | interoperability beyond one language | a second independent adapter (jacquard-host's Rust track) passes the same kit before any v1 claim |
 | One serial invocation, one outstanding request | concurrency, streaming, callbacks, throughput | demonstrated need, then the C4 scheduler contract and resource evidence |
 | No automatic side-effect retry (D83) | transparent recovery from ambiguous completion | per-operation idempotency, receipts, and a crash/recovery contract |
+| Controlled replay fixtures (D84) | production traffic replay | explicit privacy, retention, redaction, and evidence-store authority |
 | Coarse Core 0.2 grants | domain, path, port, or database-row containment | the host authority report, then Task 202's reviewed attenuation algebra |
 | No deadline or memory ceiling in the worker | protection from a runaway target | host process limits (jacquard-host) and Core fuel/allocation limits |
 | Startup configuration failures exit 1 | a protocol status for a missing or unpopulated store | a later protocol version or a documented host-side classification |

--- a/test/gen_host_kit.ml
+++ b/test/gen_host_kit.ml
@@ -6,6 +6,8 @@ let () =
   let kit = Host_kit.kit_dir () in
   let binary = Host_kit.default_binary () in
   let store = Host_kit.fresh_path "store" in
+  (* the store is scratch on every exit path, including a failed recipe *)
+  at_exit (fun () -> if Sys.file_exists store then Host_kit.remove_tree store);
   (match
      Host_kit.build_store ~binary
        ~fixtures:(Filename.concat kit "fixtures.jac")
@@ -59,6 +61,5 @@ let () =
   Host_kit.write_file
     (Filename.concat kit "transcripts.json")
     (Yojson.Safe.pretty_to_string (`List transcripts) ^ "\n");
-  Host_kit.remove_tree store;
   Printf.printf "host kit: %d transcripts, %d diverging\n" (List.length transcripts)
     (List.length pending)

--- a/test/host_kit.ml
+++ b/test/host_kit.ml
@@ -499,6 +499,7 @@ let play ~binary ~store case =
         reaped := Some status;
         status
   in
+  let stderr = ref "" in
   let status =
     Fun.protect
       ~finally:(fun () ->
@@ -511,7 +512,10 @@ let play ~binary ~store case =
              Unix.kill pid Sys.sigkill;
              ignore (reap ())
            with Unix.Unix_error _ -> ());
-        ())
+        if Sys.file_exists stderr_path then begin
+          (try stderr := read_file stderr_path with Sys_error _ -> ());
+          try Sys.remove stderr_path with Sys_error _ -> ()
+        end)
       (fun () ->
         (try with_deadline 30 run
          with Timeout ->
@@ -519,8 +523,7 @@ let play ~binary ~store case =
            frames := `Assoc [ ("kind", `String "fake-host-timeout") ] :: !frames);
         reap ())
   in
-  let stderr = if Sys.file_exists stderr_path then read_file stderr_path else "" in
-  if Sys.file_exists stderr_path then Sys.remove stderr_path;
+  let stderr = !stderr in
   {
     core_frames = List.rev !frames;
     exit_code = (match status with Unix.WEXITED code -> Some code | _ -> None);

--- a/test/host_kit.ml
+++ b/test/host_kit.ml
@@ -84,13 +84,15 @@ let write_file path contents =
   let channel = open_out_bin path in
   Fun.protect ~finally:(fun () -> close_out channel) (fun () -> output_string channel contents)
 
+(* best effort on every step: scratch removal must never raise, least of all from at_exit *)
 let rec remove_tree path =
-  match Unix.lstat path with
-  | { Unix.st_kind = Unix.S_DIR; _ } ->
-      Array.iter (fun entry -> remove_tree (Filename.concat path entry)) (Sys.readdir path);
-      Unix.rmdir path
-  | _ -> Sys.remove path
-  | exception Unix.Unix_error _ -> ()
+  try
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter (fun entry -> remove_tree (Filename.concat path entry)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Sys.remove path
+  with Unix.Unix_error _ | Sys_error _ -> ()
 
 let bytes_of_hex hex =
   String.init
@@ -506,12 +508,12 @@ let play ~binary ~store case =
         close_input ();
         close_in_noerr output;
         Sys.set_signal Sys.sigpipe previous;
-        (* any other failure must still reap the worker and drop its operator file *)
-        (if Option.is_none !reaped then
-           try
-             Unix.kill pid Sys.sigkill;
-             ignore (reap ())
-           with Unix.Unix_error _ -> ());
+        (* any other failure must still reap the worker and drop its operator file; a kill
+           that fails (the child already exited) must not skip the reap *)
+        if Option.is_none !reaped then begin
+          (try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ());
+          try ignore (reap ()) with Unix.Unix_error _ -> ()
+        end;
         if Sys.file_exists stderr_path then begin
           (try stderr := read_file stderr_path with Sys_error _ -> ());
           try Sys.remove stderr_path with Sys_error _ -> ()


### PR DESCRIPTION
## Summary

HB.3b, the second half of the HB.3 publication: the host boundary evidence pack, the status lines that follow from it, and the deferred kit tooling debt.

- `docs/release/host-boundary/EVIDENCE.md`: the shipped slices HB.0 through HB.3a with their pull requests and merge commits; the four artifacts an adapter pins by SHA-256 at `61575c7`; the executable results (21 of 21 transcripts replay, 20 conform, the one recorded divergence, all 13 terminal mappings, the worker and kit case counts, the inventory); the first independent adapter, jacquard-host, which pinned the kit, replays it in full, built its embedding and integration slices on it, and returned its authority inventory and `jacquard-host-core-requirements-v1` (ten items summarised); gates and reviews; reproduction commands.
- `docs/release/host-boundary/LIMITS.md`: every still-active limit with its removal gate, including "one independent adapter" whose gate is the second adapter before any v1 claim (D79).
- `docs/release/host-boundary/DECISION.md`: HBD-1 (`noncanonical-target-hash`, E1603 versus E1601) and HBD-2 (diagnostic prose in vector templates) with options and recommendations, both PENDING for the owner; nothing is approved by this PR.
- Status lines in README.md, docs/README.md, AGENTS.md, docs/SKILL.md, docs/host-worker-v0.md, and docs/host-boundary.md sections 10 and 11 now say the kit is published and pinned by one adapter, with the second adapter as the remaining gate; no adapter, ABI, or HTTP server ships here.
- Kit tooling: the fake host reads and removes its stderr temp file inside its cleanup, so an exception in the play loop cannot leak it; the generator registers its scratch store for removal at exit before the recipe runs.

## Evidence

- `dune build @fmt` clean; the focused kit suite passes (7 cases); `dune exec test/gen_host_kit.exe` regenerates `kit.json` and `transcripts.json` byte-identically; the full test suite passes. No test inventory change.
- Independent review: BLOCK on the first commit (a still-active section-10 limit was missing from LIMITS.md; wording precision; two kit tooling debt items), closed in the second; delta re-review PASS at `7200085`. Full gate PASS (1014 cases) on both commits.

## Decisions left to the owner

HBD-1 and HBD-2 in `DECISION.md`. This PR records them; it does not decide them.
