### PR TITLE
APP.4: reopen populated stores with the prelude; store add leaves the store unchanged on refusal

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1766,14 +1766,34 @@ let with_store store_dir f =
 
 let store_add_cmd store_dir file origin syntax =
   with_store store_dir (fun store ->
-      match
-        process_forms ?origin ~syntax store ~file (read_file file) ~on_expr:(fun _ ->
-            Error [ cli_diagnostic ~code:"E0704" "store add expects declarations only" ])
-      with
-      | Ok () ->
-          print_endline "ok";
-          ok
-      | Error ds -> print_diags ds)
+      let source = read_file file in
+      let expression_refusal = cli_diagnostic ~code:"E0704" "store add expects declarations only" in
+      (* refuse before installing anything: a file with a top-level expression must leave the
+         store exactly as it was *)
+      let declarations_only =
+        Result.bind
+          (parse_tops ~syntax ~names:(Store.names_view store) ~file source)
+          (fun (tops, _warnings) ->
+            let rec check = function
+              | [] -> Ok ()
+              | parsed :: rest ->
+                  Result.bind (validate_parsed_top parsed) (function
+                    | Kernel.Expr _ -> Error [ expression_refusal ]
+                    | Kernel.Decl _ -> check rest)
+            in
+            check tops)
+      in
+      match declarations_only with
+      | Error ds -> print_diags ds
+      | Ok () -> (
+          match
+            process_forms ?origin ~syntax store ~file source ~on_expr:(fun _ ->
+                Error [ expression_refusal ])
+          with
+          | Ok () ->
+              print_endline "ok";
+              ok
+          | Error ds -> print_diags ds))
 
 let store_name_cmd store_dir name hex =
   with_store store_dir (fun store ->

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1809,8 +1809,13 @@ let store_add_cmd store_dir file origin syntax =
               (Sys.readdir objects_dir)
           in
           match
-            process_forms ?origin ~syntax store ~file source ~on_expr:(fun _ ->
-                Error [ expression_refusal ])
+            (* an exception part-way through is a refusal too: roll back, then re-raise *)
+            try
+              process_forms ?origin ~syntax store ~file source ~on_expr:(fun _ ->
+                  Error [ expression_refusal ])
+            with exn ->
+              restore ();
+              raise exn
           with
           | Ok () ->
               print_endline "ok";

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1764,10 +1764,10 @@ let diff_cmd operand_a operand_b syntax prelude =
 let with_store store_dir f =
   match Store.open_store store_dir with Error ds -> print_diags ds | Ok store -> f store
 
-let store_add_cmd store_dir file origin =
+let store_add_cmd store_dir file origin syntax =
   with_store store_dir (fun store ->
       match
-        process_forms ?origin ~syntax:Bootstrap store ~file (read_file file) ~on_expr:(fun _ ->
+        process_forms ?origin ~syntax store ~file (read_file file) ~on_expr:(fun _ ->
             Error [ cli_diagnostic ~code:"E0704" "store add expects declarations only" ])
       with
       | Ok () ->
@@ -2391,7 +2391,7 @@ let store_t =
         const (configure_diagnostics store_add_cmd)
         $ diagnostic_format_arg $ store_pos_dir
         $ Arg.(required & pos 1 (some file) None & info [] ~docv:"FILE")
-        $ origin_arg)
+        $ origin_arg $ syntax_arg)
   in
   let name =
     Cmd.v

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1786,6 +1786,28 @@ let store_add_cmd store_dir file origin syntax =
       match declarations_only with
       | Error ds -> print_diags ds
       | Ok () -> (
+          (* a failure part-way through a file must leave the store as it was: snapshot the
+             index and object set, and restore them if any declaration is refused *)
+          let names_path = Filename.concat store_dir "names.jqd" in
+          let objects_dir = Filename.concat store_dir "objects" in
+          let names_before =
+            if Sys.file_exists names_path then Some (read_file names_path) else None
+          in
+          let objects_before = Sys.readdir objects_dir |> Array.to_list in
+          let restore () =
+            (match names_before with
+            | Some bytes ->
+                let channel = open_out_bin names_path in
+                Fun.protect
+                  ~finally:(fun () -> close_out channel)
+                  (fun () -> output_string channel bytes)
+            | None -> if Sys.file_exists names_path then Sys.remove names_path);
+            Array.iter
+              (fun entry ->
+                if not (List.mem entry objects_before) then
+                  Sys.remove (Filename.concat objects_dir entry))
+              (Sys.readdir objects_dir)
+          in
           match
             process_forms ?origin ~syntax store ~file source ~on_expr:(fun _ ->
                 Error [ expression_refusal ])
@@ -1793,7 +1815,9 @@ let store_add_cmd store_dir file origin syntax =
           | Ok () ->
               print_endline "ok";
               ok
-          | Error ds -> print_diags ds))
+          | Error ds ->
+              restore ();
+              print_diags ds))
 
 let store_name_cmd store_dir name hex =
   with_store store_dir (fun store ->

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -102,7 +102,8 @@ jac test TESTS.jac --allow fs --allow net --allow clock --allow console
 # prelude and every installed declaration and records which prelude files
 # (names and bytes) it was created with: reopening with that prelude is a
 # no-op, so separate entry points can run against one installed model, and
-# reopening with a different prelude is refused (E0705) without changes.
+# reopening with a different prelude is refused (E0705) without changes. A
+# `store add` that refuses any declaration leaves the store exactly as it was.
 jac run MODEL.jac --store STORE
 jac run ENTRY.jac --store STORE
 jac store add STORE PROGRAM.jac

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -99,8 +99,10 @@ jac test TESTS.jac --cache-dir .jacquard-test-cache
 jac test TESTS.jac --allow fs --allow net --allow clock --allow console
 
 # Content store, canonical-structure diff, traces, and tiers. A store keeps the
-# prelude and every installed declaration; reopening it with the same prelude
-# is idempotent, so separate entry points can run against one installed model.
+# prelude and every installed declaration and records which prelude files
+# (names and bytes) it was created with: reopening with that prelude is a
+# no-op, so separate entry points can run against one installed model, and
+# reopening with a different prelude is refused (E0705) without changes.
 jac run MODEL.jac --store STORE
 jac run ENTRY.jac --store STORE
 jac store add STORE PROGRAM.jac

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -98,7 +98,11 @@ jac test TESTS.jac --seed 42 --exhaustive --budget 10000
 jac test TESTS.jac --cache-dir .jacquard-test-cache
 jac test TESTS.jac --allow fs --allow net --allow clock --allow console
 
-# Content store, canonical-structure diff, traces, and tiers.
+# Content store, canonical-structure diff, traces, and tiers. A store keeps the
+# prelude and every installed declaration; reopening it with the same prelude
+# is idempotent, so separate entry points can run against one installed model.
+jac run MODEL.jac --store STORE
+jac run ENTRY.jac --store STORE
 jac store add STORE PROGRAM.jac
 jac store rename STORE old-name new-name
 jac diff STORE_A STORE_B

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -138,6 +138,7 @@ malformed source, path, or host-message byte in a string field is replaced with 
 | E0702 | prelude name missing or wrong kind | truncated prelude |
 | E0703 | effect not grantable | `--allow filesystem` |
 | E0704 | store add expects declarations only | an expression in `jacquard store add` |
+| E0705 | prelude differs from the store's recorded prelude | reopening a store with an edited prelude directory |
 
 ## Type and effect checker (E08xx, W08xx)
 

--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `1014`
+Test count: `1015`
 
 Cram count: `61`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -99,13 +99,16 @@ inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
 finish-once accounting, and bounded evidence. See
 [the session contract](../../host-session-v0.md).
 
-Reopening a persistent store with the public prelude is idempotent: the loader
-resolves the prelude's own later files through a trusted view that can still
-name the derived members an earlier load hid, while user programs keep the
-public view. `jac store add` selects the parser by file extension, so the
-advertised `.jac` installation command works. Pinned by the reload case in
-`test/test_prelude.ml` (one more case, `1008`) and the reopen block of
-`test/cli/store.t`.
+Reopening a persistent store with the public prelude is idempotent: a store
+records the prelude files it was loaded with, an identical prelude reloads as
+a no-op, a different prelude is refused with E0705 before any change, and a
+store made before manifests were recorded loads its prelude through a trusted
+view in which hidden derived members outrank any same-named user binding while
+user programs keep the public view. `jac store add` selects the parser by file
+extension, so the advertised `.jac` installation command works, and refuses a
+file with a top-level expression before installing anything. Pinned by the
+reload case in `test/test_prelude.ml` (one more case, `1008`) and the reopen
+block of `test/cli/store.t`.
 
 The opt-in serial host worker adds 23 cases and one CLI transcript, bringing
 the current source inventory to `1007 / 61 / 28`. It covers the full

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `1014`
+- Alcotest/QCheck cases: `1015`
 - Cram transcript files: `61`
 - Documentation examples: `28` named examples across `8` documents
 
@@ -98,6 +98,14 @@ The serial host-session library adds 15 cases, bringing the current source
 inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
 finish-once accounting, and bounded evidence. See
 [the session contract](../../host-session-v0.md).
+
+Reopening a persistent store with the public prelude is idempotent: the loader
+resolves the prelude's own later files through a trusted view that can still
+name the derived members an earlier load hid, while user programs keep the
+public view. `jac store add` selects the parser by file extension, so the
+advertised `.jac` installation command works. Pinned by the reload case in
+`test/test_prelude.ml` (one more case, `1008`) and the reopen block of
+`test/cli/store.t`.
 
 The opt-in serial host worker adds 23 cases and one CLI transcript, bringing
 the current source inventory to `1007 / 61 / 28`. It covers the full

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -99,17 +99,6 @@ inventory to `984 / 60 / 28`. It covers typed responses, terminal mappings,
 finish-once accounting, and bounded evidence. See
 [the session contract](../../host-session-v0.md).
 
-Reopening a persistent store with the public prelude is idempotent: a store
-records the prelude files it was loaded with, an identical prelude reloads as
-a no-op, a different prelude is refused with E0705 before any change, and a
-store made before manifests were recorded loads its prelude through a trusted
-view in which hidden derived members outrank any same-named user binding while
-user programs keep the public view. `jac store add` selects the parser by file
-extension, so the advertised `.jac` installation command works, and refuses a
-file with a top-level expression before installing anything. Pinned by the
-reload case in `test/test_prelude.ml` (one more case, `1008`) and the reopen
-block of `test/cli/store.t`.
-
 The opt-in serial host worker adds 23 cases and one CLI transcript, bringing
 the current source inventory to `1007 / 61 / 28`. It covers the full
 `stdio-u32-json-v0` lifetime against a reopened store: pure and effectful
@@ -125,3 +114,17 @@ binds every synthetic HB.1 vector identity to a real store member, replays all
 worker with a deterministic fake host, and fails on any divergence that is not
 an explicitly recorded pending decision. See
 [the kit README](../../../spec/host-protocol-v0/kit/README.md).
+
+Reopening a persistent store with the public prelude is idempotent: a store
+records the prelude files it was loaded with, an identical prelude reloads as
+a no-op, a different prelude is refused with E0705 before any change, and a
+store made before manifests were recorded loads its prelude through a trusted
+view in which hidden derived members outrank any same-named user binding while
+user programs keep the public view. `jac store add` selects the parser by file
+extension, so the advertised `.jac` installation command works, refuses a
+file with a top-level expression before installing anything, and restores the
+index and object set if any declaration is refused part-way through a file,
+so a failed installation leaves the store exactly as it was. Pinned by the
+reload case in `test/test_prelude.ml` (one more case, bringing the inventory
+to `1015 / 61 / 28`) and the reopen, mismatch, and rollback blocks of
+`test/cli/store.t`.

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `1014`
+- Alcotest/QCheck cases: `1015`
 - Cram transcript files: `61`
 - Doctest examples: `28` across 8 documents
 

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `1014`
+- Alcotest/QCheck cases: `1015`
 - Cram transcript files: `61`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -51,8 +51,10 @@ let read_file path =
 
     A store records the identity of the prelude it was loaded with (file names and byte digests).
     Loading the identical prelude again is a no-op that returns [Ok []] without touching the store;
-    loading a different prelude is refused with E0705 before any mutation. A store created before
-    manifests were recorded is loaded through the trusted view and then gains a manifest. *)
+    loading a different prelude is refused with E0705 before any mutation. Every load resolves
+    prelude references through the trusted view, in which hidden derived members outrank any
+    same-named user binding; a store created before manifests were recorded gains its manifest on
+    the first load. *)
 let load ~dir store : ((string * Canon.decl_hashes list) list, Diag.t list) result =
   if not (Sys.file_exists dir && Sys.is_directory dir) then
     err ~code:"E0701" "prelude directory %s does not exist" dir

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -17,12 +17,16 @@ let diagnostic_summary = function
   | "E0701" -> "Prelude directory is unavailable"
   | "E0702" -> "Prelude contents are incomplete or have the wrong kind"
   | "E0703" -> "Requested effect is not root-grantable"
+  | "E0705" -> "Prelude does not match the store's recorded prelude"
   | code -> "Prelude loading failed (" ^ code ^ ")"
 
 let diagnostic_next_step = function
   | "E0701" -> "Pass --prelude with the path to a complete prelude directory."
   | "E0702" -> "Restore the named declaration with the required prelude kind."
   | "E0703" -> "Handle this effect inside the program instead of granting it at the root."
+  | "E0705" ->
+      "Reopen the store with the prelude it was created with, or create a new store for this \
+       prelude."
   | _ -> "Correct the prelude configuration and try again."
 
 let err ~code fmt =
@@ -43,7 +47,12 @@ let read_file path =
 
 (** [load ~dir store] loads the prelude sources into [store]. Returns
     [(relative file name, hashes of each declaration in file order)] per file, in load order. Fails
-    with the first diagnostic batch (E0701 wraps IO problems). *)
+    with the first diagnostic batch (E0701 wraps IO problems).
+
+    A store records the identity of the prelude it was loaded with (file names and byte digests).
+    Loading the identical prelude again is a no-op that returns [Ok []] without touching the store;
+    loading a different prelude is refused with E0705 before any mutation. A store created before
+    manifests were recorded is loaded through the trusted view and then gains a manifest. *)
 let load ~dir store : ((string * Canon.decl_hashes list) list, Diag.t list) result =
   if not (Sys.file_exists dir && Sys.is_directory dir) then
     err ~code:"E0701" "prelude directory %s does not exist" dir
@@ -53,6 +62,39 @@ let load ~dir store : ((string * Canon.decl_hashes list) list, Diag.t list) resu
       |> List.filter (fun f -> Filename.check_suffix f ".jqd")
       |> List.sort String.compare
     in
+    let manifest =
+      List.map
+        (fun file ->
+          (file, Digestif.SHA256.(to_hex (digest_string (read_file (Filename.concat dir file))))))
+        files
+    in
+    let manifest_verdict =
+      match Store.prelude_manifest store with
+      | None -> `Load
+      | Some recorded when recorded = manifest -> `Skip
+      | Some recorded ->
+          let names entries = List.map fst entries in
+          let missing = List.filter (fun f -> not (List.mem f files)) (names recorded) in
+          let added = List.filter (fun f -> not (List.mem_assoc f recorded)) files in
+          let changed =
+            List.filter
+              (fun (file, digest) ->
+                match List.assoc_opt file recorded with
+                | Some previous -> not (String.equal previous digest)
+                | None -> false)
+              manifest
+            |> List.map fst
+          in
+          let describe label = function
+            | [] -> None
+            | items -> Some (Printf.sprintf "%s: %s" label (String.concat ", " items))
+          in
+          `Refuse
+            (String.concat "; "
+               (List.filter_map Fun.id
+                  [ describe "changed" changed; describe "missing" missing; describe "added" added ]))
+    in
+    let installed : (string * Hash.t) list ref = ref [] in
     let load_file file =
       let path = Filename.concat dir file in
       match Reader.parse_string ~file:path (read_file path) with
@@ -71,27 +113,33 @@ let load ~dir store : ((string * Canon.decl_hashes list) list, Diag.t list) resu
                     | Ok d -> (
                         match Store.put_decl store d with
                         | Error ds -> Error ds
-                        | Ok hs -> go (hs :: acc) rest)))
+                        | Ok hs ->
+                            installed := !installed @ hs.Canon.named;
+                            go (hs :: acc) rest)))
           in
           go [] forms
     in
     let rec go acc = function
       | [] ->
-          List.iter
-            (fun name ->
-              match Store.lookup_kind store name Resolve.KCon with
-              | Some { Resolve.hash; _ } -> Store.hide_derived store hash
-              | None -> ())
-            [ "hash-opaque"; "secret-opaque"; "posterior-exact-result-v1" ];
-          (match Store.lookup_kind store "audit-sequence-v0" Resolve.KCon with
-          | Some { Resolve.hash; _ } -> Store.hide_derived store hash
-          | None -> ());
-          List.iter
-            (fun name ->
-              match Store.lookup_kind store name Resolve.KTerm with
-              | Some { Resolve.hash; _ } -> Store.hide_derived store hash
-              | None -> ())
-            [ "governance.fresh-audit-run-id"; "governance.require-audit-run-id" ];
+          (* hide by the hashes this load installed, never by a public name lookup: a user
+             binding that reuses a derived member's name must not be the one hidden *)
+          let hide name =
+            (* a derived name can also label its own type or group hash, which hide_derived
+               ignores; hide every installed hash carrying the name *)
+            List.iter
+              (fun (installed_name, hash) ->
+                if String.equal installed_name name then Store.hide_derived store hash)
+              !installed
+          in
+          List.iter hide
+            [
+              "hash-opaque";
+              "secret-opaque";
+              "posterior-exact-result-v1";
+              "audit-sequence-v0";
+              "governance.fresh-audit-run-id";
+              "governance.require-audit-run-id";
+            ];
           let bind_operation_alias effect_name operation_name alias =
             match Store.lookup_kind store effect_name Resolve.KEffect with
             | None -> err ~code:"E0702" "prelude effect `%s` is missing" effect_name
@@ -124,13 +172,19 @@ let load ~dir store : ((string * Canon.decl_hashes list) list, Diag.t list) resu
           let* () = bind_operation_alias "workspace" "write-file" "workspace.write-file" in
           let* () = bind_operation_alias "workspace" "fetch" "workspace.fetch" in
           let* () = bind_operation_alias "net" "fetch" "fetch" in
+          Store.write_prelude_manifest store manifest;
           Ok (List.rev acc)
       | file :: rest -> (
           match load_file file with
           | Error ds -> Error ds
           | Ok hashes -> go ((file, hashes) :: acc) rest)
     in
-    go [] files
+    match manifest_verdict with
+    | `Skip -> Ok []
+    | `Refuse detail ->
+        err ~code:"E0705" "prelude directory %s differs from the store's recorded prelude (%s)" dir
+          detail
+    | `Load -> go [] files
 
 let lookup_hash store ~kind name : (Hash.t, Diag.t list) result =
   match Store.lookup_kind store name kind with

--- a/src/prelude.ml
+++ b/src/prelude.ml
@@ -64,7 +64,9 @@ let load ~dir store : ((string * Canon.decl_hashes list) list, Diag.t list) resu
                 match Kernel.decl_of_form f with
                 | Error ds -> Error ds
                 | Ok d -> (
-                    match Resolve.resolve_decl (Store.names_view store) d with
+                    (* the prelude is first-party: its later files may name derived members that an
+                   earlier load already hid, so reloading a populated store stays idempotent *)
+                    match Resolve.resolve_decl (Store.trusted_names_view store) d with
                     | Error ds -> Error ds
                     | Ok d -> (
                         match Store.put_decl store d with

--- a/src/store.ml
+++ b/src/store.ml
@@ -614,6 +614,22 @@ let names_view t : Resolve.names =
         Option.map snd (List.find_opt (fun (known, _) -> Hash.equal known hash) t.call_abis));
   }
 
+(** [trusted_names_view t] is [names_view t] whose [lookup] also resolves hidden derived prelude
+    members by their immutable declaration names. It exists so that reloading the first-party
+    prelude into a store that already hides those members remains idempotent; language resolution of
+    user programs must keep using [names_view], which never exposes hidden members. *)
+let trusted_names_view t : Resolve.names =
+  let public = names_view t in
+  let hidden_entries name =
+    List.filter_map
+      (fun kind ->
+        match lookup_kind t name kind with
+        | Some _ -> None
+        | None -> lookup_internal_kind t name kind)
+      [ Resolve.KTerm; Resolve.KCon; Resolve.KOp; Resolve.KType; Resolve.KEffect ]
+  in
+  { public with Resolve.lookup = (fun name -> public.Resolve.lookup name @ hidden_entries name) }
+
 (** [bind_name t name hash] binds [name] to a hash already known to the store. Fails on an
     unprintable name (E0605) and on a [defterm] group's whole hash (E0604) — groups are addressed
     through their members. Scheduler-private hashes fail with E0907 even when their object is

--- a/src/store.ml
+++ b/src/store.ml
@@ -538,33 +538,37 @@ let lookup_all t n = List.filter_map (fun (m, e) -> if m = n then Some e else No
 (** The binding of [n] with kind [k], if any. *)
 let lookup_kind t n k = List.find_opt (fun e -> e.Resolve.kind = k) (lookup_all t n)
 
-(** [lookup_internal_kind t name kind] resolves a public binding or a hidden derived prelude member
-    by its immutable declaration metadata. This is a trusted host-only seam for wiring private
-    builtin markers after reopen; language resolution must continue to use [names_view]. *)
+(** [lookup_hidden_kind t name kind] resolves a hidden derived prelude member by its immutable
+    declaration metadata, ignoring public bindings. This is a trusted host-only seam for wiring
+    private builtin markers after reopen; language resolution must continue to use [names_view]. *)
+let lookup_hidden_kind t name kind =
+  let hidden_name hash =
+    match locate_internal t hash with
+    | Error _ -> None
+    | Ok { decl; role; _ } ->
+        let candidate =
+          match (decl.Kernel.it, role) with
+          | Kernel.DefTerm bindings, Member index ->
+              Option.map (fun binding -> binding.Kernel.bname) (List.nth_opt bindings index)
+          | Kernel.DefType { cons; _ }, Constructor index ->
+              Option.map (fun con -> con.Kernel.con_name) (List.nth_opt cons index)
+          | Kernel.DefEffect { ops; _ }, Operation index ->
+              Option.map (fun op -> op.Kernel.op_name) (List.nth_opt ops index)
+          | _ -> None
+        in
+        Option.bind candidate (fun candidate_name ->
+            if String.equal candidate_name name && entry_kind decl role = kind then
+              Some { Resolve.hash; kind }
+            else None)
+  in
+  List.find_map hidden_name t.hidden
+
+(** [lookup_internal_kind t name kind] resolves a public binding first and otherwise a hidden
+    derived prelude member; see {!lookup_hidden_kind} for the hidden-only scan. *)
 let lookup_internal_kind t name kind =
   match lookup_kind t name kind with
   | Some _ as public -> public
-  | None ->
-      let hidden_name hash =
-        match locate_internal t hash with
-        | Error _ -> None
-        | Ok { decl; role; _ } ->
-            let candidate =
-              match (decl.Kernel.it, role) with
-              | Kernel.DefTerm bindings, Member index ->
-                  Option.map (fun binding -> binding.Kernel.bname) (List.nth_opt bindings index)
-              | Kernel.DefType { cons; _ }, Constructor index ->
-                  Option.map (fun con -> con.Kernel.con_name) (List.nth_opt cons index)
-              | Kernel.DefEffect { ops; _ }, Operation index ->
-                  Option.map (fun op -> op.Kernel.op_name) (List.nth_opt ops index)
-              | _ -> None
-            in
-            Option.bind candidate (fun candidate_name ->
-                if String.equal candidate_name name && entry_kind decl role = kind then
-                  Some { Resolve.hash; kind }
-                else None)
-      in
-      List.find_map hidden_name t.hidden
+  | None -> lookup_hidden_kind t name kind
 
 (** First binding of [n] by kind rank; prefer {!lookup_kind} when the kind is known. *)
 let lookup_name t n = match lookup_all t n with [] -> None | e :: _ -> Some e
@@ -622,13 +626,38 @@ let trusted_names_view t : Resolve.names =
   let public = names_view t in
   let hidden_entries name =
     List.filter_map
-      (fun kind ->
-        match lookup_kind t name kind with
-        | Some _ -> None
-        | None -> lookup_internal_kind t name kind)
+      (fun kind -> lookup_hidden_kind t name kind)
       [ Resolve.KTerm; Resolve.KCon; Resolve.KOp; Resolve.KType; Resolve.KEffect ]
   in
-  { public with Resolve.lookup = (fun name -> public.Resolve.lookup name @ hidden_entries name) }
+  (* hidden members come first: a user binding that happens to reuse a derived member's name
+     must never be substituted into the prelude's own declarations during a reload *)
+  { public with Resolve.lookup = (fun name -> hidden_entries name @ public.Resolve.lookup name) }
+
+let prelude_manifest_file t = Filename.concat t.root "prelude.manifest"
+
+(** [prelude_manifest t] is the identity of the prelude the store was loaded with: one
+    [(file, digest)] pair per prelude file in load order, or [None] when the store predates
+    manifests or holds no prelude yet. *)
+let prelude_manifest t : (string * string) list option =
+  let path = prelude_manifest_file t in
+  if not (Sys.file_exists path) then None
+  else
+    read_file path |> String.split_on_char '\n'
+    |> List.filter_map (fun line ->
+        match String.index_opt line ' ' with
+        | Some i when i > 0 ->
+            Some (String.sub line (i + 1) (String.length line - i - 1), String.sub line 0 i)
+        | _ -> None)
+    |> Option.some
+
+(** [write_prelude_manifest t entries] records the loaded prelude's identity atomically. *)
+let write_prelude_manifest t entries =
+  let path = prelude_manifest_file t in
+  let temporary = path ^ ".tmp" in
+  let channel = open_out_bin temporary in
+  List.iter (fun (file, digest) -> Printf.fprintf channel "%s %s\n" digest file) entries;
+  close_out channel;
+  Sys.rename temporary path
 
 (** [bind_name t name hash] binds [name] to a hash already known to the store. Fails on an
     unprintable name (E0605) and on a [defterm] group's whole hash (E0604) — groups are addressed

--- a/src/store.ml
+++ b/src/store.ml
@@ -563,12 +563,14 @@ let lookup_hidden_kind t name kind =
   in
   List.find_map hidden_name t.hidden
 
-(** [lookup_internal_kind t name kind] resolves a public binding first and otherwise a hidden
-    derived prelude member; see {!lookup_hidden_kind} for the hidden-only scan. *)
+(** [lookup_internal_kind t name kind] resolves a hidden derived prelude member first and otherwise
+    a public binding. Hidden members win so that trusted wiring of private builtin markers can never
+    land on a same-named binding a user installed later; see {!lookup_hidden_kind} for the
+    hidden-only scan. *)
 let lookup_internal_kind t name kind =
-  match lookup_kind t name kind with
-  | Some _ as public -> public
-  | None -> lookup_hidden_kind t name kind
+  match lookup_hidden_kind t name kind with
+  | Some _ as hidden -> hidden
+  | None -> lookup_kind t name kind
 
 (** First binding of [n] by kind rank; prefer {!lookup_kind} when the kind is known. *)
 let lookup_name t n = match lookup_all t n with [] -> None | e :: _ -> Some e
@@ -655,8 +657,10 @@ let write_prelude_manifest t entries =
   let path = prelude_manifest_file t in
   let temporary = path ^ ".tmp" in
   let channel = open_out_bin temporary in
-  List.iter (fun (file, digest) -> Printf.fprintf channel "%s %s\n" digest file) entries;
-  close_out channel;
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr channel)
+    (fun () ->
+      List.iter (fun (file, digest) -> Printf.fprintf channel "%s %s\n" digest file) entries);
   Sys.rename temporary path
 
 (** [bind_name t name hash] binds [name] to a hash already known to the store. Fails on an

--- a/test/cli/store.t
+++ b/test/cli/store.t
@@ -161,3 +161,31 @@ before any change, and a `store add` that contains an expression installs nothin
   objects-unchanged
   $ grep -c quint appstore/names.jqd || true
   0
+
+A user binding that reuses a hidden prelude member's name keeps its own meaning across
+reopen on both the manifest path and a legacy store without a manifest; it is never wired to
+the withheld builtin. A `store add` that fails part-way (an unresolved name in a later
+declaration) installs nothing.
+
+  $ printf 'governance.fresh-audit-run-id(n) = 7\n' > shadow.jac
+  $ jacquard run shadow.jac --store appstore
+  $ printf 'governance.fresh-audit-run-id(1)\n' > use-shadow.jac
+  $ jacquard run use-shadow.jac --store appstore
+  7
+  $ rm appstore/prelude.manifest
+  $ jacquard run use-shadow.jac --store appstore
+  7
+  $ ls appstore/prelude.manifest
+  appstore/prelude.manifest
+  $ cp appstore/names.jqd names-before-partial.jqd
+  $ ls appstore/objects | wc -l | tr -d ' ' > objects-before-partial.txt
+  $ printf 'aa(n) = mul(n, 2)\nbb(n) = nope(n)\n' > partial.jac
+  $ jacquard store add appstore partial.jac
+  partial.jac:2:9-13: error[E0301]: This reference names something that is not in scope.
+    Cause: No name named `nope` is in scope; nearby names are `code`, `done`, `none`.
+    Next step: Correct the reference to an in-scope name or declaration.
+  [1]
+  $ cmp names-before-partial.jqd appstore/names.jqd && echo index-unchanged
+  index-unchanged
+  $ ls appstore/objects | wc -l | tr -d ' ' | cmp - objects-before-partial.txt && echo objects-unchanged
+  objects-unchanged

--- a/test/cli/store.t
+++ b/test/cli/store.t
@@ -105,3 +105,34 @@ through a persisted names index.
     Cause: Name `persisted-task` cannot expose scheduler-private hash 9b4eaa5e872fa3f768c71fc4cba4d3262a9ebf8a719f0cfb78f22fa9eade4310.
     Next step: Create and use Task and Channel handles only inside a structured scheduler scope.
   [1]
+
+A store populated with the public prelude reopens with the same prelude (APP.4). Installing a
+surface model with `run --store`, then running separate entry points against that store, keeps
+the name index byte-stable; `store add` selects the parser by extension, so a `.jac` file installs
+without a bootstrap twin and still refuses top-level expressions.
+
+  $ export JACQUARD_PRELUDE=../../prelude
+  $ printf 'double : (Int) ->{} Int\ndouble(n) = mul(n, 2)\n' > model.jac
+  $ printf 'double(21)\n' > entry.jac
+  $ jacquard run model.jac --store appstore
+  $ cp appstore/names.jqd names-after-install.jqd
+  $ jacquard run entry.jac --store appstore
+  42
+  $ jacquard run entry.jac --store appstore
+  42
+  $ cmp names-after-install.jqd appstore/names.jqd && echo index-stable
+  index-stable
+  $ printf 'quadruple(n) = double(double(n))\n' > more.jac
+  $ jacquard store add appstore more.jac
+  ok
+  $ printf 'quadruple(5)\n' > entry2.jac
+  $ jacquard run entry2.jac --store appstore
+  20
+  $ printf 'double(1)\n' > expr.jac
+  $ jacquard store add appstore expr.jac
+  error[E0704]: Store add accepts declarations only
+    Cause: store add expects declarations only
+    Next step: Pass declarations to `store add`, not a top-level expression.
+  [1]
+  $ grep -c 'hidden' appstore/names.jqd
+  6

--- a/test/cli/store.t
+++ b/test/cli/store.t
@@ -136,3 +136,28 @@ without a bootstrap twin and still refuses top-level expressions.
   [1]
   $ grep -c 'hidden' appstore/names.jqd
   6
+
+The store records the prelude it was loaded with. Reopening with an edited prelude is refused
+before any change, and a `store add` that contains an expression installs nothing.
+
+  $ mkdir prelude-edited && for f in ../../prelude/*.jqd; do cat "$f" > "prelude-edited/$(basename "$f")"; done
+  $ printf '\n; edited\n' >> prelude-edited/02-data.jqd
+  $ cp appstore/names.jqd names-before-mismatch.jqd
+  $ jacquard run entry.jac --store appstore --prelude prelude-edited
+  error[E0705]: Prelude does not match the store's recorded prelude
+    Cause: prelude directory prelude-edited differs from the store's recorded prelude (changed: 02-data.jqd)
+    Next step: Reopen the store with the prelude it was created with, or create a new store for this prelude.
+  [1]
+  $ cmp names-before-mismatch.jqd appstore/names.jqd && echo unchanged-after-mismatch
+  unchanged-after-mismatch
+  $ ls appstore/objects | wc -l | tr -d ' ' > objects-before.txt
+  $ printf 'quint(n) = mul(n, 5)\nquint(1)\n' > mixed.jac
+  $ jacquard store add appstore mixed.jac
+  error[E0704]: Store add accepts declarations only
+    Cause: store add expects declarations only
+    Next step: Pass declarations to `store add`, not a top-level expression.
+  [1]
+  $ ls appstore/objects | wc -l | tr -d ' ' | cmp - objects-before.txt && echo objects-unchanged
+  objects-unchanged
+  $ grep -c quint appstore/names.jqd || true
+  0

--- a/test/test_prelude.ml
+++ b/test/test_prelude.ml
@@ -522,8 +522,65 @@ let test_handler_overrides_grant () =
   | Error e -> Alcotest.failf "interposed run failed: %s" (Runtime_err.to_string e));
   Alcotest.(check string) "handler swallowed the print" "" (Buffer.contents buf)
 
+(* APP.4: loading the prelude into a store that already holds it is idempotent, hidden derived
+   members stay hidden from the public resolver view, and only the trusted loading view can name
+   them. *)
+let read_bytes path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+
+let test_reload_is_idempotent () =
+  let root =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "jacquard-prelude-reload-%d" (Unix.getpid ()))
+  in
+  let load () =
+    match Store.open_store root with
+    | Error diagnostics ->
+        Alcotest.failf "open store: %s" (String.concat "; " (List.map Diag.to_string diagnostics))
+    | Ok store -> (
+        match Prelude.load ~dir:"../prelude" store with
+        | Ok _ -> store
+        | Error diagnostics ->
+            Alcotest.failf "prelude load: %s"
+              (String.concat "; " (List.map Diag.to_string diagnostics)))
+  in
+  let objects () = Array.length (Sys.readdir (Filename.concat root "objects")) in
+  let names_path = Filename.concat root "names.jqd" in
+  ignore (load ());
+  let first_names = read_bytes names_path and first_objects = objects () in
+  let store = load () in
+  Alcotest.(check string)
+    "name index unchanged by a second load" first_names (read_bytes names_path);
+  Alcotest.(check int) "object count unchanged by a second load" first_objects (objects ());
+  List.iter
+    (fun (name, kind) ->
+      Alcotest.(check bool)
+        (name ^ " stays hidden from the public view")
+        true
+        (Store.lookup_kind store name kind = None
+        && (Store.names_view store).Resolve.lookup name = []);
+      Alcotest.(check bool)
+        (name ^ " resolves through the trusted loading view")
+        true
+        (List.exists
+           (fun (entry : Resolve.entry) -> entry.Resolve.kind = kind)
+           ((Store.trusted_names_view store).Resolve.lookup name)))
+    [
+      ("governance.fresh-audit-run-id", Resolve.KTerm);
+      ("governance.require-audit-run-id", Resolve.KTerm);
+      ("audit-sequence-v0", Resolve.KCon);
+    ];
+  Alcotest.(check bool)
+    "public names are identical in both views" true
+    ((Store.names_view store).Resolve.lookup "mul"
+    = (Store.trusted_names_view store).Resolve.lookup "mul")
+
 let suite =
   [
+    Alcotest.test_case "prelude reload is idempotent" `Quick test_reload_is_idempotent;
     Alcotest.test_case "prelude loads with zero diagnostics" `Quick test_loads_with_zero_diagnostics;
     Alcotest.test_case "prelude hashes golden-pinned" `Quick test_prelude_hashes_golden;
     Alcotest.test_case "builtins work" `Quick test_builtins_work;

--- a/test/test_prelude.ml
+++ b/test/test_prelude.ml
@@ -653,6 +653,14 @@ let test_reload_is_idempotent () =
   Alcotest.(check bool)
     "manifest restored by the legacy reload" true
     (Sys.file_exists (Store.prelude_manifest_file store));
+  (* the builtin-wiring seam must also prefer the hidden member, or the user's binding would be
+     wired to the audit-run-id builtin on reopen *)
+  Alcotest.(check bool)
+    "internal lookup prefers the hidden member over the user binding" true
+    (match Store.lookup_internal_kind store "governance.fresh-audit-run-id" Resolve.KTerm with
+    | Some { Resolve.hash; _ } ->
+        List.exists (Hash.equal hash) store.Store.hidden && not (Hash.equal hash shadow)
+    | None -> false);
   let rec remove_tree path =
     match Unix.lstat path with
     | { Unix.st_kind = Unix.S_DIR; _ } ->

--- a/test/test_prelude.ml
+++ b/test/test_prelude.ml
@@ -576,7 +576,93 @@ let test_reload_is_idempotent () =
   Alcotest.(check bool)
     "public names are identical in both views" true
     ((Store.names_view store).Resolve.lookup "mul"
-    = (Store.trusted_names_view store).Resolve.lookup "mul")
+    = (Store.trusted_names_view store).Resolve.lookup "mul");
+  (* the identical prelude reloads as a manifest no-op *)
+  (match Prelude.load ~dir:"../prelude" store with
+  | Ok [] -> ()
+  | Ok _ -> Alcotest.fail "an identical prelude must reload without installing anything"
+  | Error diagnostics ->
+      Alcotest.failf "reload: %s" (String.concat "; " (List.map Diag.to_string diagnostics)));
+  (* a different prelude is refused before any mutation *)
+  let edited = root ^ "-prelude" in
+  Sys.mkdir edited 0o755;
+  Array.iter
+    (fun file ->
+      if Filename.check_suffix file ".jqd" then begin
+        let bytes = read_bytes (Filename.concat "../prelude" file) in
+        let channel = open_out_bin (Filename.concat edited file) in
+        output_string channel bytes;
+        if String.equal file "02-data.jqd" then output_string channel "\n; edited\n";
+        close_out channel
+      end)
+    (Sys.readdir "../prelude");
+  (match Prelude.load ~dir:edited store with
+  | Error (diagnostic :: _) ->
+      Alcotest.(check string) "mismatch diagnostic" "E0705" (Diag.code_or_uncoded diagnostic);
+      Alcotest.(check bool)
+        "mismatch names the changed file" true
+        (Str.string_match (Str.regexp ".*changed: 02-data.jqd") (Diag.cause diagnostic) 0)
+  | Error [] -> Alcotest.fail "mismatch produced no diagnostic"
+  | Ok _ -> Alcotest.fail "a different prelude must be refused");
+  Alcotest.(check string)
+    "name index unchanged by a refused load" first_names (read_bytes names_path);
+  Alcotest.(check int) "object count unchanged by a refused load" first_objects (objects ());
+  (* a user binding that reuses a hidden member's name never displaces the prelude's identity,
+     neither on the manifest fast path nor on a legacy store without a manifest *)
+  let fail_diags label diagnostics =
+    Alcotest.failf "%s: %s" label (String.concat "; " (List.map Diag.to_string diagnostics))
+  in
+  let shadow =
+    match
+      Reader.parse_one ~file:"shadow.jqd"
+        "(defterm ((binding governance.fresh-audit-run-id () (lit 7))))"
+    with
+    | Error diagnostics -> fail_diags "parse shadow" diagnostics
+    | Ok form -> (
+        match Kernel.decl_of_form form with
+        | Error diagnostics -> fail_diags "shadow declaration" diagnostics
+        | Ok declaration -> (
+            match Resolve.resolve_decl (Store.names_view store) declaration with
+            | Error diagnostics -> fail_diags "resolve shadow" diagnostics
+            | Ok declaration -> (
+                match Store.put_decl store declaration with
+                | Error diagnostics -> fail_diags "put shadow" diagnostics
+                | Ok hashes -> List.assoc "governance.fresh-audit-run-id" hashes.Canon.named)))
+  in
+  let objects_with_shadow = objects () and hidden_before = store.Store.hidden in
+  (match Prelude.load ~dir:"../prelude" store with
+  | Ok [] -> ()
+  | _ -> Alcotest.fail "fast path must still apply after a user install");
+  Alcotest.(check bool)
+    "fast path keeps the user's public binding" true
+    (match Store.lookup_kind store "governance.fresh-audit-run-id" Resolve.KTerm with
+    | Some { Resolve.hash; _ } -> Hash.equal hash shadow
+    | None -> false);
+  Sys.remove (Store.prelude_manifest_file store);
+  let store = load () in
+  Alcotest.(check int)
+    "legacy reload installs no substituted objects" objects_with_shadow (objects ());
+  Alcotest.(check bool)
+    "legacy reload hides the same derived members" true
+    (List.equal Hash.equal hidden_before store.Store.hidden);
+  Alcotest.(check bool)
+    "trusted view prefers the hidden member over the user binding" true
+    (match (Store.trusted_names_view store).Resolve.lookup "governance.fresh-audit-run-id" with
+    | { Resolve.hash; _ } :: _ -> List.exists (Hash.equal hash) store.Store.hidden
+    | [] -> false);
+  Alcotest.(check bool)
+    "manifest restored by the legacy reload" true
+    (Sys.file_exists (Store.prelude_manifest_file store));
+  let rec remove_tree path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter (fun entry -> remove_tree (Filename.concat path entry)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Sys.remove path
+    | exception Unix.Unix_error _ -> ()
+  in
+  remove_tree root;
+  remove_tree edited
 
 let suite =
   [


### PR DESCRIPTION
## Summary

APP.4: reopening a populated persistent store with the public prelude, and `store add` that leaves the store unchanged on any refusal.

- A store records the prelude it was loaded with (`prelude.manifest`: file names and SHA-256 digests). Reloading the identical prelude is a no-op (`Ok []`) without touching the store; a different prelude is refused with the catalogued E0705 before any mutation; a store made before manifests existed loads and then gains a manifest.
- Every prelude load resolves through the trusted names view, in which hidden derived members outrank any same-named user binding, while user programs keep the public view. Private builtins (`governance.fresh-audit-run-id` and friends) are wired to hidden members only, so a user's same-named binding after reopen evaluates to its own body and never receives a withheld builtin.
- `jac store add` selects the parser by file extension (the advertised `.jac` command works), refuses a file with a top-level expression before installing anything, and snapshots the index and object set so a declaration refused part-way through, or an exception, restores the store exactly (then re-raises the exception).

No kernel, canonical form, HASH_V0, or prelude object change.

## Evidence

- `test/test_prelude.ml` reload case (fast path, mismatch, shadow under fast and legacy paths, internal lookup prefers hidden); `test/cli/store.t` reopen, mismatch, rollback, and shadow blocks; SKILL.md store lines; 0.2 evidence paragraph. Inventory `1015 / 61 / 28`; full gate PASS on the rebased head.
- Reviews: #1 NEEDS_DECISION (three in-scope repairs adopted), #2 BLOCK (public-first builtin wiring) fixed, #3 PASS; after the rebase onto `49ed2d0` and the deferred notes, delta review PASS at `edfb3e0` including an exception-path rollback experiment and a check that the HB.3 worker and kit never read the manifest.

## Notes

- The exception path surfaces as an uncaught-exception exit (125) after the rollback; a structured diagnostic for it is a follow-up.
- Pre-existing: `eval_support.ml` leaves temp dirs per test run (hygiene follow-up, unchanged here).
