### PR TITLE
APP.1: keep call labels off generated list nodes

### DIFF
--- a/docs/release/0.2/DECISION.md
+++ b/docs/release/0.2/DECISION.md
@@ -3,7 +3,7 @@
 Status: candidate is ready for RC1 only after the exact candidate reproduction
 and required GitHub checks are green.
 
-Test count: `1015`
+Test count: `1016`
 
 Cram count: `61`
 

--- a/docs/release/0.2/EVIDENCE.md
+++ b/docs/release/0.2/EVIDENCE.md
@@ -32,7 +32,7 @@ must select `JACQUARD_INSTALL_VERSION=jacquard-core-0.2.0-rc1` explicitly.
 The candidate inventory is discovered by the checked-in test runner and file
 tree, not estimated from task history:
 
-- Alcotest/QCheck cases: `1015`
+- Alcotest/QCheck cases: `1016`
 - Cram transcript files: `61`
 - Documentation examples: `28` named examples across `8` documents
 
@@ -128,3 +128,11 @@ so a failed installation leaves the store exactly as it was. Pinned by the
 reload case in `test/test_prelude.ml` (one more case, bringing the inventory
 to `1015 / 61 / 28`) and the reopen, mismatch, and rollback blocks of
 `test/cli/store.t`.
+
+Named call arguments over list literals (APP.1) keep the call label on the
+whole list argument and off the generated `cons`/`nil` nodes, so labeled
+constructor and function calls with list literals resolve, reorder, nest, and
+hash identically to their positional twins. Pinned by one more case in
+`test/test_surface_named_calls.ml` (bringing the current source inventory to
+`1016 / 61 / 28`) and the list block of `test/cli/named-args.t`, including a
+repeated label over list arguments reported once as E0311.

--- a/docs/release/dx-jac-export/EVIDENCE.md
+++ b/docs/release/dx-jac-export/EVIDENCE.md
@@ -6,7 +6,7 @@ artifacts and are not retroactively updated by DX.2.
 
 ## Current inventory
 
-- Alcotest/QCheck cases: `1015`
+- Alcotest/QCheck cases: `1016`
 - Cram transcript files: `61`
 - Doctest examples: `28` across 8 documents
 

--- a/docs/release/named-call-arguments/EVIDENCE.md
+++ b/docs/release/named-call-arguments/EVIDENCE.md
@@ -56,6 +56,20 @@ schedule checks. Their passing status is regression evidence only. No SX.23
 participant data, readability score, blinded rescore, or study conclusion is
 claimed or invented.
 
+## Repairs After Publication
+
+- 2026-09-10, list literals as labeled arguments. `take(items: [1, 2])` and
+  `ListBucket(values: [1, 2])` reported E0310 although the labels existed.
+  The list-literal lowering derived the generated `nil` node's metadata from
+  the whole list expression, so the interior `cons` application inherited the
+  argument's call label and was elaborated against `cons`'s own `head`/`tail`
+  ABI; only a label spelled `tail` happened to pass. Lowering now strips the
+  call label and argument container from generated interior nodes. Pinned by
+  `test_list_literal_arguments` in `test/test_surface_named_calls.ml` and the
+  list block of `test/cli/named-args.t` (interpreter/native parity, formatter
+  stability, and positional/labeled hash identity). No kernel form, hash, or
+  envelope changed.
+
 ## Limits
 
 This is bounded executable evidence, not a proof over every surface tree, a

--- a/docs/release/structured-concurrency/EVIDENCE.md
+++ b/docs/release/structured-concurrency/EVIDENCE.md
@@ -760,7 +760,7 @@ opam exec -- dune build test/test_jacquard.exe
 
 The current inventory is mechanically checked against compiled discovery:
 
-- Alcotest/QCheck cases: `1015`
+- Alcotest/QCheck cases: `1016`
 - Cram transcript files: `61`
 
 The SC.14 baseline arithmetic remains exact: twelve compiled

--- a/src/meta.ml
+++ b/src/meta.ml
@@ -231,6 +231,11 @@ let surface_call_label t =
 (** [with_surface_call_label label t] records one explicit callable ABI or call-site label. *)
 let with_surface_call_label label t = add key_surface_call_label (Sym label) t
 
+(** [without_surface_call_label t] removes a call-site label. Lowering uses it when it derives the
+    metadata of a generated child node from a labeled argument, so the label stays on the argument
+    itself and never selects a slot of the generated callee. *)
+let without_surface_call_label t = remove key_surface_call_label t
+
 (** [is_surface_reference t] is true only for a bare reference authored in `.jac`. Recovery and
     diagnostics use this hash-excluded marker to distinguish source references from bootstrap
     [(var ...)] nodes without changing resolution or identity. *)

--- a/src/surface_lower.ml
+++ b/src/surface_lower.ml
@@ -352,9 +352,16 @@ and lower_expr_node ?(quote_depth = 0) (expr : Surface_ast.expr) : (Kernel.expr,
       Ok Kernel.{ it = Match (condition, clauses); meta = Meta.with_surface_form "if" expr.meta }
   | Surface_ast.List items -> (
       let* items = map_results (lower_expr_node ~quote_depth) items in
+      (* Generated interior nodes descend from the list expression's metadata, but a call-site
+         label or argument container belongs only to the whole list: an interior `cons` or `nil`
+         must never present the enclosing argument's label to the list constructor's own ABI. *)
       let internal_meta ~form meta =
         let* meta = generated_single_meta ~form meta in
-        Ok (Meta.without_surface_container "list" meta)
+        Ok
+          (meta
+          |> Meta.without_surface_container "list"
+          |> Meta.without_surface_container "call-argument"
+          |> Meta.without_surface_call_label)
       in
       let* nil_meta = internal_meta ~form:"list-nil" expr.meta in
       let nil_meta =

--- a/test/cli/named-args.t
+++ b/test/cli/named-args.t
@@ -124,3 +124,35 @@ Named calls and purpose-specific sum types avoid these review warnings.
   $ jac check warning-free.jac > warning-free.out 2>&1
   $ grep -c 'warning\[W120[67]\]' warning-free.out || true
   0
+
+List literals are ordinary labeled arguments. The label stays on the whole list and never on the
+generated `cons`/`nil` nodes, so constructors, functions, nesting, reordering, and empty lists
+resolve; a labeled call keeps the positional call's identity and behavior in both engines.
+
+  $ cat > named-lists.jac <<'EOF'
+  > type ListBucket = | ListBucket(values: List Int)
+  > both(count: n, items: xs) = (n, xs)
+  > (
+  >   ListBucket(values: [1, 2]),
+  >   both(items: [{ print("I"); 1 }], count: { print("C"); 2 }),
+  >   both(count: 0, items: []),
+  >   both(count: 3, items: [[1], [2, 3]]),
+  > )
+  > EOF
+  $ jac run named-lists.jac --allow console > lists-interpreted.out
+  $ jac build named-lists.jac -o named-lists-native > /dev/null
+  $ ./named-lists-native --allow console > lists-native.out
+  $ cmp lists-interpreted.out lists-native.out && echo identical
+  identical
+  $ cat lists-interpreted.out
+  IC(list-bucket(cons(1, cons(2, nil))), (2, cons(1, nil)), (0, nil), (3, cons(cons(1, nil), cons(cons(2, cons(3, nil)), nil))))
+  $ jac fmt named-lists.jac > named-lists-formatted.jac
+  $ jac fmt named-lists-formatted.jac > named-lists-twice.jac
+  $ cmp named-lists-formatted.jac named-lists-twice.jac && grep -c 'items:' named-lists-formatted.jac
+  4
+  $ printf 'type ListBucket = | ListBucket(values: List Int)\nListBucket([1, 2])\n' > positional-list.jac
+  $ printf 'type ListBucket = | ListBucket(values: List Int)\nListBucket(values: [1, 2])\n' > labeled-list.jac
+  $ jac hash positional-list.jac > positional-list.hash
+  $ jac hash labeled-list.jac > labeled-list.hash
+  $ cmp positional-list.hash labeled-list.hash && echo hash-identical
+  hash-identical

--- a/test/cli/named-args.t
+++ b/test/cli/named-args.t
@@ -156,3 +156,11 @@ resolve; a labeled call keeps the positional call's identity and behavior in bot
   $ jac hash labeled-list.jac > labeled-list.hash
   $ cmp positional-list.hash labeled-list.hash && echo hash-identical
   hash-identical
+
+A repeated label whose arguments are list literals is the ordinary duplicate-label error, reported
+once for the call and never for the generated list nodes:
+
+  $ printf 'both(count: n, items: xs) = (n, xs)\nboth(items: [1], items: [2])\n' > duplicate-list.jac
+  $ jac check duplicate-list.jac > duplicate-list.out 2>&1; status=$?; grep -c 'error\[E0311\]' duplicate-list.out; echo "exit:$status"
+  1
+  exit:1

--- a/test/test_surface_named_calls.ml
+++ b/test/test_surface_named_calls.ml
@@ -291,6 +291,81 @@ let test_fail_closed_diagnostics () =
   ignore (install store "type MixedFields a = | MixedFields(left: a, a)\n");
   only_diagnostic store "MixedFields(left: 1, other: 2)" "E0314" "MixedFields(left: 1, other: 2)"
 
+(* APP.1: a list literal is an ordinary labeled argument. The label belongs to the whole list; the
+   generated interior `cons`/`nil` nodes must never carry it, or the list constructor's own ABI
+   would be consulted for the enclosing call's label. *)
+let rec call_labels acc (expression : Kernel.expr) =
+  let acc =
+    match Meta.surface_call_label expression.meta with Some label -> label :: acc | None -> acc
+  in
+  match expression.it with
+  | Kernel.App (fn, arguments) -> List.fold_left call_labels (call_labels acc fn) arguments
+  | Kernel.Let { value; body; _ } -> call_labels (call_labels acc value) body
+  | Kernel.Tuple items -> List.fold_left call_labels acc items
+  | _ -> acc
+
+(* Generated interior list nodes (`list-cons-constructor`, `list-tail`, `list-nil`) that carry a
+   call label would be elaborated against `cons`'s ABI; collect any such node's label. *)
+let rec labeled_generated_list_nodes acc (expression : Kernel.expr) =
+  let acc =
+    match (Meta.surface_generated expression.meta, Meta.surface_call_label expression.meta) with
+    | Some form, Some label when String.starts_with ~prefix:"list-" form ->
+        (form ^ ":" ^ label) :: acc
+    | _ -> acc
+  in
+  match expression.it with
+  | Kernel.App (fn, arguments) ->
+      List.fold_left labeled_generated_list_nodes (labeled_generated_list_nodes acc fn) arguments
+  | Kernel.Let { value; body; _ } ->
+      labeled_generated_list_nodes (labeled_generated_list_nodes acc value) body
+  | Kernel.Tuple items -> List.fold_left labeled_generated_list_nodes acc items
+  | _ -> acc
+
+let test_list_literal_arguments () =
+  let store, checker = make_prelude_checker () in
+  ignore
+    (install store
+       "type ListBucket = | ListBucket(values: List Int)\n\
+        type Pair = | Pair(left: List Int, right: Int)\n\
+        take(items: xs) = xs\n\
+        both(count: n, items: xs) = (n, xs)\n");
+  let labeled = resolve_expression store "ListBucket(values: [1, 2])" in
+  let positional = resolve_expression store "ListBucket([1, 2])" in
+  Alcotest.(check string)
+    "labeled list constructor prints" "ListBucket(values: [1, 2])" (print_expression labeled);
+  Alcotest.(check bool)
+    "labeled and positional list literals share identity" true
+    (Hash.equal (expression_hash labeled) (expression_hash positional));
+  Alcotest.(check (list string))
+    "only the whole list carries the label" [ "values" ] (call_labels [] labeled);
+  List.iter
+    (fun source -> ignore (check_expression checker store source))
+    [
+      "take(items: [1, 2])";
+      "take(items: [])";
+      "take(items: [[1], [2, 3]])";
+      "take(items: [add(1, 1), 3])";
+      "Pair(left: [1], right: 2)";
+      "Pair(right: 2, left: [1])";
+      "both(items: [1], count: 2)";
+      "both(count: 2, items: [1, 2, 3])";
+    ];
+  List.iter
+    (fun source ->
+      Alcotest.(check (list string))
+        (source ^ ": generated list nodes carry no call label")
+        []
+        (labeled_generated_list_nodes [] (resolve_expression store source)))
+    [
+      "ListBucket(values: [1, 2])";
+      "both(items: [1], count: 2)";
+      "take(items: [[1], [2, 3]])";
+      "Pair(right: 2, left: [add(1, 1)])";
+    ];
+  only_diagnostic store "take(itemz: [1])" "E0310" "itemz: [1]";
+  only_diagnostic store "Pair(left: [1], right: 2, extra: [3])" "E0312"
+    "Pair(left: [1], right: 2, extra: [3])"
+
 let resolved_declaration store source =
   match lower source with
   | [ Kernel.Decl declaration ] -> (
@@ -424,6 +499,7 @@ let suite =
       test_direct_calls_hashes_and_source_order;
     Alcotest.test_case "constructors and operations" `Quick test_constructor_and_operation_calls;
     Alcotest.test_case "fail-closed diagnostics" `Quick test_fail_closed_diagnostics;
+    Alcotest.test_case "list literals as labeled arguments" `Quick test_list_literal_arguments;
     Alcotest.test_case "store identity reopen conflict" `Quick
       test_store_identity_reopen_and_conflict;
     Alcotest.test_case "checker warnings and recovery names" `Quick

--- a/test/test_surface_named_calls.ml
+++ b/test/test_surface_named_calls.ml
@@ -304,8 +304,10 @@ let rec call_labels acc (expression : Kernel.expr) =
   | Kernel.Tuple items -> List.fold_left call_labels acc items
   | _ -> acc
 
-(* Generated interior list nodes (`list-cons-constructor`, `list-tail`, `list-nil`) that carry a
-   call label would be elaborated against `cons`'s ABI; collect any such node's label. *)
+(* Generated interior list nodes that carry a call label would be elaborated against `cons`'s
+   ABI. This walk keys on `surface_generated`, which marks the `list-cons-constructor` and
+   `list-nil` nodes; `list-tail` nodes carry no generated marker and are covered by the
+   `call_labels` walk above. *)
 let rec labeled_generated_list_nodes acc (expression : Kernel.expr) =
   let acc =
     match (Meta.surface_generated expression.meta, Meta.surface_call_label expression.meta) with


### PR DESCRIPTION
## Summary

APP.1: named call arguments over list literals.

A labeled argument whose value is a list literal kept its call label on the generated `cons`/`nil` nodes, which were then elaborated against `cons`'s ABI. The surface lowering now strips the call label and the `call-argument` container from the generated list nodes, so labeled constructor and function calls with list literals resolve, reorder, nest, and hash identically to their positional twins. No kernel, canonical form, HASH_V0, or prelude change.

## Evidence

- One new Alcotest case in `test/test_surface_named_calls.ml` (labels stay on the whole list; generated nodes carry none; the positional twin's hash is equal) and the list block of `test/cli/named-args.t` (interpreter and native output identical, formatting idempotent, hash identity, and a repeated label over list arguments reported once as E0311). Inventory `1016 / 61 / 28`; full gate PASS on the rebased head.
- Reviews: #1 PASS at the original head; after the rebase onto `041230b` and the deferred notes (test comment made exact; committed E0311 list case; evidence narrative), delta review PASS at `4a0e4af`.

## Notes

- Recorded debt: a single choke point for generated-node metadata in the lowering would close the latent class (unobservable today; probes with blocks and conditionals as labeled arguments resolve and run).
